### PR TITLE
feat: cross-link generated files with Obsidian-compatible markdown links

### DIFF
--- a/catalog/core/self-awareness.md
+++ b/catalog/core/self-awareness.md
@@ -18,7 +18,7 @@ Follow any context advisories injected into your prompt — they are calibrated 
 
 These are not automated. Follow them yourself:
 
-- If you're losing track of the task, re-read `agent/Core/memory.md`.
+- If you're losing track of the task, re-read [agent/Core/memory.md](memory.md).
 - If a task has more than 10 steps, break it into sub-tasks before starting.
 - Never continue if you're unsure what the plan says — re-read it.
 - If you've already read a file this session, don't re-read it unless it changed.

--- a/catalog/protocols/memory/memory.md
+++ b/catalog/protocols/memory/memory.md
@@ -9,7 +9,7 @@ description: How to read, write, and clean working memory.
 
 ## Reading Memory
 
-At session start, read `agent/Core/memory.md` and act on any flags:
+At session start, read [agent/Core/memory.md](../Core/memory.md) and act on any flags:
 
 - **Flags** — unresolved items from prior sessions. Address or escalate each one.
 - **Work state** — what was in progress. Resume or confirm completion.
@@ -32,7 +32,7 @@ Update `agent/Core/memory.md` when:
 
 ## Rules
 
-- **Do NOT use Claude Code's auto-memory system** (`~/.claude/projects/*/memory/`). All persistent memory goes in `agent/Core/memory.md` — version-controlled, auditable, inside the project.
+- **Do NOT use Claude Code's auto-memory system** (`~/.claude/projects/*/memory/`). All persistent memory goes in [agent/Core/memory.md](../Core/memory.md) — version-controlled, auditable, inside the project.
 - Memory is for cross-session continuity, not session logs
 - Keep it short — if memory exceeds 30 lines, prune aggressively
 - Never store secrets or credentials in memory

--- a/catalog/protocols/memory/memory.md
+++ b/catalog/protocols/memory/memory.md
@@ -32,7 +32,7 @@ Update `agent/Core/memory.md` when:
 
 ## Rules
 
-- **Do NOT use Claude Code's auto-memory system** (`~/.claude/projects/*/memory/`). All persistent memory goes in [agent/Core/memory.md](../Core/memory.md) — version-controlled, auditable, inside the project.
+- **Do NOT use Claude Code's auto-memory system** (`~/.claude/projects/*/memory/`). All persistent memory goes in `agent/Core/memory.md` — version-controlled, auditable, inside the project.
 - Memory is for cross-session continuity, not session logs
 - Keep it short — if memory exceeds 30 lines, prune aggressively
 - Never store secrets or credentials in memory

--- a/catalog/protocols/security/security.md
+++ b/catalog/protocols/security/security.md
@@ -32,7 +32,7 @@ description: Security enforcement — hard stops and hard enforcers.
 ## Full Reference
 
 For the complete security standard, read:
-`Playbook/Standards/SecurityStandards.md`
+[Playbook/Standards/SecurityStandards.md](../../Playbook/Standards/SecurityStandards.md)
 
 > [!note]
 > The path above is relative to the project docs location. Check your workspace CLAUDE.md → External References for the exact path.

--- a/catalog/protocols/session-start/session-start.md
+++ b/catalog/protocols/session-start/session-start.md
@@ -12,16 +12,16 @@ description: Ordered startup sequence — always steps + conditional loading by 
 
 ## Always (every session)
 
