### PR TITLE
feat: add release pipeline — GoReleaser + GitHub Actions + Homebrew Tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ bonsai
 bonsai.exe
 Bonsai
 
+# GoReleaser
+dist/
+
 # Go
 *.test
 *.out

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,60 @@
+version: 2
+
+project_name: bonsai
+
+builds:
+  - id: bonsai
+    main: .
+    binary: bonsai
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: default
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE*
+      - README*
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+      - "^ci:"
+
+brews:
+  - name: bonsai
+    repository:
+      owner: LastStep
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/LastStep/Bonsai"
+    description: "CLI tool for scaffolding Claude Code agent workspaces"
+    license: "MIT"
+    directory: Formula
+    install: |
+      bin.install "bonsai"
+    test: |
+      system "#{bin}/bonsai", "--version"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 .PHONY: build install clean
 
+VERSION ?= dev
+LDFLAGS := -s -w -X main.version=$(VERSION)
+
 build:
-	go build -o bonsai .
+	go build -ldflags "$(LDFLAGS)" -o bonsai .
 
 install:
-	go install .
+	go install -ldflags "$(LDFLAGS)" .
 
 clean:
 	rm -f bonsai

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,9 @@ import (
 
 const configFile = ".bonsai.yaml"
 
+// Version is the current CLI version, set via SetVersion at startup.
+var Version = "dev"
+
 var catalogFS fs.FS
 var guideMarkdown string
 
@@ -41,6 +44,11 @@ func requireConfig(configPath string) (*config.ProjectConfig, error) {
 		os.Exit(1)
 	}
 	return config.Load(configPath)
+}
+
+// SetVersion sets the version string on the root command.
+func SetVersion(v string) {
+	rootCmd.Version = v
 }
 
 // Execute is the main entry point for the CLI.

--- a/main.go
+++ b/main.go
@@ -9,6 +9,9 @@ import (
 	"github.com/LastStep/Bonsai/cmd"
 )
 
+// version is set via ldflags at build time.
+var version = "dev"
+
 //go:embed all:catalog
 var catalogFS embed.FS
 
@@ -21,5 +24,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+	cmd.SetVersion(version)
 	cmd.Execute(sub, guideContent)
 }


### PR DESCRIPTION
## Summary
Add automated release pipeline using GoReleaser, GitHub Actions, and Homebrew Tap. Push a semver tag (e.g., `v0.1.0`) to trigger cross-platform binary builds published to GitHub Releases, with automatic Homebrew formula updates.

## Changes
- `cmd/root.go` — add Version variable and SetVersion function for `--version` flag
- `main.go` — add version ldflags variable, wire to cmd.SetVersion
- `Makefile` — add ldflags for version injection in build/install targets
- `.goreleaser.yaml` — GoReleaser v2 config (6 platform targets, checksums, changelog, Homebrew formula)
- `.github/workflows/release.yml` — GitHub Actions workflow triggered on semver tags
- `.gitignore` — add dist/ (GoReleaser output)

## Plan
station/Playbook/Plans/Active/04-release-pipeline.md

## Verification
- [x] `make build` — passes
- [x] `./bonsai --version` — prints "bonsai version dev"
- [x] `go test ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)