### PR TITLE
feat: add trigger metadata system for ability activation

### DIFF
--- a/catalog/skills/api-design-standards/meta.yaml
+++ b/catalog/skills/api-design-standards/meta.yaml
@@ -1,3 +1,12 @@
 name: api-design-standards
 description: REST API design conventions — URLs, methods, errors, pagination, versioning
 agents: [backend, fullstack, tech-lead]
+triggers:
+  scenarios:
+    - Designing or reviewing REST/GraphQL API endpoints
+    - Defining request/response schemas or versioning strategy
+  paths:
+    - "**/routes/**"
+    - "**/handlers/**"
+    - "**/controllers/**"
+    - "**/api/**"

--- a/catalog/skills/auth-patterns/meta.yaml
+++ b/catalog/skills/auth-patterns/meta.yaml
@@ -1,3 +1,12 @@
 name: auth-patterns
 description: Authentication and authorization patterns — flows, tokens, passwords, sessions, access control
 agents: [backend, fullstack, security]
+triggers:
+  scenarios:
+    - Implementing or reviewing authentication or authorization logic
+    - Working with session management, tokens, or access control
+  paths:
+    - "**/auth/**"
+    - "**/middleware/auth*"
+    - "**/login*"
+    - "**/session*"

--- a/catalog/skills/cli-conventions/meta.yaml
+++ b/catalog/skills/cli-conventions/meta.yaml
@@ -1,3 +1,11 @@
 name: cli-conventions
 description: CLI design conventions — structure, flags, output, exit codes, configuration
 agents: [backend, fullstack]
+triggers:
+  scenarios:
+    - Building or reviewing CLI commands, flags, or argument parsing
+    - Designing command-line user experience
+  paths:
+    - "cmd/**"
+    - "**/cli/**"
+    - "**/*command*"

--- a/catalog/skills/coding-standards/meta.yaml
+++ b/catalog/skills/coding-standards/meta.yaml
@@ -1,3 +1,14 @@
 name: coding-standards
 description: Language-specific coding standards — formatting, linting, patterns
 agents: [backend, devops, frontend, fullstack, security]
+triggers:
+  scenarios:
+    - Writing or reviewing source code in any language
+    - Applying formatting, linting, or naming conventions
+  paths:
+    - "*.go"
+    - "*.py"
+    - "*.js"
+    - "*.ts"
+    - "*.java"
+    - "*.rs"

--- a/catalog/skills/container-standards/meta.yaml
+++ b/catalog/skills/container-standards/meta.yaml
@@ -1,3 +1,11 @@
 name: container-standards
 description: Container and orchestration standards — Docker multi-stage builds, image security, Kubernetes manifests
 agents: [devops]
+triggers:
+  scenarios:
+    - Writing or reviewing Dockerfiles, docker-compose, or Kubernetes manifests
+    - Configuring container builds, images, or orchestration
+  paths:
+    - "**/Dockerfile*"
+    - "**/docker-compose*"
+    - "**/k8s/**"

--- a/catalog/skills/database-conventions/meta.yaml
+++ b/catalog/skills/database-conventions/meta.yaml
@@ -1,3 +1,12 @@
 name: database-conventions
 description: SQL naming, migration patterns, schema design rules
 agents: [backend, fullstack, tech-lead]
+triggers:
+  scenarios:
+    - Writing or reviewing SQL migrations or database schemas
+    - Designing data models or query patterns
+  paths:
+    - "*.sql"
+    - "migrations/**"
+    - "**/schema.*"
+    - "**/models/**"

--- a/catalog/skills/design-guide/meta.yaml
+++ b/catalog/skills/design-guide/meta.yaml
@@ -1,3 +1,12 @@
 name: design-guide
 description: UI/UX design patterns, component conventions, accessibility rules
 agents: [frontend, fullstack]
+triggers:
+  scenarios:
+    - Building or reviewing UI components, layouts, or visual styling
+    - Working with CSS, design tokens, or component libraries
+  paths:
+    - "**/components/**"
+    - "**/*.css"
+    - "**/*.scss"
+    - "**/styles/**"

--- a/catalog/skills/dispatch/meta.yaml
+++ b/catalog/skills/dispatch/meta.yaml
@@ -1,3 +1,7 @@
 name: dispatch
 description: How to dispatch work to code agents — triage rules, prompt structure, iteration tracking
 agents: [tech-lead]
+triggers:
+  scenarios:
+    - Dispatching work to a code agent via worktree
+    - Writing an agent dispatch prompt with plan steps

--- a/catalog/skills/iac-conventions/meta.yaml
+++ b/catalog/skills/iac-conventions/meta.yaml
@@ -1,3 +1,11 @@
 name: iac-conventions
 description: Infrastructure-as-code conventions — Terraform naming, state management, modules, tagging
 agents: [devops]
+triggers:
+  scenarios:
+    - Writing or reviewing Terraform, CloudFormation, or infrastructure-as-code
+    - Managing cloud resources or infrastructure configuration
+  paths:
+    - "**/*.tf"
+    - "**/*.tfvars"
+    - "**/cloudformation/**"

--- a/catalog/skills/issue-classification/meta.yaml
+++ b/catalog/skills/issue-classification/meta.yaml
@@ -1,3 +1,7 @@
 name: issue-classification
 description: Issue types, importance levels, domain labels, and classification heuristics
 agents: [tech-lead]