-1. Read `agent/Core/identity.md` — confirm role and mindset
-2. Read `agent/Core/memory.md` — surface pending flags, check work state
-3. Read `agent/Core/self-awareness.md` — refresh context monitoring rules
-4. Read `INDEX.md` — get project snapshot
-5. Read `Playbook/Status.md` — see what's in progress and pending
-6. Scan `Playbook/Backlog.md` — check for P0 items not yet in Status.md (escalate immediately if found)
-7. Read `Logs/FieldNotes.md` — check for user updates since last session
-8. Check `Reports/Pending/` — process any unreviewed agent reports
-9. Read `agent/Protocols/security.md` — refresh security constraints (if installed)
-10. Read `agent/Protocols/scope-boundaries.md` — refresh what you own (if installed)
+1. Read [agent/Core/identity.md](../Core/identity.md) — confirm role and mindset
+2. Read [agent/Core/memory.md](../Core/memory.md) — surface pending flags, check work state
+3. Read [agent/Core/self-awareness.md](../Core/self-awareness.md) — refresh context monitoring rules
+4. Read [INDEX.md](../../INDEX.md) — get project snapshot
+5. Read [Playbook/Status.md](../../Playbook/Status.md) — see what's in progress and pending
+6. Scan [Playbook/Backlog.md](../../Playbook/Backlog.md) — check for P0 items not yet in Status.md (escalate immediately if found)
+7. Read [Logs/FieldNotes.md](../../Logs/FieldNotes.md) — check for user updates since last session
+8. Check [Reports/Pending/](../../Reports/Pending/) — process any unreviewed agent reports
+9. Read [agent/Protocols/security.md](security.md) — refresh security constraints (if installed)
+10. Read [agent/Protocols/scope-boundaries.md](scope-boundaries.md) — refresh what you own (if installed)
 
 > [!note]
 > Paths like `INDEX.md`, `Playbook/`, `Logs/`, and `Reports/` refer to the project docs location configured during `bonsai init`. Check your workspace CLAUDE.md → External References for the exact paths.
@@ -34,16 +34,16 @@ description: Ordered startup sequence — always steps + conditional loading by 
 ### If executing a plan
 
 - Read the assigned plan in full before writing any code
-- Read `Playbook/Standards/SecurityStandards.md`
-- Read relevant coding standards from `agent/Skills/`
+- Read [Playbook/Standards/SecurityStandards.md](../../Playbook/Standards/SecurityStandards.md)
+- Read relevant coding standards from [agent/Skills/](../Skills/)
 
 ### If starting new work
 
-- Check if a plan exists in `Playbook/Plans/Active/` — if not, ask the user
+- Check if a plan exists in [Playbook/Plans/Active/](../../Playbook/Plans/Active/) — if not, ask the user
 - Read scope boundaries before touching any files
 
 ### If reviewing or reporting
 
 - Read the relevant plan or prior report
-- Read `Playbook/Standards/SecurityStandards.md`
+- Read [Playbook/Standards/SecurityStandards.md](../../Playbook/Standards/SecurityStandards.md)
 - Submit reports to `Reports/Pending/` using the report template

--- a/catalog/routines/doc-freshness-check/doc-freshness-check.md.tmpl
+++ b/catalog/routines/doc-freshness-check/doc-freshness-check.md.tmpl
@@ -24,7 +24,7 @@ Detect documentation drift — docs that are stale relative to recent code chang
 
 3. **Check navigation links:**
    - Verify all links in `{{ .Workspace }}CLAUDE.md` navigation tables resolve to real files
-   - Verify all links in `agent/Core/`, `agent/Protocols/`, `agent/Workflows/`, `agent/Skills/` resolve
+   - Verify all links in [agent/Core/](../Core/), [agent/Protocols/](../Protocols/), [agent/Workflows/](../Workflows/), [agent/Skills/](../Skills/) resolve
 
 4. **Report findings:**
    - List stale docs with specific drift description

--- a/catalog/routines/memory-consolidation/memory-consolidation.md.tmpl
+++ b/catalog/routines/memory-consolidation/memory-consolidation.md.tmpl
@@ -10,7 +10,7 @@ frequency: 5 days
 
 ## Purpose
 
-Bridge Claude Code auto-memory and `agent/Core/memory.md`. Validate facts against codebase. Clean redundant entries. This is the primary mechanism for preventing memory drift between Claude Code's built-in system and our version-controlled agent memory.
+Bridge Claude Code auto-memory and [agent/Core/memory.md](../Core/memory.md). Validate facts against codebase. Clean redundant entries. This is the primary mechanism for preventing memory drift between Claude Code's built-in system and our version-controlled agent memory.
 
 ## Procedure
 
@@ -19,7 +19,7 @@ Bridge Claude Code auto-memory and `agent/Core/memory.md`. Validate facts agains
    - Read any individual memory files referenced by the MEMORY.md index
 
 2. **Read current agent memory:**
