### PR TITLE
feat(ui): Phase 1 foundation — adaptive palette, NO_COLOR, FatalPanel

### DIFF
--- a/catalog/skills/design-guide/design-guide.md
+++ b/catalog/skills/design-guide/design-guide.md
@@ -1,30 +1,87 @@
 # Design Guide
 
+Bonsai CLI design rules. Applies to `internal/tui/**` and `cmd/*.go`.
+
 ---
 
-## Component Patterns
+## 1. Design Principles
 
-- One component per file — named exports matching the filename
-- Prefer composition over prop-drilling — use context or state management for deeply shared state
-- Keep components focused — if a component does more than one thing, split it
-- Separate presentational components from data-fetching containers
+- **Respect the Terminal** — render correctly on dark, light, NO_COLOR, TERM=dumb, and piped output. Never assume a dark background.
+- **One Voice** — every command speaks through the same vocabulary: headings, panels, helpers. Don't invent new shapes.
+- **Progressive Disclosure** — show the minimum first. Hints, details, and trees come after the outcome, not before.
+- **Feedback is Mandatory** — every mutation ends with `tui.Success(...)` (or a panel that clearly states the outcome).
+- **Understated Personality** — muted palette, rounded borders, no emoji, no marketing copy.
 
-## Styling
+## 2. Adaptive Palette
 
-- Use the project's configured CSS solution consistently (Tailwind, CSS Modules, etc.)
-- Never use inline styles except for truly dynamic values (e.g., calculated positions)
-- Design tokens (colors, spacing, typography) come from the theme — never hardcode
+Nine semantic tokens live in `internal/tui/styles.go`. All are `lipgloss.AdaptiveColor` typed as `lipgloss.TerminalColor`.
 
-## Accessibility
+| Token | Role |
+|-------|------|
+| `Leaf` | primary brand / success accent |
+| `Bark` | labels, headings, table headers |
+| `Stone` | muted text, borders, tree branches |
+| `Water` | informational accents, review panels |
+| `Moss` | success panels and checkmarks |
+| `Ember` | errors, fatal panels |
+| `Amber` | warnings, removal panels |
+| `Sand` | option text, file leaves |
+| `Petal` | selection markers, prompt cursors |
 
-- All interactive elements must be keyboard-navigable
-- Images need `alt` text — decorative images get `alt=""`
-- Form inputs need associated labels
-- Color must not be the only way to convey information
-- Test with screen reader when adding new interactive patterns
+**Never** write `lipgloss.Color("#...")` in new code. If a one-off adaptive value is unavoidable (e.g., a theme override), inline it as `lipgloss.AdaptiveColor{Dark: "#...", Light: "#..."}` — never hardcode a single hex.
 
-## Responsive
+## 3. Glyph Set
 