+triggers:
+  scenarios:
+    - Classifying or triaging a new issue or bug report
+    - Determining issue type, importance, and domain labels

--- a/catalog/skills/mobile-patterns/meta.yaml
+++ b/catalog/skills/mobile-patterns/meta.yaml
@@ -1,3 +1,12 @@
 name: mobile-patterns
 description: Mobile development patterns — state management, offline-first, navigation, performance
 agents: [fullstack]
+triggers:
+  scenarios:
+    - Developing or reviewing iOS or Android application code
+    - Working with mobile-specific patterns, navigation, or platform APIs
+  paths:
+    - "**/ios/**"
+    - "**/android/**"
+    - "**/*.swift"
+    - "**/*.kt"

--- a/catalog/skills/planning-template/meta.yaml
+++ b/catalog/skills/planning-template/meta.yaml
@@ -1,3 +1,7 @@
 name: planning-template
 description: Plan format, tier rules, and template for writing implementation plans
 agents: [tech-lead]
+triggers:
+  scenarios:
+    - Writing a new implementation plan
+    - Structuring a plan with tier rules and verification steps

--- a/catalog/skills/pr-creation/meta.yaml
+++ b/catalog/skills/pr-creation/meta.yaml
@@ -1,3 +1,7 @@
 name: pr-creation
 description: How to create well-structured pull requests — branch naming, title conventions, body template, draft workflow
 agents: [tech-lead, fullstack, backend, frontend]
+triggers:
+  scenarios:
+    - Creating a pull request with proper conventions
+    - Setting up branch naming, PR title, and body template

--- a/catalog/skills/review-checklist/meta.yaml
+++ b/catalog/skills/review-checklist/meta.yaml
@@ -1,3 +1,7 @@
 name: review-checklist
 description: Structured code review checklist — correctness, security, performance, maintainability
 agents: [reviewer, security, tech-lead]
+triggers:
+  scenarios:
+    - Performing a structured code review
+    - Checking correctness, security, performance, and maintainability

--- a/catalog/skills/test-strategy/meta.yaml
+++ b/catalog/skills/test-strategy/meta.yaml
@@ -1,3 +1,11 @@
 name: test-strategy
 description: Test architecture — which tests to write, when, and why; pyramid, coverage, anti-patterns
 agents: [backend, frontend, fullstack, qa]
+triggers:
+  scenarios:
+    - Defining the overall testing approach for a feature or module
+    - Deciding which test types to use and what to prioritize
+  paths:
+    - "**/*_test.go"
+    - "**/*.test.*"
+    - "**/*.spec.*"

--- a/catalog/skills/testing/meta.yaml
+++ b/catalog/skills/testing/meta.yaml
@@ -1,3 +1,12 @@
 name: testing
 description: Testing conventions — frameworks, patterns, coverage requirements
 agents: [backend, frontend, fullstack, security]
+triggers:
+  scenarios:
+    - Writing or reviewing unit tests, integration tests, or test fixtures
+    - Evaluating test coverage or test quality
+  paths:
+    - "**/*_test.go"
+    - "**/*.test.*"
+    - "**/*.spec.*"
+    - "**/test/**"

--- a/catalog/skills/workspace-guide/meta.yaml
+++ b/catalog/skills/workspace-guide/meta.yaml
@@ -1,3 +1,7 @@
 name: workspace-guide
 description: Bonsai workspace operational guide — how to use workflows, skills, routines, sensors, and the Playbook effectively
 agents: all
+triggers:
+  scenarios:
+    - Learning how this agent workspace is organized
+    - Understanding workspace conventions and file purposes

--- a/catalog/workflows/api-development/meta.yaml
+++ b/catalog/workflows/api-development/meta.yaml
@@ -1,3 +1,10 @@
 name: api-development
 description: Spec-first API development — define contract, generate scaffolding, implement, test, document
 agents: [backend, fullstack]
+triggers:
+  scenarios:
+    - Building a new API endpoint or service from requirements
+    - Implementing CRUD operations, middleware, or API integrations
+  examples:
+    - prompt: "Build the user management API"
+      action: "Load api-development workflow, design endpoints, implement handlers"

--- a/catalog/workflows/code-review/meta.yaml
+++ b/catalog/workflows/code-review/meta.yaml
@@ -1,3 +1,10 @@
 name: code-review
 description: Review agent output against the plan — correctness, standards, security
 agents: [security, tech-lead]
+triggers:
+  scenarios:
+    - Reviewing agent output against the plan for correctness and standards
+    - Checking implementation changes before merging
+  examples:
+    - prompt: "Review the changes on the feature branch"
+      action: "Load code-review workflow, diff branch against main, check plan compliance"

--- a/catalog/workflows/issue-to-implementation/meta.yaml
+++ b/catalog/workflows/issue-to-implementation/meta.yaml
@@ -1,3 +1,10 @@
 name: issue-to-implementation
 description: End-to-end autonomous workflow — issue intake, analysis, research, planning, agent dispatch, review loop, logging, audit, and close
 agents: [tech-lead]
+triggers:
+  scenarios:
+    - Taking an issue from intake through to shipped code
+    - Running the full autonomous implementation workflow
+  examples:
+    - prompt: "Pick up issue #15 and ship it"
+      action: "Load issue-to-implementation workflow, analyze issue, plan, dispatch, review, merge"