-   - `agent/Core/memory.md` — all sections (Flags, Work State, Notes, Feedback, References)
+   - [agent/Core/memory.md](../Core/memory.md) — all sections (Flags, Work State, Notes, Feedback, References)
 
 3. **For each entry in auto-memory, apply consolidation decision:**
    - **keep** — already exists in agent memory, still accurate — no action

--- a/catalog/scaffolding/INDEX.md.tmpl
+++ b/catalog/scaffolding/INDEX.md.tmpl
@@ -28,22 +28,22 @@ description: Master lookup table — read this first every session.
 | Path | What it contains | When to use it |
 |------|-----------------|----------------|
 | `INDEX.md` | This file — project snapshot and document map | Read first, every session |
-| `CLAUDE.md` | Navigation table — routes to agent instructions | First file loaded every session |
-| `Playbook/Status.md` | Live task tracker (in-progress / pending / done) | Start of every session; after completing work |
-| `Playbook/Roadmap.md` | Phases and milestones | When planning next steps |
-| `Playbook/Backlog.md` | Prioritized intake queue — bugs, features, debt, ideas | When discovering out-of-scope issues; before promoting to Status.md |
-| `Playbook/Plans/Active/` | Numbered implementation plans for agents | When handing off work to an agent |
-| `Playbook/Standards/SecurityStandards.md` | Hard security rules — all agents | Every session, every plan, every code review |
-| `Logs/FieldNotes.md` | User-maintained notes on work done outside sessions | Read every session |
-| `Logs/KeyDecisionLog.md` | Settled architectural decisions | When planning or when a topic comes up |
-| `Reports/Pending/` | Unprocessed agent completion reports | Check every session start |
-| `Reports/report-template.md` | Structured report format for agents | When submitting a completion report |
+| [CLAUDE.md](CLAUDE.md) | Navigation table — routes to agent instructions | First file loaded every session |
+| [Playbook/Status.md](Playbook/Status.md) | Live task tracker (in-progress / pending / done) | Start of every session; after completing work |
+| [Playbook/Roadmap.md](Playbook/Roadmap.md) | Phases and milestones | When planning next steps |
+| [Playbook/Backlog.md](Playbook/Backlog.md) | Prioritized intake queue — bugs, features, debt, ideas | When discovering out-of-scope issues; before promoting to Status.md |
+| [Playbook/Plans/Active/](Playbook/Plans/Active/) | Numbered implementation plans for agents | When handing off work to an agent |
+| [Playbook/Standards/SecurityStandards.md](Playbook/Standards/SecurityStandards.md) | Hard security rules — all agents | Every session, every plan, every code review |
+| [Logs/FieldNotes.md](Logs/FieldNotes.md) | User-maintained notes on work done outside sessions | Read every session |
+| [Logs/KeyDecisionLog.md](Logs/KeyDecisionLog.md) | Settled architectural decisions | When planning or when a topic comes up |
+| [Reports/Pending/](Reports/Pending/) | Unprocessed agent completion reports | Check every session start |
+| [Reports/report-template.md](Reports/report-template.md) | Structured report format for agents | When submitting a completion report |
 
 ---
 
 ## Agent Handoff Notes
 
 > [!note]
-> Agent instructions use a 4-layer structure: agent/Core/ → agent/Protocols/ → agent/Workflows/ → agent/Skills/. Each workspace's `CLAUDE.md` is a pure routing table.
+> Agent instructions use a 4-layer structure: [agent/Core/](agent/Core/) → [agent/Protocols/](agent/Protocols/) → [agent/Workflows/](agent/Workflows/) → [agent/Skills/](agent/Skills/). Each workspace's [CLAUDE.md](CLAUDE.md) is a pure routing table.
 
 <!-- Add agent-specific handoff notes as you add agents to the project -->

--- a/catalog/scaffolding/Playbook/Backlog.md.tmpl
+++ b/catalog/scaffolding/Playbook/Backlog.md.tmpl
@@ -6,8 +6,8 @@ description: Prioritized backlog — bugs, features, debt, research, and improve
 # {{ .ProjectName }} — Backlog
 
 > [!note]