-- Mobile-first approach — start with the smallest breakpoint
-- Test at standard breakpoints: 375px, 768px, 1024px, 1440px
-- No horizontal scrolling at any breakpoint
+Six glyphs, defined as constants in `styles.go`:
+
+`GlyphCheck` `✓` · `GlyphCross` `✗` · `GlyphWarn` `⚠` · `GlyphArrow` `→` · `GlyphDash` `—` · `GlyphDot` `·`
+
+No emoji. No additional Unicode decorations. If you need a new glyph, justify it in the PR.
+
+## 4. Panel Vocabulary
+
+| Helper | When |
+|--------|------|
+| `Success` / `SuccessPanel` | terminal success message at end of a command |
+| `ErrorPanel` | recoverable error — command returns `nil` and user can retry |
+| `FatalPanel(title, detail, hint)` | unrecoverable error — calls `os.Exit(1)`; use for missing config, catalog corruption, argument validation |
+| `WarningPanel` / `Warning` | non-blocking issue (skipped file, ignored flag) |
+| `InfoPanel` / `Info` | contextual information, not a result |
+| `EmptyPanel` | "no items" state in list/catalog views |
+| `TitledPanel(title, content, color)` | review/summary block before a confirm prompt |
+
+## 5. Spacing Contract
+
+- **Display helpers own their top margin.** Every `Success`, `Error`, `Heading`, `*Panel`, `TitledPanel` starts with `\n`.
+- **Commands own exactly one trailing `tui.Blank()`** on success paths — after `tui.Success(...)` and before `return nil`.
+- **Do not add `tui.Blank()` between a `TitledPanel` and an `AskConfirm`.** The panel already owns its gap and Huh owns its own.
+- **Cancelled paths** (`!confirmed` → `return nil`) and **guard paths** (`ErrorPanel` + `return nil`) do not emit a trailing `Blank` — the rendered panel already closes the output.
+
+## 6. Canonical Command Flow
+
+```
+Heading → Input (AskText / AskSelect / PickItems)
+       → Review (TitledPanel)
+       → Confirm (AskConfirm)
+       → Execute (spinner)
+       → Results (showWriteResults / trees)
+       → Success (+ optional Hint)
+       → Blank
+```
+
+Every mutating command (`init`, `add`, `remove`, `update`) follows this shape. Read-only commands (`list`, `catalog`) skip Confirm/Execute.
+
+## 7. Error Format
+
+- **Fatal (exit 1):** `tui.FatalPanel(title, detail, hint)` — title is a short noun phrase, detail explains the cause, hint is one actionable line (usually a command to run).
+- **Recoverable:** `tui.ErrorPanel(msg)` followed by `return nil` — the command exits cleanly, the user can fix and retry.
+- **Never** use `fmt.Println`, `fmt.Errorf`, or bare `log.Fatal` for user-facing errors. Never surface raw Go error strings without a panel.
+
+## 8. Anti-Patterns
+
+- Hardcoded `lipgloss.Color("#hex")` — breaks light terminals.
+- Emoji in any output — breaks terminal fidelity and tone.
+- Double blanks between elements (`Blank()` immediately after a `Panel` that already owns its margin).
+- `os.Exit(1)` without a preceding `FatalPanel` — the user sees no explanation.
+- Raw `error.Error()` strings printed to stdout — wrap them in a panel with a hint.
+- Inventing new panel shapes or colors instead of reusing the eight semantic helpers above.

--- a/catalog/skills/design-guide/meta.yaml
+++ b/catalog/skills/design-guide/meta.yaml
@@ -1,12 +1,10 @@
 name: design-guide
-description: UI/UX design patterns, component conventions, accessibility rules
-agents: [frontend, fullstack]
+description: Bonsai CLI design system — palette, spacing, panels, errors, command flow
+agents: [tech-lead, backend, frontend, fullstack]
 triggers:
   scenarios:
-    - Building or reviewing UI components, layouts, or visual styling
-    - Working with CSS, design tokens, or component libraries
+    - Modifying TUI styles, panels, display helpers, or color definitions
+    - Adding or changing CLI output formatting in any command
   paths:
-    - "**/components/**"
-    - "**/*.css"
-    - "**/*.scss"
-    - "**/styles/**"
+    - "internal/tui/**"
+    - "cmd/*.go"

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -92,8 +92,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	agentDef := cat.GetAgent(agentType)
 	if agentDef == nil {
-		tui.Error("Unknown agent type: " + agentType)
-		os.Exit(1)
+		tui.FatalPanel("Unknown agent type", agentType+" is not in the catalog.", "Run: bonsai catalog")
 	}
 
 	// 2. Workspace directory
@@ -120,8 +119,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	if existingWorkspaces[workspace] {
-		tui.ErrorPanel("Workspace " + workspace + " is already in use.")
-		os.Exit(1)
+		tui.FatalPanel("Workspace conflict", workspace+" is already in use by another agent.", "Choose a different directory.")
 	}
 
 	// 3. Pick components
@@ -181,7 +179,6 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	)
 
 	tui.TitledPanel("Review", summary, tui.Water)
-	tui.Blank()
 
 	confirmed, err := tui.AskConfirm("Generate files?", true)
 	if err != nil || !confirmed {
@@ -228,6 +225,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	showWriteResults(&wr, workspace)
 
 	tui.Success(fmt.Sprintf("Added %s at %s", agentDef.DisplayName, workspace))
+	tui.Blank()
 	return nil
 }
 
@@ -235,8 +233,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 func runAddItems(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog.Catalog, agentType string, installed *config.InstalledAgent) error {
 	agentDef := cat.GetAgent(agentType)
 	if agentDef == nil {
-		tui.Error("Unknown agent type: " + agentType)
-		os.Exit(1)
+		tui.FatalPanel("Unknown agent type", agentType+" is not in the catalog.", "Run: bonsai catalog")
 	}
 
 	tui.Info(fmt.Sprintf("%s is already installed at %s — showing uninstalled abilities.", agentDef.DisplayName, installed.Workspace))
@@ -353,7 +350,6 @@ func runAddItems(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog
 	)
 
 	tui.TitledPanel("Adding", summary, tui.Water)
-	tui.Blank()
 
 	confirmed, err := tui.AskConfirm("Generate files?", true)
 	if err != nil || !confirmed {
@@ -397,5 +393,6 @@ func runAddItems(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog
 	showWriteResults(&wr, installed.Workspace)
 
 	tui.Success(fmt.Sprintf("Added %d abilities to %s", totalSelected, agentDef.DisplayName))
+	tui.Blank()
 	return nil
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,7 +36,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	cat := loadCatalog()
 
-	tui.Banner()
+	tui.Banner(Version)
 	tui.Heading("Initialize Project")
 
 	projectName, err := tui.AskText("Project name:", "", true)
@@ -53,8 +53,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 	docsPath = strings.TrimSpace(docsPath)
 	if docsPath == "" || docsPath == "/" {
-		tui.ErrorPanel("Station directory cannot be empty or root. Use a subdirectory like station/.")
-		os.Exit(1)
+		tui.FatalPanel("Invalid station directory", "Cannot be empty or root.", "Use a subdirectory like: station/")
 	}
 	if !strings.HasSuffix(docsPath, "/") {
 		docsPath += "/"
@@ -86,8 +85,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	const techLeadType = "tech-lead"
 	agentDef := cat.GetAgent(techLeadType)
 	if agentDef == nil {
-		tui.ErrorPanel("Tech Lead agent not found in catalog.")
-		os.Exit(1)
+		tui.FatalPanel("Tech Lead agent not found", "The built-in catalog is missing the tech-lead agent.", "This is a bug — please report it.")
 	}
 
 	workspace := docsPath
@@ -145,7 +143,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 		describer,
 	)
 	tui.TitledPanel("Review", summary, tui.Water)
-	tui.Blank()
 
 	confirmed, err := tui.AskConfirm("Generate project?", true)
 	if err != nil || !confirmed {

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -51,8 +51,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	agent, exists := cfg.Agents[agentName]
 	if !exists {
-		tui.Error("Agent " + agentName + " is not installed.")
-		os.Exit(1)
+		tui.FatalPanel("Agent not installed", agentName+" is not in the current project.", "Run: bonsai list")
 	}
 
 	// Prevent removing tech-lead while other agents depend on it
@@ -81,7 +80,6 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	)
 
 	tui.TitledPanel("Remove", preview, tui.Amber)
-	tui.Blank()
 
 	confirmed, err := tui.AskConfirm("Remove "+agentDisplayName+"?", false)
 	if err != nil || !confirmed {
@@ -132,6 +130,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	tui.Success("Removed " + agentDisplayName)
+	tui.Blank()
 	return nil
 }
 
@@ -289,7 +288,6 @@ func runRemoveItem(name string, it itemType) error {
 		{"From", strings.Join(fromLabels, ", ")},
 	})
 	tui.TitledPanel("Remove Item", content, tui.Amber)
-	tui.Blank()
 
 	confirmed, err := tui.AskConfirm("Remove "+displayName+"?", false)
 	if err != nil || !confirmed {
@@ -358,6 +356,7 @@ func runRemoveItem(name string, it itemType) error {
 	}
 
 	tui.Success("Removed " + displayName)
+	tui.Blank()
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,27 +27,35 @@ var guideMarkdown string
 var rootCmd = &cobra.Command{
 	Use:   "bonsai",
 	Short: "Scaffold Claude Code agent workspaces for your project.",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if noColor, _ := cmd.Flags().GetBool("no-color"); noColor {
+			tui.DisableColor()
+		}
+	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
 }
 
 func loadCatalog() *catalog.Catalog {
 	cat, err := catalog.New(catalogFS)
 	if err != nil {
-		tui.ErrorPanel("Failed to load catalog: " + err.Error())
-		os.Exit(1)
+		tui.FatalPanel("Failed to load catalog", err.Error(), "This is a bug — please report it.")
 	}
 	return cat
 }
 
 func requireConfig(configPath string) (*config.ProjectConfig, error) {
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		tui.ErrorPanel("No " + configFile + " found.\nRun bonsai init first.")
-		os.Exit(1)
+		tui.FatalPanel("No "+configFile+" found", "This command requires an initialized project.", "Run: bonsai init")
 	}
 	return config.Load(configPath)
 }
 
 // SetVersion sets the version string on the root command.
 func SetVersion(v string) {
+	Version = v
 	rootCmd.Version = v
 }
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -186,5 +186,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	} else {
 		tui.Success("Update complete — workspace synced")
 	}
+	tui.Blank()
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/huh/spinner v0.0.0-20260223110133-9dc45e34a40b
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
+	github.com/mattn/go-isatty v0.0.20
+	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -40,7 +42,6 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
@@ -48,7 +49,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/tui/prompts.go
+++ b/internal/tui/prompts.go
@@ -12,7 +12,9 @@ import (
 func BonsaiTheme() *huh.Theme {
 	t := huh.ThemeBase()
 
-	t.Focused.Base = t.Focused.Base.BorderForeground(lipgloss.Color("#3A5F4A"))
+	t.Focused.Base = t.Focused.Base.BorderForeground(
+		lipgloss.AdaptiveColor{Dark: "#3A5F4A", Light: "#5A7F6A"},
+	)
 	t.Focused.Card = t.Focused.Base
 	t.Focused.Title = t.Focused.Title.Foreground(Bark).Bold(true)
 	t.Focused.NoteTitle = t.Focused.NoteTitle.Foreground(Bark).Bold(true).MarginBottom(1)
@@ -29,7 +31,9 @@ func BonsaiTheme() *huh.Theme {
 	t.Focused.UnselectedPrefix = lipgloss.NewStyle().Foreground(Stone).SetString("· ")
 	t.Focused.UnselectedOption = t.Focused.UnselectedOption.Foreground(Sand)
 	t.Focused.FocusedButton = t.Focused.FocusedButton.Foreground(lipgloss.Color("#FFFFFF")).Background(Leaf)
-	t.Focused.BlurredButton = t.Focused.BlurredButton.Foreground(Sand).Background(lipgloss.Color("#2D2D3D"))
+	t.Focused.BlurredButton = t.Focused.BlurredButton.Foreground(Sand).Background(
+		lipgloss.AdaptiveColor{Dark: "#2D2D3D", Light: "#E5E7EB"},
+	)
 	t.Focused.Next = t.Focused.FocusedButton
 
 	t.Focused.TextInput.Cursor = t.Focused.TextInput.Cursor.Foreground(Leaf)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -2,24 +2,40 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
+	"github.com/mattn/go-isatty"
+	"github.com/muesli/termenv"
 )
+
+// ─── Color Profile ────────────────────────────────────────────────────────
+
+func init() {
+	if !isatty.IsTerminal(os.Stdout.Fd()) || termenv.EnvNoColor() {
+		DisableColor()
+	}
+}
+
+// DisableColor forces all output to plain text (no ANSI escapes).
+func DisableColor() {
+	lipgloss.SetColorProfile(termenv.Ascii)
+}
 
 // ─── Zen Garden Palette ───────────────────────────────────────────────────
 
 var (
-	Leaf  = lipgloss.Color("#4A9E6F")
-	Bark  = lipgloss.Color("#D4A76A")
-	Stone = lipgloss.Color("#6B7280")
-	Water = lipgloss.Color("#7EC8E3")
-	Moss  = lipgloss.Color("#73D677")
-	Ember = lipgloss.Color("#E36F6F")
-	Amber = lipgloss.Color("#E3C16F")
-	Sand  = lipgloss.Color("#C4B7A6")
-	Petal = lipgloss.Color("#D4A0C0")
+	Leaf  lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#4A9E6F", Light: "#2D7A4B"}
+	Bark  lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#D4A76A", Light: "#8B6914"}
+	Stone lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#6B7280", Light: "#4B5563"}
+	Water lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#7EC8E3", Light: "#1A7FA0"}
+	Moss  lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#73D677", Light: "#2D8A3E"}
+	Ember lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#E36F6F", Light: "#C53030"}
+	Amber lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#E3C16F", Light: "#B7791F"}
+	Sand  lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#C4B7A6", Light: "#6B5E4F"}
+	Petal lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#D4A0C0", Light: "#9B4D8A"}
 )
 
 // ─── Styles ───────────────────────────────────────────────────────────────
@@ -74,9 +90,13 @@ const (
 // ─── Banner ───────────────────────────────────────────────────────────────
 
 // Banner prints the Bonsai welcome banner.
-func Banner() {
+func Banner(version string) {
 	title := lipgloss.NewStyle().Bold(true).Foreground(Leaf).Render("B O N S A I")
-	sub := StyleMuted.Render("agent scaffolder")
+	subtitle := "agent scaffolder"
+	if version != "" && version != "dev" {
+		subtitle += " " + GlyphDot + " v" + version
+	}
+	sub := StyleMuted.Render(subtitle)
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
@@ -148,6 +168,19 @@ func SuccessPanel(content, title string) {
 // ErrorPanel renders a red-bordered panel.
 func ErrorPanel(msg string) {
 	fmt.Println("\n" + indent(PanelError.Render(msg), 2))
+}
+
+// FatalPanel renders a structured error and exits. title: what happened. detail: why. hint: how to fix.
+func FatalPanel(title, detail, hint string) {
+	content := StyleError.Bold(true).Render(title)
+	if detail != "" {
+		content += "\n" + detail
+	}
+	if hint != "" {
+		content += "\n" + StyleMuted.Render(hint)
+	}
+	fmt.Println("\n" + indent(PanelError.Render(content), 2))
+	os.Exit(1)
 }
 
 // WarningPanel renders a yellow-bordered panel.


### PR DESCRIPTION
## Summary
UI/UX Phase 1 — adaptive palette, NO_COLOR support, version banner, FatalPanel, consistent spacing, rewritten design-guide skill. Zero visual change on dark terminals.

Plan: station/Playbook/Plans/Active/11-uiux-overhaul-phase1.md

## Changes
- `internal/tui/styles.go` — AdaptiveColor palette, `init()` TTY/NO_COLOR gate, `DisableColor()`, `FatalPanel`, `Banner(version)`
- `internal/tui/prompts.go` — two hardcoded hex colors replaced with inline AdaptiveColor
- `cmd/root.go` — `--no-color` flag, `PersistentPreRun`, `SetVersion` updates package-level `Version`, migrated 2 FatalPanel sites
- `cmd/init.go` — `Banner(Version)`, migrated 2 FatalPanel sites, removed 1 redundant Blank
- `cmd/add.go` — migrated 3 FatalPanel sites, removed 2 Blanks, added 2 trailing Blanks
- `cmd/remove.go` — migrated 1 FatalPanel site, removed 2 Blanks, added 2 trailing Blanks
- `cmd/update.go` — added 1 trailing Blank
- `catalog/skills/design-guide/meta.yaml` — re-scoped to Bonsai TUI/CLI
- `catalog/skills/design-guide/design-guide.md` — rewritten with Bonsai CLI design rules
- `go.mod`, `go.sum` — `termenv` and `go-isatty` promoted to direct

## Verification
- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `go test ./...` — passes
- [x] `gofmt -s -l .` — clean
- [x] `go mod tidy` — only termenv + go-isatty promoted
- [x] `NO_COLOR=1`, `--no-color`, `TERM=dumb`, piped — all emit zero ANSI escapes