--- a/catalog/workflows/plan-execution/meta.yaml
+++ b/catalog/workflows/plan-execution/meta.yaml
@@ -1,3 +1,10 @@
 name: plan-execution
 description: Execute an assigned plan step by step — implement, test, report
 agents: [backend, devops, frontend, fullstack]
+triggers:
+  scenarios:
+    - Executing an approved implementation plan step by step
+    - Dispatching agents and tracking plan completion
+  examples:
+    - prompt: "Execute plan 08 phase A"
+      action: "Load plan-execution workflow, read plan, dispatch agents, track progress"

--- a/catalog/workflows/planning/meta.yaml
+++ b/catalog/workflows/planning/meta.yaml
@@ -1,3 +1,10 @@
 name: planning
 description: End-to-end planning process — from request to dispatch-ready plan
 agents: [tech-lead]
+triggers:
+  scenarios:
+    - Starting end-to-end planning for a new feature or task
+    - Translating requirements into a structured implementation plan
+  examples:
+    - prompt: "Plan the new caching layer"
+      action: "Load planning workflow, analyze requirements, write plan to Plans/Active/"

--- a/catalog/workflows/pr-review/meta.yaml
+++ b/catalog/workflows/pr-review/meta.yaml
@@ -1,3 +1,10 @@
 name: pr-review
 description: Review a pull request — context, scope, correctness, security, performance, standards
 agents: [tech-lead]
+triggers:
+  scenarios:
+    - Reviewing a pull request for correctness, security, and standards
+    - Evaluating PR scope, changes, and test coverage
+  examples:
+    - prompt: "Review PR #42"
+      action: "Load pr-review workflow, fetch PR details, review against checklist"

--- a/catalog/workflows/reporting/meta.yaml
+++ b/catalog/workflows/reporting/meta.yaml
@@ -1,3 +1,10 @@
 name: reporting
 description: Completion report format — what was done, tested, issues encountered
 agents: [backend, devops, frontend, fullstack, security]
+triggers:
+  scenarios:
+    - Generating a structured completion or status report
+    - Documenting project progress, findings, or audit results
+  examples:
+    - prompt: "Write the completion report for this task"
+      action: "Load reporting workflow, compile findings, write to Reports/Pending/"

--- a/catalog/workflows/security-audit/meta.yaml
+++ b/catalog/workflows/security-audit/meta.yaml
@@ -1,3 +1,10 @@
 name: security-audit
 description: Security audit — secrets scan, dependency audit, SAST, config review, access control, infrastructure
 agents: [devops, security, tech-lead]
+triggers:
+  scenarios:
+    - Running a security audit on the codebase or recent changes
+    - Checking for secrets, vulnerable dependencies, or unsafe patterns
+  examples:
+    - prompt: "Check the project for security issues"
+      action: "Load security-audit workflow, scan secrets, audit deps, review config"

--- a/catalog/workflows/session-logging/meta.yaml
+++ b/catalog/workflows/session-logging/meta.yaml
@@ -1,3 +1,10 @@
 name: session-logging
 description: End-of-session log — what was done, decisions made, open items
 agents: all
+triggers:
+  scenarios:
+    - Writing an end-of-session log entry
+    - Recording decisions made and open items from the current session
+  examples:
+    - prompt: "Log what we did today"
+      action: "Load session-logging workflow, compile session summary, append to logs"

--- a/catalog/workflows/test-plan/meta.yaml
+++ b/catalog/workflows/test-plan/meta.yaml
@@ -1,3 +1,10 @@
 name: test-plan
 description: Design a structured test plan for a feature — scope, prioritize, allocate test types
 agents: [tech-lead]
+triggers:
+  scenarios:
+    - Designing a structured test plan for a feature or module
+    - Deciding test scope, priorities, and test type allocation
+  examples:
+    - prompt: "Plan the tests for the new API endpoints"
+      action: "Load test-plan workflow, analyze feature, design test coverage strategy"

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -211,6 +211,8 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		Title("Generating workspace...").
 		Action(func() {
 			_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false)
+			_ = generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false)
+			_ = generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false)
 			_ = generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false)
 		}).
 		Run()
@@ -378,6 +380,8 @@ func runAddItems(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog
 		Title("Generating files...").
 		Action(func() {
 			_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false)
+			_ = generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false)
+			_ = generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false)
 			_ = generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false)
 		}).
 		Run()

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -184,6 +184,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 		Action(func() {
 			_ = generate.Scaffolding(cwd, cfg, cat, lock, &wr, false)
 			_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false)
+			_ = generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false)
+			_ = generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false)
 			_ = generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false)
 		}).
 		Run()

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -119,11 +119,15 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	if deleteFiles {
 		agentDir := filepath.Join(cwd, agent.Workspace, "agent")
 		claudeMD := filepath.Join(cwd, agent.Workspace, "CLAUDE.md")
+		claudeDir := filepath.Join(cwd, agent.Workspace, ".claude")
 		if err := os.RemoveAll(agentDir); err == nil {
 			tui.Info("Deleted " + agentDir)
 		}
 		if err := os.Remove(claudeMD); err == nil {
 			tui.Info("Deleted " + claudeMD)
+		}
+		if err := os.RemoveAll(claudeDir); err == nil {
+			tui.Info("Deleted " + claudeDir)
 		}
 	}
 