-> This is the intake queue for all work not yet in `Status.md`. Items flow from here into active work.
-> For current active work, see `Playbook/Status.md`. For long-term direction, see `Playbook/Roadmap.md`.
+> This is the intake queue for all work not yet in [Status.md](Status.md). Items flow from here into active work.
+> For current active work, see [Status.md](Status.md). For long-term direction, see [Roadmap.md](Roadmap.md).
 
 ---
 

--- a/catalog/scaffolding/Playbook/Status.md.tmpl
+++ b/catalog/scaffolding/Playbook/Status.md.tmpl
@@ -6,7 +6,7 @@ description: Live task tracker. Update this file at the start and end of every w
 # {{ .ProjectName }} — Status
 
 > [!note]
-> Move items between tables as work progresses. Link to the relevant plan in `Plans/Active/` or `Plans/Archive/`.
+> Move items between tables as work progresses. Link to the relevant plan in [Plans/Active/](Plans/Active/) or [Plans/Archive/](Plans/Archive/).
 
 ---
 

--- a/catalog/workflows/issue-to-implementation/issue-to-implementation.md
+++ b/catalog/workflows/issue-to-implementation/issue-to-implementation.md
@@ -18,9 +18,9 @@ description: End-to-end autonomous workflow — issue intake to shipped code via
 
 Load before starting:
 
-- `agent/Skills/issue-classification.md` — issue types, importance levels
-- `agent/Skills/dispatch.md` — triage rules, agent prompt structure
-- `agent/Skills/planning-template.md` — plan format and tier rules
+- [agent/Skills/issue-classification.md](../Skills/issue-classification.md) — issue types, importance levels
+- [agent/Skills/dispatch.md](../Skills/dispatch.md) — triage rules, agent prompt structure
+- [agent/Skills/planning-template.md](../Skills/planning-template.md) — plan format and tier rules
 
 ---
 
@@ -46,7 +46,7 @@ The user sets the mode at the start. When in doubt, default to supervised.
 ## Phase 0: Pre-Flight
 
 1. Run `git status`. If the working tree has uncommitted changes, **stop and warn the user**. Suggest committing or stashing before proceeding.
-2. Check `Playbook/Status.md` — if there's in-progress work that could conflict, flag it before starting.
+2. Check [Playbook/Status.md](../../Playbook/Status.md) — if there's in-progress work that could conflict, flag it before starting.
 
 ---
 
@@ -66,7 +66,7 @@ The user sets the mode at the start. When in doubt, default to supervised.
 
 ### Classify
 
-Use `agent/Skills/issue-classification.md`:
+Use [agent/Skills/issue-classification.md](../Skills/issue-classification.md):
 
 - **Type:** bug, feature, change, debt, research
 - **Domains:** which parts of the codebase are affected
@@ -81,9 +81,9 @@ Understand what the issue touches before planning anything.
 1. **Trace** — use Explore agents or Grep/Read to find affected files, functions, modules
 2. **Blast radius** — what files change, what tests are affected, what depends on the changed code
 3. **Architecture** — read relevant architecture docs, schemas, API specs
-4. **Overlap** — check `Playbook/Status.md` for in-progress work that conflicts
-5. **Related items** — check `Playbook/Backlog.md` for items that should be bundled with this work
-6. **Prior decisions** — check `Logs/KeyDecisionLog.md` for constraints on the approach
+4. **Overlap** — check [Playbook/Status.md](../../Playbook/Status.md) for in-progress work that conflicts
+5. **Related items** — check [Playbook/Backlog.md](../../Playbook/Backlog.md) for items that should be bundled with this work
+6. **Prior decisions** — check [Logs/KeyDecisionLog.md](../../Logs/KeyDecisionLog.md) for constraints on the approach
 
 ---
 
@@ -159,7 +159,7 @@ Fix every issue before proceeding. Do not carry known problems into dispatch.
 
 ## Phase 7: Triage
 
-Use the decision tree from `agent/Skills/dispatch.md`.
+Use the decision tree from [agent/Skills/dispatch.md](../Skills/dispatch.md).
 
 ### Self-dispatch when ALL true:
 
