### PR TITLE
docs: command reference pages (Plan 10 Phase B2)

### DIFF
--- a/website/src/content/docs/commands/add.mdx
+++ b/website/src/content/docs/commands/add.mdx
@@ -1,8 +1,140 @@
 ---
 title: bonsai add
-description: bonsai add — add agents or abilities
+description: Add a new agent to the project or add abilities to an existing agent.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Steps, FileTree, Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">This page is under construction.</Aside>
+## Synopsis
+
+```
+bonsai add
+```
+
+## Description
+
+`bonsai add` operates in two modes depending on the state of your project:
+
+1. **New agent mode** -- if the selected agent type is not yet installed, Bonsai walks you through the full setup: workspace directory, skills, workflows, protocols, sensors, and routines. It then generates the complete agent workspace.
+
+2. **Add abilities mode** -- if the selected agent type is already installed, Bonsai detects this and pivots to showing only uninstalled abilities. You pick which new items to add, and Bonsai appends them to the existing agent configuration and generates the new files.
+
+A `.bonsai.yaml` must exist before running this command. If it does not, Bonsai exits with an error directing you to run [`bonsai init`](/Bonsai/commands/init/) first.
+
+<Aside>
+The Tech Lead agent must be installed before you can add any other agent type. If Tech Lead is not present, Bonsai blocks the operation (except when adding Tech Lead itself via `bonsai add`).
+</Aside>
+
+## Interactive Flow: New Agent
+
+<Steps>
+
+1. **Agent type picker** -- select from available agent types (Tech Lead, Backend, Frontend, Fullstack, DevOps, Security). Each option shows the agent's description.
+
+2. **Workspace directory** -- text input. Where this agent's files will live (e.g. `backend/`). Defaults to the agent type name with a trailing slash. Tech Lead always uses the station directory. Bonsai blocks duplicate workspaces.
+
+3. **Skills picker** -- multi-select. Shows skills compatible with the selected agent type. Agent defaults are pre-selected. Required items are locked.
+
+4. **Workflows picker** -- multi-select. Shows compatible workflows with defaults pre-selected.
+
+5. **Protocols picker** -- multi-select. Shows compatible protocols with defaults pre-selected.
+
+6. **Sensors picker** -- multi-select. Shows compatible sensors (excluding `routine-check`, which is auto-managed). Defaults pre-selected.
+
+7. **Routines picker** -- multi-select. Shows compatible routines with execution frequency displayed. Defaults pre-selected.
+
+8. **Review summary** -- formatted tree of all selected abilities, grouped by category.
+
+9. **Confirm** -- yes/no. Declining exits without generating files.
+
+</Steps>
+
+## Interactive Flow: Add Abilities to Existing Agent
+
+When you select an agent type that is already installed, the flow changes:
+
+<Steps>
+
+1. **Agent type picker** -- same as above. Bonsai detects the agent is already installed and displays a notice.
+
+2. **Abilities pickers** -- Bonsai filters each category (skills, workflows, protocols, sensors, routines) to show only items that are **not yet installed**. Nothing is pre-selected since these are additions. If all available abilities are already installed, Bonsai reports this and exits.
+
+3. **Review summary** -- shows only the new abilities being added.
+
+4. **Confirm** -- yes/no. Declining exits without changes.
+
+</Steps>
+
+<Aside type="tip">
+If any routines are selected (in either mode), the `routine-check` sensor is automatically added to the agent's sensor list. It is also automatically removed if all routines are later removed.
+</Aside>
+
+## Flags
+
+This command has no flags.
+
+## Examples
+
+**Add a backend agent:**
+
+```bash
+bonsai add
+# Select "Backend" from the agent type picker
+# Enter workspace directory: backend/
+# Pick skills, workflows, protocols, sensors
+# Review and confirm
+```
+
+Generates the full `backend/` workspace with identity, protocols, skills, and sensors.
+
+**Add skills to an existing agent:**
+
+```bash
+bonsai add
+# Select "Backend" (already installed)
+# → "Backend is already installed at backend/ — showing uninstalled abilities."
+# Pick new skills/workflows to add
+# Review and confirm
+```
+
+Only new abilities are shown in the pickers. Selected items are appended to the existing configuration.
+
+**All abilities already installed:**
+
+```bash
+bonsai add
+# Select "Backend" (already installed, everything added)
+# → "All available abilities are already installed."
+```
+
+## What Gets Generated
+
+When adding a new agent (e.g. Backend at `backend/`):
+
+<FileTree>
+
+- backend/
+  - CLAUDE.md -- agent navigation (cross-linked)
+  - .claude/
+    - rules/ -- path-scoped rule files for skills with triggers
+    - skills/ -- workflow slash-command skill files
+  - agent/
+    - Core/
+      - identity.md
+      - memory.md
+      - self-awareness.md
+    - Protocols/ -- security, scope, startup, memory
+    - Workflows/ -- code-review, session-logging, etc.
+    - Skills/ -- coding-standards, etc.
+    - Sensors/ -- context-guard.sh, scope-guard-files.sh, etc.
+
+</FileTree>
+
+The root `.claude/settings.json` is also updated to include hook entries for the new agent's sensors.
+
+## See Also
+
+- [`bonsai init`](/Bonsai/commands/init/) -- must be run before add
+- [`bonsai remove`](/Bonsai/commands/remove/) -- remove agents or individual abilities
+- [`bonsai list`](/Bonsai/commands/list/) -- see what is currently installed
+- [`bonsai catalog`](/Bonsai/commands/catalog/) -- browse all available abilities before adding