@@ -305,6 +309,20 @@ func runRemoveItem(name string, it itemType) error {
 				relPath := filepath.Join(t.agent.Workspace, "agent", it.dir, name+it.ext)
 				lock.Untrack(relPath)
 				_ = os.Remove(filepath.Join(cwd, relPath))
+
+				// Clean up generated trigger files
+				if it.singular == "skill" {
+					rulePath := filepath.Join(t.agent.Workspace, ".claude", "rules", "skill-"+name+".md")
+					lock.Untrack(rulePath)
+					_ = os.Remove(filepath.Join(cwd, rulePath))
+				}
+				if it.singular == "workflow" {
+					skillDir := filepath.Join(t.agent.Workspace, ".claude", "skills", name)
+					skillPath := filepath.Join(skillDir, "SKILL.md")
+					lock.Untrack(filepath.Join(t.agent.Workspace, ".claude", "skills", name, "SKILL.md"))
+					_ = os.Remove(filepath.Join(cwd, skillPath))
+					_ = os.Remove(filepath.Join(cwd, skillDir)) // remove empty dir
+				}
 
 				// Routine-specific: update auto-sensor and dashboard
 				if it.singular == "routine" {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -158,6 +158,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 				generate.EnsureRoutineCheckSensor(installed)
 				_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false)
 			}
+			_ = generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false)
+			_ = generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false)
 			_ = generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false)
 		}).
 		Run()

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -73,6 +73,7 @@ type CatalogItem struct {
 	Description string      `yaml:"description"`
 	Agents      AgentCompat `yaml:"agents"`
 	Required    AgentCompat `yaml:"required"`
+	Triggers    *Triggers   `yaml:"triggers,omitempty"`
 	ContentPath string      `yaml:"-"`
 }
 
@@ -86,6 +87,19 @@ type SensorItem struct {
 	Event       string      `yaml:"event"`
 	Matcher     string      `yaml:"matcher,omitempty"`
 	ContentPath string      `yaml:"-"`
+}
+
+// TriggerExample is a prompt-action pair showing how an ability activates.
+type TriggerExample struct {
+	Prompt string `yaml:"prompt"`
+	Action string `yaml:"action"`
+}
+
+// Triggers holds activation metadata for skills and workflows.
+type Triggers struct {
+	Scenarios []string         `yaml:"scenarios,omitempty"`
+	Examples  []TriggerExample `yaml:"examples,omitempty"`
+	Paths     []string         `yaml:"paths,omitempty"`
 }
 
 // RoutineItem represents a periodic self-maintenance routine.

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -112,6 +112,27 @@ func descFor(names []string, cat *catalog.Catalog, category string, customItems 
 	return result
 }
 
+// scenariosDesc returns a trigger-aware description for CLAUDE.md tables.
+// Uses triggers.scenarios (joined with "; ") if available, falls back to description.
+func scenariosDesc(item *catalog.CatalogItem) string {
+	if item != nil && item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
+		return strings.Join(item.Triggers.Scenarios, "; ")
+	}
+	if item != nil {
+		return item.Description
+	}
+	return ""
+}
+
+// CuratedSlashWorkflows is the set of workflows that get .claude/skills/ files
+// and appear in the Quick Triggers table. Keep this small — each entry consumes
+// ~1,536 chars of context budget at session start.
+var CuratedSlashWorkflows = map[string]bool{
+	"planning": true, "code-review": true, "pr-review": true,
+	"security-audit": true, "issue-to-implementation": true,
+	"test-plan": true, "plan-execution": true,
+}
+
 // ─── Write result types ────────────────────────────────────────────────
 
 // FileAction describes what happened to a single file during generation.
@@ -549,6 +570,40 @@ func howToWorkLines(agentName string, docsPrefix string, hasRoutines bool, hasWo
 	return lines
 }
 
+func quickTriggersLines(installed *config.InstalledAgent, cat *catalog.Catalog) []string {
+	var lines []string
+	lines = append(lines,
+		"### Quick Triggers", "",
+		"> Common phrases and commands that activate specific behaviors.", "",
+		"| You want to... | Say or do this |",
+		"|----------------|---------------|",
+		"| Start a session | \"Hi, get started\" |",
+	)
+
+	// Add workflow-based triggers from curated set — derive descriptions from catalog
+	for _, w := range installed.Workflows {
+		if !CuratedSlashWorkflows[w] {
+			continue
+		}
+		desc := catalog.DisplayNameFrom(w)
+		if item := cat.GetWorkflow(w); item != nil {
+			if item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
+				desc = item.Triggers.Scenarios[0]
+			} else {
+				desc = item.Description
+			}
+		}
+		lines = append(lines, fmt.Sprintf("| %s | \"[describe task]\" or `/%s` |", desc, w))
+	}
+
+	lines = append(lines,
+		"| Self-review before shipping | \"Verify everything\" |",
+		"| End session | \"That's all\" |",
+		"", "",
+	)
+	return lines
+}
+
 const (
 	bonsaiStartMarker = "<!-- BONSAI_START -->"
 	bonsaiEndMarker   = "<!-- BONSAI_END -->"
@@ -578,6 +633,10 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 		"| [agent/Core/self-awareness.md](agent/Core/self-awareness.md) | Context monitoring, hard thresholds |", "",
 	)
 