@@ -188,7 +188,7 @@ Use the decision tree from `agent/Skills/dispatch.md`.
 > [!warning]
 > **You do not write code.** Every implementation change — no matter how small — is dispatched to a subagent running in an isolated worktree. You orchestrate; they implement.
 
-Dispatch implementation agents using the dispatch skill. See `agent/Skills/dispatch.md` for full prompt structure and syntax.
+Dispatch implementation agents using the dispatch skill. See [agent/Skills/dispatch.md](../Skills/dispatch.md) for full prompt structure and syntax.
 
 ### Worktree isolation
 
@@ -395,7 +395,7 @@ Only merge after all audits in Phase 11 pass. The draft PR has existed since Pha
 
 ### 1. Review the PR
 
-Use the PR review workflow (`agent/Workflows/pr-review.md`):
+Use the PR review workflow ([agent/Workflows/pr-review.md](pr-review.md)):
 
 ```bash
 gh pr view {pr_number} --json title,body,files,additions,deletions

--- a/catalog/workflows/plan-execution/plan-execution.md
+++ b/catalog/workflows/plan-execution/plan-execution.md
@@ -43,5 +43,5 @@ When you have been assigned a plan to implement.
 
 ### 5. Report
 
-- Write a completion report using `agent/Workflows/reporting.md`
+- Write a completion report using [agent/Workflows/reporting.md](reporting.md)
 - Include what was done, what was tested, any issues encountered

--- a/catalog/workflows/planning/planning.md
+++ b/catalog/workflows/planning/planning.md
@@ -19,8 +19,8 @@ When a new task, feature, or fix needs a plan before agents can execute.
 
 - What does the user want?
 - What's the scope? (single-domain or multi-domain)
-- What tier? (Tier 1 Patch or Tier 2 Feature — see `agent/Skills/planning-template.md`)
-- Check `Playbook/Backlog.md` — is this request already captured? Are there related P0/P1 items that should be bundled?
+- What tier? (Tier 1 Patch or Tier 2 Feature — see [agent/Skills/planning-template.md](../Skills/planning-template.md))
+- Check [Playbook/Backlog.md](../../Playbook/Backlog.md) — is this request already captured? Are there related P0/P1 items that should be bundled?
 
 ### 2. Research
 
@@ -34,7 +34,7 @@ If you see a design fork — raise it. Don't wait for the user to ask.
 
 ### 4. Write the Plan
 
-- Use the appropriate tier template from `agent/Skills/planning-template.md`
+- Use the appropriate tier template from [agent/Skills/planning-template.md](../Skills/planning-template.md)
 - Steps must be specific enough that agents don't make design decisions
 
 ### 5. Self-Review

--- a/catalog/workflows/reporting/reporting.md
+++ b/catalog/workflows/reporting/reporting.md
@@ -15,7 +15,7 @@ After completing a plan or significant task. Submit this report for review.
 
 ## Steps
 
-1. Read the report template at `Reports/report-template.md`
+1. Read the report template at [Reports/report-template.md](../../Reports/report-template.md)
 2. Fill in all sections — be specific
 3. Save the report to `Reports/Pending/` with the naming convention: `YYYY-MM-DD-plan-NN-agent.md`
 

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -511,16 +511,16 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 		fmt.Sprintf("# %s — %s", cfg.ProjectName, agentDef.DisplayName), "",
 		fmt.Sprintf("**Working directory:** `%s`", installed.Workspace), "",
 		"> [!warning]",
-		"> **FIRST:** Read `agent/Core/identity.md`, then `agent/Core/memory.md`.", "",
+		"> **FIRST:** Read [agent/Core/identity.md](agent/Core/identity.md), then [agent/Core/memory.md](agent/Core/memory.md).", "",
 		"---", "",
 		"## Navigation", "",
 		"> All agent instruction files live in `agent/`.", "",
 		"### Core (load first, every session)", "",
 		"| File | Purpose |",
 		"|------|---------|",
-		"| `agent/Core/identity.md` | Who I am, relationships, mindset |",
-		"| `agent/Core/memory.md` | Working memory — flags, work state, notes |",
-		"| `agent/Core/self-awareness.md` | Context monitoring, hard thresholds |", "",
+		"| [agent/Core/identity.md](agent/Core/identity.md) | Who I am, relationships, mindset |",
+		"| [agent/Core/memory.md](agent/Core/memory.md) | Working memory — flags, work state, notes |",
+		"| [agent/Core/self-awareness.md](agent/Core/self-awareness.md) | Context monitoring, hard thresholds |", "",
 	)
 
 	if len(installed.Protocols) > 0 {
@@ -531,7 +531,7 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 			"|------|---------|",
 		)
 		for _, p := range installed.Protocols {
-			lines = append(lines, fmt.Sprintf("| `agent/Protocols/%s.md` | %s |", p, protoDescs[p]))
+			lines = append(lines, fmt.Sprintf("| [agent/Protocols/%s.md](agent/Protocols/%s.md) | %s |", p, p, protoDescs[p]))
 		}
 		lines = append(lines, "")
 	}
@@ -544,7 +544,7 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 			"|----------|-----------|",
 		)
 		for _, w := range installed.Workflows {
-			lines = append(lines, fmt.Sprintf("| %s | `agent/Workflows/%s.md` |", wfDescs[w], w))
+			lines = append(lines, fmt.Sprintf("| %s | [agent/Workflows/%s.md](agent/Workflows/%s.md) |", wfDescs[w], w, w))
 		}
 		lines = append(lines, "")
 	}
@@ -557,7 +557,7 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 			"|------|-----------|",
 		)
 		for _, s := range installed.Skills {
-			lines = append(lines, fmt.Sprintf("| %s | `agent/Skills/%s.md` |", skillDescs[s], s))
+			lines = append(lines, fmt.Sprintf("| %s | [agent/Skills/%s.md](agent/Skills/%s.md) |", skillDescs[s], s, s))
 		}
 		lines = append(lines, "")
 	}
@@ -584,11 +584,11 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 					}
 				}
 			}
-			lines = append(lines, fmt.Sprintf("| %s | %s | `agent/Routines/%s.md` |",
-				displayName, freq, r))
+			lines = append(lines, fmt.Sprintf("| %s | %s | [agent/Routines/%s.md](agent/Routines/%s.md) |",
+				displayName, freq, r, r))
 		}
 		lines = append(lines, "",
-			"> Routines are opt-in — check `agent/Core/routines.md` for the dashboard and procedures.", "")
+			"> Routines are opt-in — check [agent/Core/routines.md](agent/Core/routines.md) for the dashboard and procedures.", "")
 	}
 
 	if len(installed.Sensors) > 0 {
@@ -604,7 +604,7 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 				if sensor.Matcher != "" {
 					eventStr += fmt.Sprintf(" (%s)", sensor.Matcher)
 				}
-				lines = append(lines, fmt.Sprintf("| `agent/Sensors/%s.sh` | %s | %s |", sensorName, eventStr, sensor.Description))
+				lines = append(lines, fmt.Sprintf("| [agent/Sensors/%s.sh](agent/Sensors/%s.sh) | %s | %s |", sensorName, sensorName, eventStr, sensor.Description))
 			} else if custom != nil {
 				if meta, ok := custom[sensorName]; ok && meta.Event != "" {
 					eventStr := meta.Event
@@ -615,7 +615,7 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 					if desc == "" {
 						desc = catalog.DisplayNameFrom(sensorName)
 					}
-					lines = append(lines, fmt.Sprintf("| `agent/Sensors/%s.sh` | %s | %s |", sensorName, eventStr, desc))
+					lines = append(lines, fmt.Sprintf("| [agent/Sensors/%s.sh](agent/Sensors/%s.sh) | %s | %s |", sensorName, sensorName, eventStr, desc))
 				}
 			}
 		}
@@ -627,22 +627,36 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 		"---", "",
 		"## Memory", "",
 		"> [!warning]",
-		"> **Do NOT use Claude Code's auto-memory system** (`~/.claude/projects/*/memory/`). All persistent memory goes in `agent/Core/memory.md` — version-controlled, auditable, inside the project.", "",
-		"When you would normally write to auto-memory (feedback, references, project context, flags), write to the appropriate section in `agent/Core/memory.md` instead.", "",
+		"> **Do NOT use Claude Code's auto-memory system** (`~/.claude/projects/*/memory/`). All persistent memory goes in [agent/Core/memory.md](agent/Core/memory.md) — version-controlled, auditable, inside the project.", "",
+		"When you would normally write to auto-memory (feedback, references, project context, flags), write to the appropriate section in [agent/Core/memory.md](agent/Core/memory.md) instead.", "",
 		"---", "",
 		"### External References", "",
 		"| Need | Read this |",
 		"|------|-----------|",
-		fmt.Sprintf("| Project snapshot | `%sINDEX.md` |", docsPrefix),
-		fmt.Sprintf("| Current work status | `%sPlaybook/Status.md` |", docsPrefix),
-		fmt.Sprintf("| Long-term direction | `%sPlaybook/Roadmap.md` |", docsPrefix),
-		fmt.Sprintf("| Security standards | `%sPlaybook/Standards/SecurityStandards.md` |", docsPrefix),
-		fmt.Sprintf("| Your assigned plan | `%sPlaybook/Plans/Active/` |", docsPrefix),
-		fmt.Sprintf("| Backlog | `%sPlaybook/Backlog.md` |", docsPrefix),
-		fmt.Sprintf("| Prior decisions | `%sLogs/KeyDecisionLog.md` |", docsPrefix),
+	)
+
+	// extRef computes the relative path from the workspace root (where CLAUDE.md lives)
+	// to a file inside DocsPath. Display text keeps docsPrefix for agent context.
+	extRef := func(target string) string {
+		full := filepath.Join(cfg.DocsPath, target)
+		rel, err := filepath.Rel(installed.Workspace, full)
+		if err != nil {
+			return target
+		}
+		return filepath.ToSlash(rel)
+	}
+
+	lines = append(lines,
+		fmt.Sprintf("| Project snapshot | [%sINDEX.md](%s) |", docsPrefix, extRef("INDEX.md")),
+		fmt.Sprintf("| Current work status | [%sPlaybook/Status.md](%s) |", docsPrefix, extRef("Playbook/Status.md")),
+		fmt.Sprintf("| Long-term direction | [%sPlaybook/Roadmap.md](%s) |", docsPrefix, extRef("Playbook/Roadmap.md")),
+		fmt.Sprintf("| Security standards | [%sPlaybook/Standards/SecurityStandards.md](%s) |", docsPrefix, extRef("Playbook/Standards/SecurityStandards.md")),
+		fmt.Sprintf("| Your assigned plan | [%sPlaybook/Plans/Active/](%s) |", docsPrefix, extRef("Playbook/Plans/Active/")),
+		fmt.Sprintf("| Backlog | [%sPlaybook/Backlog.md](%s) |", docsPrefix, extRef("Playbook/Backlog.md")),
+		fmt.Sprintf("| Prior decisions | [%sLogs/KeyDecisionLog.md](%s) |", docsPrefix, extRef("Logs/KeyDecisionLog.md")),
 	)
 	if hasScaffolding(cfg, "reports") {
-		lines = append(lines, fmt.Sprintf("| Submit report | `%sReports/Pending/` |", docsPrefix))
+		lines = append(lines, fmt.Sprintf("| Submit report | [%sReports/Pending/](%s) |", docsPrefix, extRef("Reports/Pending/")))
 	}
 	lines = append(lines, "")
 


### PR DESCRIPTION
## Summary
Add Obsidian-compatible markdown links between generated workspace files. Converts ~52 navigation references from backtick code spans to clickable relative links.

## Changes
- `internal/generate/generate.go` — WorkspaceClaudeMD() produces markdown links in all navigation tables and reference sections
- `catalog/protocols/` — session-start, memory, security get relative links
- `catalog/workflows/` — issue-to-implementation, planning, reporting, plan-execution get relative links
- `catalog/core/self-awareness.md` — relative link to memory.md
- `catalog/routines/` — memory-consolidation, doc-freshness-check get relative links
- `catalog/scaffolding/` — INDEX.md.tmpl, Backlog.md.tmpl, Status.md.tmpl get relative links

## Plan
station/Playbook/Plans/Active/03-cross-linking-generated-files.md

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes