### PR TITLE
docs: community health files and README polish

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a bug in Bonsai
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1. Run `bonsai ...`
+2. Select ...
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened. Include error messages or unexpected output.
+
+## Environment
+
+- **Bonsai version:** (`bonsai --version`)
+- **OS:** (e.g., macOS 15, Ubuntu 24.04, Windows 11)
+- **Install method:** (Homebrew / binary download / `go install`)
+- **Go version** (if built from source): (`go version`)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussion
+    url: https://github.com/LastStep/Bonsai/discussions
+    about: Ask questions and share ideas in GitHub Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: Suggest a feature or catalog item
+labels: enhancement
+---
+
+## Problem / Use Case
+
+What problem does this solve? Why do you need it?
+
+## Proposed Solution
+
+Describe what you'd like to see — a new command, catalog item, behavior change, etc.
+
+## Alternatives Considered
+
+Any other approaches you've thought about.
+
+## Agent Types
+
+Which agent types would this apply to? (e.g., all, tech-lead, backend, frontend)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+What changed and why.
+
+## Changes
+
+- `path/file` — what changed
+
+## Test Plan
+
+How you tested this — commands run, scenarios verified.
+
+## Checklist
+
+- [ ] `make build` passes
+- [ ] `gofmt -s` clean (no formatting issues)
+- [ ] Tested affected commands manually
+- [ ] Updated docs if behavior changed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,22 @@
+# Code of Conduct
+
+## Our Standards
+
+We are committed to providing a welcoming and productive environment for everyone. We expect all participants to:
+
+- **Be respectful** — treat others as you'd want to be treated
+- **Be constructive** — offer helpful feedback, not criticism for its own sake
+- **Be collaborative** — work together toward shared goals
+- **Be patient** — remember that everyone has different experience levels
+
+Unacceptable behavior includes personal attacks, trolling, unwelcome attention, and any conduct that makes others feel unsafe or unwelcome.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported through [GitHub's private reporting](https://github.com/LastStep/Bonsai/security/advisories/new). All reports will be reviewed and handled with discretion.
+
+Project maintainers may remove, edit, or reject comments, commits, issues, and other contributions that do not align with this Code of Conduct.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to Bonsai
+
+Thanks for your interest in contributing to Bonsai! This guide covers everything you need to get started.
+
+## Development Setup
+
+**Requirements:** Go 1.24+
+
+```bash
+git clone https://github.com/LastStep/Bonsai.git
+cd Bonsai
+make build        # builds ./bonsai binary
+./bonsai --help   # verify it works
+```
+
+## Making Changes
+
+1. **Fork** the repo and create a branch from `main`
+2. Make your changes
+3. Run `make build` to verify the binary compiles
+4. Test your changes manually (see below)
+5. Submit a pull request
+
+### Testing Changes
+
+The catalog is embedded in the binary, so you need to rebuild after editing catalog files:
+
+```bash
+make build
+mkdir /tmp/test-project && cd /tmp/test-project
+/path/to/bonsai init
+/path/to/bonsai add
+/path/to/bonsai list
+```
+
+## Adding Catalog Items
+
+Bonsai's catalog lives in `catalog/`. Each category follows the same pattern:
+
+### Skills, Workflows, Protocols
+
+1. Create `catalog/{category}/{item-name}/meta.yaml` with `name`, `description`, and `agents`
+2. Create `catalog/{category}/{item-name}/{item-name}.md` with the content
+3. Set `agents:` to a list of compatible agent types, or `"all"`
+
+### Sensors
+
+1. Create `catalog/sensors/{name}/meta.yaml` — include `event` and optionally `matcher`
+2. Create `catalog/sensors/{name}/{name}.sh.tmpl` — hook script template
+
+### Routines
+
+1. Create `catalog/routines/{name}/meta.yaml` — include `frequency` (e.g. `"5 days"`)
+2. Create `catalog/routines/{name}/{name}.md.tmpl` — procedure template
+
+See `CLAUDE.md` for the full naming conventions and template context variables.
+
+## Pull Request Process
+
+- **One feature or fix per PR** — keep changes focused
+- **Open an issue first** for significant changes so we can discuss the approach
+- **Write a clear PR description** — what changed and why
+- **Test manually** — `make build` must pass, and test the affected commands
+
+## Code Style
+
+- Follow standard Go conventions (`gofmt`, `go vet`)
+- Keep the CLI interactive — use Huh forms for user input
+- Generator functions go in `internal/generate/`, catalog loading in `internal/catalog/`, commands in `cmd/`
+- All data shapes use Go structs
+
+## Development with Claude Code
+
+Bonsai dogfoods itself — the repo has a full Bonsai workspace in `station/`. If you use Claude Code for development, the agent instructions in `station/agent/` provide context about the codebase and conventions.
+
+## Questions?
+
+Open an [issue](https://github.com/LastStep/Bonsai/issues) or start a [discussion](https://github.com/LastStep/Bonsai/discussions) — we're happy to help.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ sudo mv bonsai /usr/local/bin/
 go install github.com/LastStep/Bonsai@latest
 ```
 
+**Verify:**
+
+```bash
+bonsai --version
+```
+
 ---
 
 ## Quick Start
@@ -328,12 +334,13 @@ Bonsai workspaces are designed to be extended. After generation, you own the fil
 | **[Handbook](HANDBOOK.md)** | Mental model, interaction patterns, sensor/routine deep dives, best practices |
 | **[Working With Agents](docs/working-with-agents.md)** | Communication patterns, framing techniques, and collaboration rhythms that get the best results |
 | **[Custom Files](docs/custom-files.md)** | How to create your own abilities — meta.yaml format, frontmatter, templates |
+| **[Contributing](CONTRIBUTING.md)** | How to set up for development, add catalog items, and submit PRs |
 
 ---
 
 ## Contributing
 
-Bonsai is early-stage and evolving fast. If you have ideas, find bugs, or want to add catalog items:
+Bonsai is early-stage and evolving fast. If you have ideas, find bugs, or want to add catalog items — see [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
 
 1. Open an [issue](https://github.com/LastStep/Bonsai/issues) to discuss
 2. Fork, branch, and submit a PR
@@ -345,6 +352,7 @@ Bonsai is early-stage and evolving fast. If you have ideas, find bugs, or want t
 
 **[GitHub](https://github.com/LastStep/Bonsai)** · **[Releases](https://github.com/LastStep/Bonsai/releases)** · **[MIT License](LICENSE)**
 
-Built with [Cobra](https://github.com/spf13/cobra), [Huh](https://github.com/charmbracelet/huh), [LipGloss](https://github.com/charmbracelet/lipgloss), and [BubbleTea](https://github.com/charmbracelet/bubbletea).
+Built with [Cobra](https://github.com/spf13/cobra), [Huh](https://github.com/charmbracelet/huh), [LipGloss](https://github.com/charmbracelet/lipgloss), and [BubbleTea](https://github.com/charmbracelet/bubbletea).<br>
+Developed with [Claude Code](https://claude.ai/code).
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Bonsai, please report it through [GitHub's private vulnerability reporting](https://github.com/LastStep/Bonsai/security/advisories/new).
+
+**Do not open a public issue for security vulnerabilities.**
+
+We will acknowledge your report within 48 hours and provide an initial assessment of the issue.
+
+## Scope
+
+The following are in scope for security reports:
+
+- **CLI binary** — command injection, path traversal, unsafe file operations
+- **Embedded catalog** — template injection, unsafe defaults in generated files
+- **Generated hook scripts** — script injection, privilege escalation
+- **Template rendering** — arbitrary code execution via template variables
+- **Configuration files** — sensitive data exposure in `.bonsai.yaml` or generated configs
+
+## Out of Scope
+
+- **User-customized files** — files you modify after generation are your responsibility
+- **Third-party dependencies** — report these to the upstream maintainer directly
+- **Claude Code itself** — report issues with Claude Code at [anthropics/claude-code](https://github.com/anthropics/claude-code/issues)
+
+## Supported Versions
+
+Only the latest release is supported with security updates.


### PR DESCRIPTION
## Summary
Add community health files, README refinements, and repo polish for official public release.

- **CONTRIBUTING.md** — dev setup, catalog contribution guide, PR process, Claude Code development workflow
- **CODE_OF_CONDUCT.md** — adapted from Contributor Covenant v2.1
- **SECURITY.md** — vulnerability reporting via GitHub private reporting
- **Issue templates** — bug report, feature request, config (disables blank issues)
- **PR template** — summary, changes, test plan, checklist
- **README updates** — Claude Code credit in footer, install verification step, Contributing link in guides table

## Changes
- `CONTRIBUTING.md` — new file
- `CODE_OF_CONDUCT.md` — new file
- `SECURITY.md` — new file
- `.github/ISSUE_TEMPLATE/bug_report.md` — new file
- `.github/ISSUE_TEMPLATE/feature_request.md` — new file
- `.github/ISSUE_TEMPLATE/config.yml` — new file
- `.github/pull_request_template.md` — new file
- `README.md` — footer, install section, guides table

## Plan
station/Playbook/Plans/Active/07-docs-and-repo-polish.md

## Verification
- [x] `make build` — passes
- [x] All 7 new files created with correct content
- [x] README renders with Claude Code credit, verification step, and Contributing guide link
- [x] Issue templates have valid YAML frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)