+	// Quick Triggers reference
+	qt := quickTriggersLines(installed, cat)
+	lines = append(lines, qt...)
+
 	if len(installed.Protocols) > 0 {
 		protoDescs := descFor(installed.Protocols, cat, "protocol", custom)
 		lines = append(lines,
@@ -595,11 +654,17 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 		wfDescs := descFor(installed.Workflows, cat, "workflow", custom)
 		lines = append(lines,
 			"### Workflows (load when starting an activity)", "",
-			"| Activity | Read this |",
-			"|----------|-----------|",
+			"| Activate when... | Read this |",
+			"|------------------|-----------|",
 		)
 		for _, w := range installed.Workflows {
-			lines = append(lines, fmt.Sprintf("| %s | [agent/Workflows/%s.md](agent/Workflows/%s.md) |", wfDescs[w], w, w))
+			desc := wfDescs[w]
+			if item := cat.GetWorkflow(w); item != nil {
+				if sd := scenariosDesc(item); sd != "" {
+					desc = sd
+				}
+			}
+			lines = append(lines, fmt.Sprintf("| %s | [agent/Workflows/%s.md](agent/Workflows/%s.md) |", desc, w, w))
 		}
 		lines = append(lines, "")
 	}
@@ -608,11 +673,17 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 		skillDescs := descFor(installed.Skills, cat, "skill", custom)
 		lines = append(lines,
 			"### Skills (load when doing specific work)", "",
-			"| Need | Read this |",
-			"|------|-----------|",
+			"| Activate when... | Read this |",
+			"|------------------|-----------|",
 		)
 		for _, s := range installed.Skills {
-			lines = append(lines, fmt.Sprintf("| %s | [agent/Skills/%s.md](agent/Skills/%s.md) |", skillDescs[s], s, s))
+			desc := skillDescs[s]
+			if item := cat.GetSkill(s); item != nil {
+				if sd := scenariosDesc(item); sd != "" {
+					desc = sd
+				}
+			}
+			lines = append(lines, fmt.Sprintf("| %s | [agent/Skills/%s.md](agent/Skills/%s.md) |", desc, s, s))
 		}
 		lines = append(lines, "")
 	}
@@ -956,6 +1027,134 @@ func RoutineDashboard(projectRoot string, workspaceRoot string, installed *confi
 	return nil
 }
 
+// PathScopedRules generates .claude/rules/skill-{name}.md files for skills
+// that have triggers.paths defined. These auto-load when Claude reads matching files.
+func PathScopedRules(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
+	for _, installed := range cfg.Agents {
+		for _, skillName := range installed.Skills {
+			item := cat.GetSkill(skillName)
+			if item == nil || item.Triggers == nil || len(item.Triggers.Paths) == 0 {
+				continue
+			}
+
+			// Build content
+			var lines []string
+			lines = append(lines, "---")
+			lines = append(lines, "paths:")
+			for _, p := range item.Triggers.Paths {
+				lines = append(lines, fmt.Sprintf("  - \"%s\"", p))
+			}
+			lines = append(lines, "---", "")
+			lines = append(lines, fmt.Sprintf("When working with files matching these paths, load and follow the **%s** skill at `%sagent/Skills/%s.md`.",
+				item.DisplayName, installed.Workspace, skillName))
+
+			if len(item.Triggers.Scenarios) > 0 {
+				lines = append(lines, "", "Activate when:")
+				for _, s := range item.Triggers.Scenarios {
+					lines = append(lines, "- "+s)
+				}
+			}
+			lines = append(lines, "")
+
+			content := []byte(strings.Join(lines, "\n"))
+			relPath := filepath.Join(installed.Workspace, ".claude", "rules", "skill-"+skillName+".md")
+			r := writeFile(projectRoot, relPath, content, "generated:rule-skill-"+skillName, lock, force)
+			result.Add(r)
+		}
+	}
+	return nil
+}
+
+// WorkflowSkills generates .claude/skills/{name}/SKILL.md files for curated
+// workflows, enabling /slash-command invocation and description-based auto-invocation.
+func WorkflowSkills(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
+	for _, installed := range cfg.Agents {
+		for _, wfName := range installed.Workflows {
+			if !CuratedSlashWorkflows[wfName] {
+				continue
+			}
+			item := cat.GetWorkflow(wfName)
+			if item == nil {
+				continue
+			}
+
+			var lines []string
+			lines = append(lines, "---")
+			lines = append(lines, fmt.Sprintf("name: %s", wfName))
+
+			// Description from scenarios or fallback
+			desc := item.Description
+			if item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
+				desc = strings.Join(item.Triggers.Scenarios, ". ")
+			}
+			lines = append(lines, fmt.Sprintf("description: %s", desc))
+
+			// when_to_use from scenarios
+			if item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
+				lines = append(lines, fmt.Sprintf("when_to_use: %s", strings.Join(item.Triggers.Scenarios, "; ")))
+			}
+
+			lines = append(lines, "---", "")
+			lines = append(lines, fmt.Sprintf("Load and follow the **%s** workflow at `%sagent/Workflows/%s.md`.",
+				item.DisplayName, installed.Workspace, wfName))
+
+			// Examples section
+			if item.Triggers != nil && len(item.Triggers.Examples) > 0 {
+				lines = append(lines, "", "## Examples", "")
+				for _, ex := range item.Triggers.Examples {
+					lines = append(lines, fmt.Sprintf("> **User:** \"%s\"", ex.Prompt))
+					lines = append(lines, fmt.Sprintf("> **Action:** %s", ex.Action))
+					lines = append(lines, "")
+				}
+			}
+			lines = append(lines, "")
+
+			content := []byte(strings.Join(lines, "\n"))
+			relPath := filepath.Join(installed.Workspace, ".claude", "skills", wfName, "SKILL.md")
+			r := writeFile(projectRoot, relPath, content, "generated:skill-workflow-"+wfName, lock, force)
+			result.Add(r)
+		}
+	}
+	return nil
+}
+
+// triggerSection generates a markdown trigger header from catalog triggers metadata.
+func triggerSection(item *catalog.CatalogItem, workspace string, category string, isSlashCommand bool) string {
+	if item.Triggers == nil {
+		return ""
+	}
+	t := item.Triggers
+
+	var lines []string
+	lines = append(lines, "## Triggers", "")
+
+	if isSlashCommand {
+		lines = append(lines, fmt.Sprintf("**Slash command:** `/%s`", item.Name))
+	}
+
+	if len(t.Paths) > 0 {
+		lines = append(lines, fmt.Sprintf("**Auto-loads when reading:** %s", strings.Join(t.Paths, ", ")))
+	}
+
+	if len(t.Scenarios) > 0 {
+		lines = append(lines, "**Activate when:**")
+		for _, s := range t.Scenarios {
+			lines = append(lines, "- "+s)
+		}
+	}
+
+	if len(t.Examples) > 0 {
+		lines = append(lines, "", "**Examples:**")
+		for _, ex := range t.Examples {
+			lines = append(lines, fmt.Sprintf("> **User:** \"%s\"", ex.Prompt))
+			lines = append(lines, fmt.Sprintf("> **Action:** %s", ex.Action))
+		}
+	}
+
+	lines = append(lines, "", "---", "")
+	return strings.Join(lines, "\n")
+}
+
 // AgentWorkspace generates the full agent/ directory in a workspace.
 func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *config.InstalledAgent, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
 	workspaceRoot := filepath.Join(projectRoot, installed.Workspace)
@@ -1068,6 +1267,12 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 		if err != nil {
 			return fmt.Errorf("skill %s: %w", skillName, err)
 		}
+
+		// Prepend trigger section if triggers exist
+		if ts := triggerSection(item, installed.Workspace, "skill", false); ts != "" {
+			content = append([]byte(ts), content...)
+		}
+
 		relPath, _ := filepath.Rel(projectRoot, filepath.Join(agentDir, "Skills", skillName+".md"))
 		r := writeFile(projectRoot, relPath, content, "catalog:skills/"+skillName, lock, force)
 		result.Add(r)
@@ -1083,6 +1288,12 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 		if err != nil {
 			return err
 		}
+
+		// Prepend trigger section if triggers exist
+		if ts := triggerSection(item, installed.Workspace, "workflow", CuratedSlashWorkflows[wfName]); ts != "" {
+			data = append([]byte(ts), data...)
+		}
+
 		relPath, _ := filepath.Rel(projectRoot, filepath.Join(agentDir, "Workflows", wfName+".md"))
 		r := writeFile(projectRoot, relPath, data, "catalog:workflows/"+wfName, lock, force)
 		result.Add(r)

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -627,3 +627,364 @@ func TestHowToWorkGuidePointer(t *testing.T) {
 		t.Error("workspace-guide pointer should NOT appear when hasWorkspaceGuide is false")
 	}
 }