--- a/website/src/content/docs/commands/catalog.mdx
+++ b/website/src/content/docs/commands/catalog.mdx
@@ -1,8 +1,76 @@
 ---
 title: bonsai catalog
-description: bonsai catalog — browse available abilities
+description: Browse all available abilities in the embedded catalog — agents, skills, workflows, protocols, sensors, routines, and scaffolding.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">This page is under construction.</Aside>
+## Synopsis
+
+```
+bonsai catalog [--agent <type>]
+```
+
+## Description
+
+`bonsai catalog` displays the full contents of Bonsai's embedded catalog in formatted tables. The catalog is bundled inside the binary and includes all available agent types, skills, workflows, protocols, sensors, routines, and scaffolding items.
+
+Each section is printed as a table showing names, descriptions, and relevant metadata. For example, sensors show their hook event and matcher, routines show their frequency, and all ability types show which agent types they are compatible with and whether they are required.
+
+Use the `--agent` flag to filter the catalog to items compatible with a specific agent type. Agent types are always shown unfiltered.
+
+This is a read-only command with no interactive prompts and no side effects.
+
+## Flags
+
+| Flag | Short | Type | Default | Description |
+|:-----|:------|:-----|:--------|:------------|
+| `--agent` | `-a` | string | `""` | Filter to items compatible with a specific agent type |
+
+## Examples
+
+**Browse the full catalog:**
+
+```bash
+bonsai catalog
+```
+
+Displays all sections: Agents, Skills, Workflows, Protocols, Sensors, Routines, and Scaffolding.
+
+**Filter to a specific agent type:**
+
+```bash
+bonsai catalog --agent backend
+```
+
+Shows all agent types (unfiltered), then shows only skills, workflows, protocols, sensors, and routines that are compatible with the `backend` agent type. Each filtered section includes a note like `(for backend)`.
+
+**Using the short flag:**
+
+```bash
+bonsai catalog -a security
+```
+
+<Aside type="tip">
+The catalog shows what is **available**, not what is installed. Use [`bonsai list`](/Bonsai/commands/list/) to see what is currently installed in your project.
+</Aside>
+
+### Catalog Sections
+
+The output includes these tables:
+
+| Section | Columns |
+|:--------|:--------|
+| **Agents** | Name, Description |
+| **Skills** | Name, Description, Agents, Required |
+| **Workflows** | Name, Description, Agents, Required |
+| **Protocols** | Name, Description, Agents, Required |
+| **Sensors** | Name, Description, Event, Agents, Required |
+| **Routines** | Name, Description, Frequency, Agents, Required |
+| **Scaffolding** | Name, Description, Required, If Removed |
+
+## See Also
+
+- [`bonsai add`](/Bonsai/commands/add/) -- install abilities from the catalog into your project
+- [`bonsai list`](/Bonsai/commands/list/) -- see what is currently installed
+- [Catalog Overview](/Bonsai/catalog/overview/) -- browse the catalog in the documentation

--- a/website/src/content/docs/commands/guide.mdx
+++ b/website/src/content/docs/commands/guide.mdx
@@ -1,8 +1,59 @@
 ---
 title: bonsai guide
-description: bonsai guide — view the custom files guide
+description: View the custom files guide in your terminal — learn how to create custom skills, workflows, protocols, sensors, and routines.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">This page is under construction.</Aside>
+## Synopsis
+
+```
+bonsai guide
+```
+
+## Description
+
+`bonsai guide` renders the custom files guide directly in your terminal using [Glamour](https://github.com/charmbracelet/glamour) markdown rendering. The guide explains how to create custom skills, workflows, protocols, sensors, and routines that Bonsai can detect and track via [`bonsai update`](/Bonsai/commands/update/).
+
+The guide content is embedded in the Bonsai binary alongside the catalog. It covers:
+
+- The BONSAI frontmatter format required for custom files
+- File naming conventions (kebab-case, correct extensions)
+- Directory placement for each ability type
+- Required and optional frontmatter fields per type
+- Examples of custom skills, sensors, and routines
+
+This is a read-only command with no interactive prompts and no side effects. If the guide content contains YAML frontmatter, it is automatically stripped before rendering.
+
+<Aside type="tip">
+The guide output adapts to your terminal's color scheme. Glamour auto-detects whether you are using a light or dark terminal theme and renders accordingly.
+</Aside>
+
+## Flags
+
+This command has no flags.
+
+## Examples
+
+**View the guide:**
+
+```bash
+bonsai guide
+```
+
+Renders the full custom files guide with styled headings, code blocks, and tables in your terminal. The output is word-wrapped to 100 columns for readability.
+
+**Pipe to a pager for long output:**
+
+```bash
+bonsai guide | less -R
+```
+
+The `-R` flag preserves ANSI color codes when piping through `less`.
+
+## See Also
+
+- [`bonsai update`](/Bonsai/commands/update/) -- detect and track custom files after creating them
+- [Creating Custom Skills](/Bonsai/guides/creating-custom-skills/) -- detailed web guide for custom skills
+- [Creating Custom Sensors](/Bonsai/guides/creating-custom-sensors/) -- detailed web guide for custom sensors
+- [Creating Custom Routines](/Bonsai/guides/creating-custom-routines/) -- detailed web guide for custom routines

--- a/website/src/content/docs/commands/init.mdx
+++ b/website/src/content/docs/commands/init.mdx
@@ -1,8 +1,130 @@
 ---
 title: bonsai init
-description: bonsai init — create a new agent workspace
+description: Initialize Bonsai in the current project — set up project config, Tech Lead agent, and scaffolding.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Steps, FileTree, Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">This page is under construction.</Aside>
+## Synopsis
+
+```
+bonsai init
+```
+
+## Description
+
+`bonsai init` bootstraps Bonsai in your current project directory. It creates the project configuration file (`.bonsai.yaml`), installs the Tech Lead agent as the primary orchestrator, and generates project scaffolding (status tracker, roadmap, plans, logs).
+
+This is the first command you run in any new project. It walks you through an interactive setup that configures the project name, station directory, scaffolding selection, and Tech Lead abilities. After init completes, your project has a fully wired agent workspace ready for Claude Code sessions.
+
+If a `.bonsai.yaml` file already exists in the current directory, init exits with a warning and makes no changes. To add more agents after initialization, use [`bonsai add`](/Bonsai/commands/add/).
+
+## Interactive Flow
+
+<Steps>
+
+1. **Project name** -- text input, required. This is stored in `.bonsai.yaml` and used in generated file headings and navigation.
+
+2. **Description** -- text input, optional. A short description of the project.
+
+3. **Station directory** -- text input, defaults to `station/`. This is the root directory for the Tech Lead workspace and all project scaffolding. Must be a subdirectory (not empty or `/`).
+
+4. **Scaffolding picker** -- multi-select. Choose which project infrastructure to generate. Some items are required and cannot be unchecked:
+   - **Index** (required) -- project snapshot overview
+   - **Playbook** (required) -- status, roadmap, backlog, plans, standards
+   - **Logs** (required) -- field notes, decisions, routine log
+   - **Reports** (optional) -- completion report templates and staging area
+
+5. **Skills picker** -- multi-select. Choose skills for the Tech Lead agent. Agent defaults are pre-selected. Required items are locked.
+
+6. **Workflows picker** -- multi-select. Choose workflows for the Tech Lead. Includes procedures like planning, code review, security audit, and session logging.
+
+7. **Protocols picker** -- multi-select. Choose protocols for the Tech Lead. Protocols are hard rules (security, scope, startup sequence).
+
+8. **Sensors picker** -- multi-select. Choose sensors (automated hook scripts). The `routine-check` sensor is managed automatically and does not appear in the picker.
+
+9. **Routines picker** -- multi-select. Choose periodic maintenance routines (backlog hygiene, dependency audit, etc.). Each shows its execution frequency.
+
+10. **Review summary** -- a formatted tree showing all selected abilities organized by category. Inspect your choices before generating.
+
+11. **Confirm** -- yes/no prompt. Selecting "no" exits without generating any files.
+
+</Steps>
+
+<Aside type="tip">
+If any routines are selected, the `routine-check` sensor is automatically added to the Tech Lead's sensor list. You never need to install or manage it manually.
+</Aside>
+
+## Flags
+
+This command has no flags.
+
+## Examples
+
+**Basic initialization:**
+
+```bash
+cd my-project
+bonsai init
+```
+
+Walks through the full interactive flow and generates the workspace.
+
+**Init in a project that already has Bonsai:**
+
+```bash
+bonsai init
+# ⚠ .bonsai.yaml already exists. Skipping init.
+```
+
+If `.bonsai.yaml` is already present, init exits immediately with no changes.
+
+## What Gets Generated
+
+After completing `bonsai init` with default settings:
+
+<FileTree>
+
+- my-project/
+  - .bonsai.yaml -- project config (agents, scaffolding, docs path)
+  - .bonsai-lock.yaml -- file tracking (content hashes for conflict detection)
+  - .claude/
+    - settings.json -- auto-wired sensor hooks
+  - station/
+    - CLAUDE.md -- Tech Lead navigation (cross-linked)
+    - INDEX.md -- project snapshot
+    - agent/
+      - Core/
+        - identity.md
+        - memory.md
+        - self-awareness.md
+        - routines.md -- routine dashboard (if routines selected)
+      - Protocols/ -- security, scope, startup, memory
+      - Workflows/ -- planning, code-review, session-logging, etc.
+      - Skills/ -- planning-template, review-checklist, etc.
+      - Sensors/ -- context-guard.sh, scope-guard-files.sh, etc.
+      - Routines/ -- backlog-hygiene.md, dependency-audit.md, etc.
+    - Playbook/
+      - Status.md
+      - Roadmap.md
+      - Backlog.md
+      - Standards/
+        - SecurityStandards.md
+      - Plans/
+        - Active/
+    - Logs/
+      - FieldNotes.md
+      - KeyDecisionLog.md
+      - RoutineLog.md
+    - Reports/ -- (if selected)
+      - report-template.md
+      - Pending/
+
+</FileTree>
+
+## See Also
+
+- [`bonsai add`](/Bonsai/commands/add/) -- add code agents or abilities after initialization
+- [`bonsai list`](/Bonsai/commands/list/) -- see what is currently installed
+- [How Bonsai Works](/Bonsai/concepts/how-bonsai-works/) -- the mental model behind stations, agents, and the instruction stack
+- [Workspaces](/Bonsai/concepts/workspaces/) -- how agent workspaces are structured

--- a/website/src/content/docs/commands/list.mdx
+++ b/website/src/content/docs/commands/list.mdx
@@ -1,8 +1,84 @@
 ---
 title: bonsai list
-description: bonsai list — show installed components
+description: Display all installed agents and their abilities — skills, workflows, protocols, sensors, and routines.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">This page is under construction.</Aside>
+## Synopsis
+
+```
+bonsai list
+```
+
+## Description
+
+`bonsai list` displays the current state of your Bonsai project. It reads `.bonsai.yaml` and shows:
+
+- The **project name** as a heading
+- **Scaffolding** items that were selected during init (Index, Playbook, Logs, Reports)
+- A **card for each installed agent** showing its workspace directory and all installed abilities grouped by category
+
+This is a read-only command with no interactive prompts and no side effects. It does not modify any files.
+
+If no agents are installed, Bonsai displays an empty state message suggesting you run `bonsai add`.
+
+## Flags
+
+This command has no flags.
+
+## Examples
+
+**List installed agents:**
+
+```bash
+bonsai list
+```
+
+Example output:
+
+```
+  My Project
+
+  Scaffolding: Index, Playbook, Logs, Reports
+
+  ┌ Tech Lead ─────────────────────────────────────────┐
+  │ Workspace   station/                                │
+  │ Skills      Planning Template, Review Checklist,    │
+  │             Issue Classification, PR Creation       │
+  │ Workflows   Code Review, Planning, PR Review,      │
+  │             Security Audit, Session Logging, ...    │
+  │ Protocols   Memory, Scope Boundaries, Security,    │
+  │             Session Start                           │
+  │ Sensors     Context Guard, Scope Guard Files,      │
+  │             Session Context, Status Bar, ...        │
+  │ Routines    Backlog Hygiene, Dependency Audit, ...  │
+  └────────────────────────────────────────────────────-┘
+
+  ┌ Backend ───────────────────────────────────────────-┐
+  │ Workspace   backend/                                │
+  │ Skills      Coding Standards                        │
+  │ Workflows   Code Review, Session Logging            │
+  │ Protocols   Memory, Scope Boundaries, Security,    │
+  │             Session Start                           │
+  │ Sensors     Context Guard, Scope Guard Files,      │
+  │             Session Context, Status Bar             │
+  └────────────────────────────────────────────────────-┘
+```
+
+<Aside type="tip">
+All ability names shown in the output use display names (title-cased, human-readable), not the kebab-case machine identifiers used in config files. For example, `scope-guard-files` appears as "Scope Guard Files".
+</Aside>
+
+**Empty project:**
+
+```bash
+bonsai list
+# No agents installed.
+# Run bonsai add to get started.
+```
+
+## See Also
+
+- [`bonsai catalog`](/Bonsai/commands/catalog/) -- browse all available abilities (not just installed ones)
+- [`bonsai add`](/Bonsai/commands/add/) -- add agents or abilities to the project

--- a/website/src/content/docs/commands/remove.mdx
+++ b/website/src/content/docs/commands/remove.mdx
@@ -1,8 +1,118 @@
 ---
 title: bonsai remove
-description: bonsai remove — remove agents or abilities
+description: Remove an installed agent or a specific ability (skill, workflow, protocol, sensor, routine) from the project.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Steps, Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">This page is under construction.</Aside>
+## Synopsis
+
+```
+bonsai remove <agent>
+bonsai remove skill <name>
+bonsai remove workflow <name>
+bonsai remove protocol <name>
+bonsai remove sensor <name>
+bonsai remove routine <name>
+```
+
+## Description
+
+`bonsai remove` operates in two modes:
+
+**Agent removal** -- pass an agent type name (e.g. `backend`) to remove the entire agent from the project. Bonsai shows a preview of everything that will be removed and asks for confirmation. Optionally, the `--delete-files` flag also deletes the generated agent directory and CLAUDE.md from disk.
+
+**Ability removal** -- use a subcommand (`skill`, `workflow`, `protocol`, `sensor`, `routine`) followed by the item name to remove a single ability. Bonsai finds which agents have the item installed. If multiple agents have it, you are asked which agent to remove it from (or all). The generated file is deleted from disk and untracked from the lock file.
+
+<Aside type="caution">
+You cannot remove the Tech Lead while other agents are still installed. Remove all other agents first, then remove Tech Lead.
+</Aside>
+
+### Safety Checks
+
+- **Required items cannot be removed.** If an ability is marked as required for an agent type, Bonsai blocks removal and displays a warning.
+- **`routine-check` sensor is auto-managed.** You cannot remove it directly. It is automatically removed when the last routine is removed from an agent, and automatically added when the first routine is added.
+- **Agent removal blocks Tech Lead while dependents exist.** The Tech Lead is the orchestration hub; removing it while code agents are installed would break the project structure.
+
+## Interactive Flow: Agent Removal
+
+<Steps>
+
+1. **Preview** -- Bonsai displays a formatted tree of the agent and all its installed abilities (skills, workflows, protocols, sensors, routines).
+
+2. **Confirm** -- yes/no prompt (defaults to "no" for safety). Declining exits without changes.
+
+3. **File deletion** -- if `--delete-files` was passed, Bonsai deletes the agent's `agent/` directory, `CLAUDE.md`, and `.claude/` directory from the workspace.
+
+</Steps>
+
+## Interactive Flow: Ability Removal
+
+<Steps>
+
+1. **Agent selection** -- if the item is installed in multiple agents, Bonsai presents a picker: choose a specific agent or "All agents".
+
+2. **Required check** -- Bonsai checks if the item is required for each target agent. Required items are skipped with a warning.
+
+3. **Preview** -- a summary card showing the item name, type, and which agent(s) it will be removed from.
+
+4. **Confirm** -- yes/no prompt (defaults to "no"). Declining exits without changes.
+
+</Steps>
+
+After confirmation, Bonsai removes the item from the config, deletes the generated file, untracks it from the lock file, regenerates the workspace `CLAUDE.md` navigation, and updates `.claude/settings.json`.
+
+<Aside type="tip">
+When removing a routine, Bonsai also updates the routine dashboard (`agent/Core/routines.md`). If the last routine is removed, the dashboard file is deleted and the `routine-check` sensor is automatically removed.
+</Aside>
+
+## Flags
+
+| Flag | Short | Type | Default | Description |
+|:-----|:------|:-----|:--------|:------------|
+| `--delete-files` | `-d` | bool | `false` | Also delete the generated `agent/` directory, `CLAUDE.md`, and `.claude/` directory (agent removal only) |
+
+## Examples
+
+**Remove a backend agent (config only):**
+
+```bash
+bonsai remove backend
+# Shows preview of Backend agent and all abilities
+# Confirm: Remove Backend? (y/N)
+```
+
+Removes the agent from `.bonsai.yaml` and updates `.claude/settings.json`. The workspace files remain on disk.
+
+**Remove a backend agent and delete files:**
+
+```bash
+bonsai remove backend --delete-files
+# Shows preview, confirms, then deletes:
+#   backend/agent/
+#   backend/CLAUDE.md
+#   backend/.claude/
+```
+
+**Remove a skill from an agent:**
+
+```bash
+bonsai remove skill coding-standards
+# If installed in one agent: shows summary and confirms
+# If installed in multiple: asks which agent (or all)
+```
+
+Deletes the skill file, removes it from config, and regenerates the agent's `CLAUDE.md`.
+
+**Attempt to remove a required item:**
+
+```bash
+bonsai remove protocol security
+# ⚠ Security is required for Backend — skipping.
+# ✗ Security is required and cannot be removed.
+```
+
+## See Also
+
+- [`bonsai add`](/Bonsai/commands/add/) -- add agents or abilities
+- [`bonsai list`](/Bonsai/commands/list/) -- see what is currently installed

--- a/website/src/content/docs/commands/update.mdx
+++ b/website/src/content/docs/commands/update.mdx
@@ -1,8 +1,96 @@
 ---
 title: bonsai update
-description: bonsai update — sync workspace changes
+description: Sync workspace — detect custom files, re-render all generated abilities, and refresh CLAUDE.md navigation.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import { Steps, Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution">This page is under construction.</Aside>
+## Synopsis
+
+```
+bonsai update
+```
+
+## Description
+
+`bonsai update` synchronizes your workspace by performing two operations:
+
+1. **Custom file detection** -- scans each agent's workspace directories (`agent/Skills/`, `agent/Workflows/`, `agent/Protocols/`, `agent/Sensors/`, `agent/Routines/`) for files that are not tracked by Bonsai. If valid custom files are found, you can choose to track them in the project config.
+
+2. **Workspace re-render** -- regenerates all agent files (abilities, CLAUDE.md navigation, `.claude/settings.json`, path-scoped rules, workflow skills). Files that have not been modified by the user are updated silently. Files that have been modified since Bonsai generated them trigger a conflict resolution flow.
+
+Run `bonsai update` after:
+- Creating a custom skill, workflow, protocol, sensor, or routine file in an agent's workspace
+- Upgrading Bonsai to a new version (to pick up updated catalog templates)
+- Manually editing `.bonsai.yaml` to add or change items
+
+## Interactive Flow
+
+<Steps>
+
+1. **Scan for custom files** -- Bonsai walks each agent's ability directories looking for untracked files. Files are matched by extension (`.md` for skills/workflows/protocols/routines, `.sh` for sensors) and checked against the config and lock file.
+
+2. **Show invalid files** -- files missing required frontmatter are flagged with a warning. Skills, workflows, and protocols need at minimum a `description` field. Sensors additionally require `event`. Routines additionally require `frequency`. Invalid files are skipped.
+
+3. **Multi-select picker** -- valid custom files are shown in a multi-select picker grouped by type (e.g. `[skill] My Custom Skill`). All are pre-selected. Uncheck any you do not want to track.
+
+4. **Regenerate workspace** -- Bonsai re-renders all generated files for all agents. This includes ability files, CLAUDE.md navigation, `.claude/settings.json`, path-scoped rules, and workflow skill files.
+
+5. **Handle conflicts** -- if any generated files have been modified by the user since the last generation, Bonsai presents a conflict resolution flow:
+   - A multi-select picker shows all conflicted files (pre-selected for update)
+   - Uncheck files you want to keep as-is
+   - Optionally create `.bak` backups before overwriting
+
+</Steps>
+
+<Aside type="tip">
+Custom files must include BONSAI frontmatter at the top of the file for Bonsai to recognize them. See [`bonsai guide`](/Bonsai/commands/guide/) for the required format, or run `bonsai guide` in your terminal.
+</Aside>
+
+## Flags
+
+This command has no flags.
+
+## Examples
+
+**Update after creating a custom skill:**
+
+Create a file at `backend/agent/Skills/my-pattern.md` with proper frontmatter, then run:
+
+```bash
+bonsai update
+# Custom files found — Backend
+# [skill] My Pattern — description from frontmatter
+# Track these custom files? (multi-select)
+# Syncing workspace...
+# ✓ Update complete — custom files tracked
+```
+
+The custom skill is added to `.bonsai.yaml` under the Backend agent's skills list, tracked in the lock file, and included in the regenerated `CLAUDE.md` navigation.
+
+**Update after upgrading Bonsai:**
+
+```bash
+bonsai update
+# Syncing workspace...
+# Updated: 12 files
+# ✓ Update complete — workspace synced
+```
+
+If no custom files are found, Bonsai skips the detection phase and proceeds directly to re-rendering.
+
+**Handling conflicts:**
+
+```bash
+bonsai update
+# 3 file(s) modified since Bonsai generated them.
+# Select which files to update. Unchecked files keep your changes.
+# (multi-select picker with conflicted files)
+# Create .bak backups before overwriting? (y/N)
+```
+
+## See Also
+
+- [`bonsai add`](/Bonsai/commands/add/) -- add catalog abilities (update handles custom files)
+- [`bonsai guide`](/Bonsai/commands/guide/) -- view the custom files format guide
+- [Abilities](/Bonsai/concepts/abilities/) -- understand skills, workflows, and protocols


### PR DESCRIPTION
## Summary
Replace all 7 stub command pages with comprehensive reference documentation sourced from cmd/*.go Cobra definitions.

## Changes
- `commands/init.mdx` — full reference: interactive flow, generated output
- `commands/add.mdx` — full reference: two modes (new agent / add abilities)
- `commands/remove.mdx` — full reference: agent removal + ability removal + flags
- `commands/list.mdx` — full reference: display format
- `commands/catalog.mdx` — full reference: --agent filter flag
- `commands/update.mdx` — full reference: custom file detection + conflict handling
- `commands/guide.mdx` — full reference: terminal rendering

## Plan
station/Playbook/Plans/Active/10-docs-site.md — Phase B (B2)

## Verification
- [x] `npm run build` — passes
- [x] No broken internal links
- [x] All command details match cmd/*.go source