+
+// ─── Trigger tests ──────────────────────────────────────────────────
+
+// buildTestCatalogWithItems creates a catalog with skills and workflows for trigger testing.
+func buildTestCatalogWithItems(extraFiles map[string]string) (*catalog.Catalog, error) {
+	fsys := fstest.MapFS{
+		// Shared core files
+		"core/memory.md.tmpl":    &fstest.MapFile{Data: []byte("memory for {{ .AgentDisplayName }}")},
+		"core/self-awareness.md": &fstest.MapFile{Data: []byte("self-awareness content")},
+		// Agent definition
+		"agents/test-agent/agent.yaml":            &fstest.MapFile{Data: []byte("name: test-agent\ndescription: test\n")},
+		"agents/test-agent/core/identity.md.tmpl": &fstest.MapFile{Data: []byte("I am {{ .AgentDisplayName }}")},
+	}
+	for k, v := range extraFiles {
+		fsys[k] = &fstest.MapFile{Data: []byte(v)}
+	}
+	return catalog.New(fsys)
+}
+
+func TestScenariosDescFallback(t *testing.T) {
+	// nil triggers → falls back to description
+	item := &catalog.CatalogItem{Description: "A test description"}
+	result := scenariosDesc(item)
+	if result != "A test description" {
+		t.Errorf("expected description fallback, got %q", result)
+	}
+
+	// non-nil triggers with scenarios → uses scenarios
+	item.Triggers = &catalog.Triggers{
+		Scenarios: []string{"When doing X"},
+	}
+	result = scenariosDesc(item)
+	if result != "When doing X" {
+		t.Errorf("expected scenario, got %q", result)
+	}
+
+	// nil item → empty string
+	result = scenariosDesc(nil)
+	if result != "" {
+		t.Errorf("expected empty string for nil item, got %q", result)
+	}
+}
+
+func TestScenariosDescJoinsScenarios(t *testing.T) {
+	item := &catalog.CatalogItem{
+		Description: "fallback",
+		Triggers: &catalog.Triggers{
+			Scenarios: []string{"Scenario A", "Scenario B", "Scenario C"},
+		},
+	}
+	result := scenariosDesc(item)
+	expected := "Scenario A; Scenario B; Scenario C"
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestClaudeMDUsesScenarios(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"skills/test-skill/meta.yaml":     "name: test-skill\ndescription: A test skill\nagents: all\ntriggers:\n  scenarios:\n    - Testing trigger scenarios\n  paths:\n    - \"*.test\"\n",
+		"skills/test-skill/test-skill.md": "# Test Skill\n\nSkill content here.\n",
+		"workflows/planning/meta.yaml":    "name: planning\ndescription: End-to-end planning\nagents: all\ntriggers:\n  scenarios:\n    - Starting end-to-end planning\n    - Translating requirements into a plan\n  examples:\n    - prompt: \"Plan the caching layer\"\n      action: \"Load planning workflow\"\n",
+		"workflows/planning/planning.md":  "# Planning Workflow\n\nWorkflow content here.\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	agentDef := cat.GetAgent("test-agent")
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: ".",
+		Skills:    []string{"test-skill"},
+		Workflows: []string{"planning"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+	_ = WorkspaceClaudeMD(tmpDir, tmpDir, agentDef, installed, cfg, cat, lock, &wr, false)
+
+	claudeMD, err := os.ReadFile(filepath.Join(tmpDir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	content := string(claudeMD)
+
+	if !strings.Contains(content, "Activate when...") {
+		t.Error("CLAUDE.md should have 'Activate when...' header")
+	}
+	if !strings.Contains(content, "Testing trigger scenarios") {
+		t.Error("CLAUDE.md should contain skill scenario text")
+	}
+	if !strings.Contains(content, "Starting end-to-end planning") {
+		t.Error("CLAUDE.md should contain workflow scenario text")
+	}
+}
+
+func TestPathScopedRulesGenerated(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"skills/test-skill/meta.yaml":     "name: test-skill\ndescription: A test skill\nagents: all\ntriggers:\n  scenarios:\n    - Testing trigger scenarios\n  paths:\n    - \"*.test\"\n    - \"**/test/**\"\n",
+		"skills/test-skill/test-skill.md": "# Test Skill\n\nSkill content here.\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: "station/",
+		Skills:    []string{"test-skill"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+	err = PathScopedRules(tmpDir, cfg, cat, lock, &wr, false)
+	if err != nil {
+		t.Fatalf("PathScopedRules: %v", err)
+	}
+
+	rulePath := filepath.Join(tmpDir, "station", ".claude", "rules", "skill-test-skill.md")
+	data, err := os.ReadFile(rulePath)
+	if err != nil {
+		t.Fatalf("rule file not created: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "paths:") {
+		t.Error("rule file should contain paths: frontmatter")
+	}
+	if !strings.Contains(content, "*.test") {
+		t.Error("rule file should contain the path glob")
+	}
+	if !strings.Contains(content, "Testing trigger scenarios") {
+		t.Error("rule file should contain scenario text")
+	}
+}
+
+func TestPathScopedRulesSkippedWhenNoPaths(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"skills/no-paths/meta.yaml":   "name: no-paths\ndescription: A skill without paths\nagents: all\ntriggers:\n  scenarios:\n    - No paths skill\n",
+		"skills/no-paths/no-paths.md": "# No Paths Skill\n\nContent.\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: "station/",
+		Skills:    []string{"no-paths"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+	_ = PathScopedRules(tmpDir, cfg, cat, lock, &wr, false)
+
+	rulePath := filepath.Join(tmpDir, "station", ".claude", "rules", "skill-no-paths.md")
+	if _, err := os.Stat(rulePath); err == nil {
+		t.Error("rule file should NOT be created for skill without paths")
+	}
+}
+
+func TestWorkflowSkillsGenerated(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"workflows/planning/meta.yaml":   "name: planning\ndescription: End-to-end planning\nagents: all\ntriggers:\n  scenarios:\n    - Starting end-to-end planning\n  examples:\n    - prompt: \"Plan the caching layer\"\n      action: \"Load planning workflow\"\n",
+		"workflows/planning/planning.md": "# Planning Workflow\n\nWorkflow content here.\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: "station/",
+		Workflows: []string{"planning"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+	err = WorkflowSkills(tmpDir, cfg, cat, lock, &wr, false)
+	if err != nil {
+		t.Fatalf("WorkflowSkills: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpDir, "station", ".claude", "skills", "planning", "SKILL.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("SKILL.md not created: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "name: planning") {
+		t.Error("SKILL.md should contain workflow name")
+	}
+	if !strings.Contains(content, "Starting end-to-end planning") {
+		t.Error("SKILL.md should contain scenario description")
+	}
+	if !strings.Contains(content, "Plan the caching layer") {
+		t.Error("SKILL.md should contain example prompt")
+	}
+}
+
+func TestWorkflowSkillsSkippedWhenNotCurated(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"workflows/session-logging/meta.yaml":          "name: session-logging\ndescription: End-of-session log\nagents: all\ntriggers:\n  scenarios:\n    - Logging session\n",
+		"workflows/session-logging/session-logging.md": "# Session Logging\n\nContent.\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: "station/",
+		Workflows: []string{"session-logging"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+	_ = WorkflowSkills(tmpDir, cfg, cat, lock, &wr, false)
+
+	skillPath := filepath.Join(tmpDir, "station", ".claude", "skills", "session-logging", "SKILL.md")
+	if _, err := os.Stat(skillPath); err == nil {
+		t.Error("SKILL.md should NOT be created for non-curated workflow")
+	}
+}
+
+func TestTriggerSectionPrepended(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"skills/test-skill/meta.yaml":     "name: test-skill\ndescription: A test skill\nagents: all\ntriggers:\n  scenarios:\n    - Testing trigger scenarios\n  paths:\n    - \"*.test\"\n",
+		"skills/test-skill/test-skill.md": "# Test Skill\n\nSkill content here.\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	agentDef := cat.GetAgent("test-agent")
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: ".",
+		Skills:    []string{"test-skill"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+	err = AgentWorkspace(tmpDir, agentDef, installed, cfg, cat, lock, &wr, false)
+	if err != nil {
+		t.Fatalf("AgentWorkspace: %v", err)
+	}
+
+	skillPath := filepath.Join(tmpDir, "agent", "Skills", "test-skill.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read skill file: %v", err)
+	}
+	content := string(data)
+
+	if !strings.HasPrefix(content, "## Triggers") {
+		t.Error("skill file should start with '## Triggers' section")
+	}
+	if !strings.Contains(content, "Testing trigger scenarios") {
+		t.Error("skill file should contain scenario text in trigger section")
+	}
+	if !strings.Contains(content, "# Test Skill") {
+		t.Error("skill file should still contain original content after trigger section")
+	}
+}
+
+func TestBackwardCompatNilTriggers(t *testing.T) {
+	// Build catalog with NO triggers — should work fine
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"skills/plain-skill/meta.yaml":      "name: plain-skill\ndescription: A plain skill\nagents: all\n",
+		"skills/plain-skill/plain-skill.md": "# Plain Skill\n\nContent.\n",
+		"workflows/plain-wf/meta.yaml":      "name: plain-wf\ndescription: A plain workflow\nagents: all\n",
+		"workflows/plain-wf/plain-wf.md":    "# Plain Workflow\n\nContent.\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	agentDef := cat.GetAgent("test-agent")
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: ".",
+		Skills:    []string{"plain-skill"},
+		Workflows: []string{"plain-wf"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+
+	// AgentWorkspace should not crash
+	err = AgentWorkspace(tmpDir, agentDef, installed, cfg, cat, lock, &wr, false)
+	if err != nil {
+		t.Fatalf("AgentWorkspace with nil triggers should not error: %v", err)
+	}
+
+	// PathScopedRules should not crash or create files
+	var wr2 WriteResult
+	err = PathScopedRules(tmpDir, cfg, cat, lock, &wr2, false)
+	if err != nil {
+		t.Fatalf("PathScopedRules with nil triggers should not error: %v", err)
+	}
+	for _, f := range wr2.Files {
+		if strings.Contains(f.RelPath, "rules") {
+			t.Error("should not create rule files when no paths triggers")
+		}
+	}
+
+	// WorkflowSkills should not crash (plain-wf is not curated)
+	var wr3 WriteResult
+	err = WorkflowSkills(tmpDir, cfg, cat, lock, &wr3, false)
+	if err != nil {
+		t.Fatalf("WorkflowSkills with nil triggers should not error: %v", err)
+	}
+
+	// Verify skill file does NOT have trigger section
+	skillPath := filepath.Join(tmpDir, "agent", "Skills", "plain-skill.md")
+	data, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read skill file: %v", err)
+	}
+	if strings.HasPrefix(string(data), "## Triggers") {
+		t.Error("skill file without triggers should not start with trigger section")
+	}
+}


### PR DESCRIPTION
## Summary
- Add trigger metadata (scenarios, examples, paths) to catalog schema and all 27 ability meta.yaml files
- Enrich CLAUDE.md tables with scenario-based "Activate when..." descriptions and Quick Triggers reference
- Generate `.claude/rules/skill-*.md` path-scoped rules and `.claude/skills/*/SKILL.md` for curated workflows
- Prepend trigger sections to generated skill and workflow files; wire generators into init/add/update/remove commands

## Changes
- `internal/catalog/catalog.go` — Add `Triggers`, `TriggerExample` structs and `Triggers` field to `CatalogItem`
- `internal/generate/generate.go` — Add `scenariosDesc()`, `quickTriggersLines()`, `triggerSection()`, `PathScopedRules()`, `WorkflowSkills()`; enrich CLAUDE.md tables with scenario descriptions
- `internal/generate/generate_test.go` — 9 new tests for trigger functionality
- `cmd/init.go`, `cmd/add.go`, `cmd/update.go`, `cmd/remove.go` — Wire new generators and cleanup logic
- `catalog/skills/*/meta.yaml` — Add trigger metadata (17 files)
- `catalog/workflows/*/meta.yaml` — Add trigger metadata (10 files)

## Plan
station/Playbook/Plans/Active/08-better-trigger-sections.md (Phase A)

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `gofmt -s -l .` — clean

## Test plan
- [ ] `bonsai init` generates CLAUDE.md with "Activate when..." headers and Quick Triggers table
- [ ] `.claude/rules/skill-*.md` files exist for skills with paths
- [ ] `.claude/skills/*/SKILL.md` files exist for curated workflows
- [ ] Skill/workflow files have "## Triggers" section at top
- [ ] `bonsai remove skill <name>` cleans up rule files
- [ ] `bonsai remove workflow <name>` cleans up SKILL.md files
- [ ] Backward compat: configs without triggers work without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)