### PR TITLE
feat(docs): catalog auto-generation script and LLM layer (Plan 10 Phase C)

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -22,7 +22,38 @@ export default defineConfig({
       },
       lastUpdated: true,
       customCss: ['./src/styles/custom.css'],
-      plugins: [starlightLlmsTxt(), starlightLinksValidator()],
+      plugins: [
+        starlightLlmsTxt({
+          projectName: 'Bonsai',
+          description: `Bonsai is a CLI tool for scaffolding Claude Code agent workspaces. It generates structured instruction files — identity, memory, protocols, skills, workflows, sensors, and routines — so AI agents work like teammates, not tools.`,
+          details: `- Install: \`go install github.com/LastStep/Bonsai@latest\` or \`brew install LastStep/tap/bonsai\`
+- 6 agent types: tech-lead, backend, frontend, fullstack, devops, security
+- Abilities are modular: skills (reference), workflows (multi-step), protocols (rules), sensors (hooks), routines (periodic)`,
+          customSets: [
+            {
+              label: 'Concepts',
+              description: 'How Bonsai works — agents, abilities, sensors, routines, scaffolding, workspaces',
+              paths: ['concepts/**'],
+            },
+            {
+              label: 'Commands',
+              description: 'CLI reference for all 7 commands with flags and examples',
+              paths: ['commands/**'],
+            },
+            {
+              label: 'Catalog',
+              description: 'All 6 agent types, 17 skills, 10 workflows, 4 protocols, 12 sensors, 8 routines with descriptions and compatibility',
+              paths: ['catalog/**'],
+            },
+            {
+              label: 'Configuration',
+              description: '.bonsai.yaml, .bonsai-lock.yaml, meta.yaml, and agent.yaml schemas',
+              paths: ['reference/**'],
+            },
+          ],
+        }),
+        starlightLinksValidator(),
+      ],
       sidebar: [
         {
           label: 'Start Here',

--- a/website/package.json
+++ b/website/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "generate:catalog": "node scripts/generate-catalog.mjs"
   },
   "dependencies": {
     "@astrojs/starlight": "latest",

--- a/website/public/catalog.json
+++ b/website/public/catalog.json
@@ -1,0 +1,909 @@
+{
+  "generated": "2026-04-16T21:04:30.212Z",
+  "counts": {
+    "agents": 6,
+    "skills": 17,
+    "workflows": 10,
+    "protocols": 4,
+    "sensors": 12,
+    "routines": 8
+  },
+  "agents": [
+    {
+      "name": "backend",
+      "display_name": "Backend Agent",
+      "description": "Executes backend plans — API, database, server-side logic",
+      "defaults": {
+        "skills": [
+          "coding-standards",
+          "testing",
+          "database-conventions"
+        ],
+        "workflows": [
+          "plan-execution",
+          "reporting",
+          "session-logging"
+        ],
+        "protocols": [
+          "session-start",
+          "security",
+          "scope-boundaries"
+        ],
+        "sensors": [
+          "session-context",
+          "scope-guard-files"
+        ]
+      }
+    },
+    {
+      "name": "devops",
+      "display_name": "DevOps Agent",
+      "description": "Manages infrastructure-as-code, CI/CD pipelines, containers, and deployment automation",
+      "defaults": {
+        "skills": [
+          "coding-standards",
+          "iac-conventions",
+          "container-standards"
+        ],
+        "workflows": [
+          "plan-execution",
+          "reporting",
+          "session-logging",
+          "security-audit"
+        ],
+        "protocols": [
+          "session-start",
+          "security",
+          "scope-boundaries"
+        ],
+        "sensors": [
+          "session-context",
+          "scope-guard-files",
+          "iac-safety-guard"
+        ],
+        "routines": [
+          "dependency-audit",
+          "infra-drift-check"
+        ]
+      }
+    },
+    {
+      "name": "frontend",
+      "display_name": "Frontend Agent",
+      "description": "Executes frontend plans — UI components, state management, styling",
+      "defaults": {
+        "skills": [
+          "coding-standards",
+          "testing",
+          "design-guide"
+        ],
+        "workflows": [
+          "plan-execution",
+          "reporting",
+          "session-logging"
+        ],
+        "protocols": [
+          "session-start",
+          "security",
+          "scope-boundaries"
+        ],
+        "sensors": [
+          "session-context",
+          "scope-guard-files"
+        ]
+      }
+    },
+    {
+      "name": "fullstack",
+      "display_name": "Full-Stack Agent",
+      "description": "Implements full-stack features end-to-end — UI, API routes, database, auth, tests",
+      "defaults": {
+        "skills": [
+          "coding-standards",
+          "testing",
+          "design-guide",
+          "database-conventions",
+          "api-design-standards",
+          "auth-patterns"
+        ],
+        "workflows": [
+          "plan-execution",
+          "reporting",
+          "session-logging"
+        ],
+        "protocols": [
+          "session-start",
+          "security",
+          "scope-boundaries"
+        ],
+        "sensors": [
+          "session-context",
+          "scope-guard-files"
+        ]
+      }
+    },
+    {
+      "name": "security",
+      "display_name": "Security Agent",
+      "description": "Audits code for vulnerabilities, reviews auth patterns, scans dependencies, enforces security standards",
+      "defaults": {
+        "skills": [
+          "coding-standards",
+          "testing",
+          "auth-patterns",
+          "review-checklist"
+        ],
+        "workflows": [
+          "code-review",
+          "reporting",
+          "session-logging",
+          "security-audit"
+        ],
+        "protocols": [
+          "session-start",
+          "security",
+          "scope-boundaries"
+        ],
+        "sensors": [
+          "session-context",
+          "scope-guard-files",
+          "scope-guard-commands",
+          "api-security-check"
+        ],
+        "routines": [
+          "vulnerability-scan",
+          "dependency-audit"
+        ]
+      }
+    },
+    {
+      "name": "tech-lead",
+      "display_name": "Tech Lead Agent",
+      "description": "Architects the system, writes plans, reviews agent output — never writes application code",
+      "defaults": {
+        "skills": [
+          "planning-template",
+          "issue-classification",
+          "dispatch",
+          "review-checklist"
+        ],
+        "workflows": [
+          "issue-to-implementation",
+          "planning",
+          "code-review",
+          "session-logging"
+        ],
+        "protocols": [
+          "session-start",
+          "security",
+          "scope-boundaries"
+        ],
+        "sensors": [
+          "session-context",
+          "scope-guard-files",
+          "scope-guard-commands",
+          "dispatch-guard",
+          "subagent-stop-review"
+        ]
+      }
+    }
+  ],
+  "skills": [
+    {
+      "name": "api-design-standards",
+      "description": "REST API design conventions — URLs, methods, errors, pagination, versioning",
+      "agents": [
+        "backend",
+        "fullstack",
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Designing or reviewing REST/GraphQL API endpoints",
+          "Defining request/response schemas or versioning strategy"
+        ],
+        "paths": [
+          "**/routes/**",
+          "**/handlers/**",
+          "**/controllers/**",
+          "**/api/**"
+        ]
+      }
+    },
+    {
+      "name": "auth-patterns",
+      "description": "Authentication and authorization patterns — flows, tokens, passwords, sessions, access control",
+      "agents": [
+        "backend",
+        "fullstack",
+        "security"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Implementing or reviewing authentication or authorization logic",
+          "Working with session management, tokens, or access control"
+        ],
+        "paths": [
+          "**/auth/**",
+          "**/middleware/auth*",
+          "**/login*",
+          "**/session*"
+        ]
+      }
+    },
+    {
+      "name": "cli-conventions",
+      "description": "CLI design conventions — structure, flags, output, exit codes, configuration",
+      "agents": [
+        "backend",
+        "fullstack"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Building or reviewing CLI commands, flags, or argument parsing",
+          "Designing command-line user experience"
+        ],
+        "paths": [
+          "cmd/**",
+          "**/cli/**",
+          "**/*command*"
+        ]
+      }
+    },
+    {
+      "name": "coding-standards",
+      "description": "Language-specific coding standards — formatting, linting, patterns",
+      "agents": [
+        "backend",
+        "devops",
+        "frontend",
+        "fullstack",
+        "security"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Writing or reviewing source code in any language",
+          "Applying formatting, linting, or naming conventions"
+        ],
+        "paths": [
+          "*.go",
+          "*.py",
+          "*.js",
+          "*.ts",
+          "*.java",
+          "*.rs"
+        ]
+      }
+    },
+    {
+      "name": "container-standards",
+      "description": "Container and orchestration standards — Docker multi-stage builds, image security, Kubernetes manifests",
+      "agents": [
+        "devops"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Writing or reviewing Dockerfiles, docker-compose, or Kubernetes manifests",
+          "Configuring container builds, images, or orchestration"
+        ],
+        "paths": [
+          "**/Dockerfile*",
+          "**/docker-compose*",
+          "**/k8s/**"
+        ]
+      }
+    },
+    {
+      "name": "database-conventions",
+      "description": "SQL naming, migration patterns, schema design rules",
+      "agents": [
+        "backend",
+        "fullstack",
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Writing or reviewing SQL migrations or database schemas",
+          "Designing data models or query patterns"
+        ],
+        "paths": [
+          "*.sql",
+          "migrations/**",
+          "**/schema.*",
+          "**/models/**"
+        ]
+      }
+    },
+    {
+      "name": "design-guide",
+      "description": "Bonsai CLI design system — palette, spacing, panels, errors, command flow",
+      "agents": [
+        "backend",
+        "frontend",
+        "fullstack",
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Modifying TUI styles, panels, display helpers, or color definitions",
+          "Adding or changing CLI output formatting in any command"
+        ],
+        "paths": [
+          "internal/tui/**",
+          "cmd/*.go"
+        ]
+      }
+    },
+    {
+      "name": "dispatch",
+      "description": "How to dispatch work to code agents — triage rules, prompt structure, iteration tracking",
+      "agents": [
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Dispatching work to a code agent via worktree",
+          "Writing an agent dispatch prompt with plan steps"
+        ]
+      }
+    },
+    {
+      "name": "iac-conventions",
+      "description": "Infrastructure-as-code conventions — Terraform naming, state management, modules, tagging",
+      "agents": [
+        "devops"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Writing or reviewing Terraform, CloudFormation, or infrastructure-as-code",
+          "Managing cloud resources or infrastructure configuration"
+        ],
+        "paths": [
+          "**/*.tf",
+          "**/*.tfvars",
+          "**/cloudformation/**"
+        ]
+      }
+    },
+    {
+      "name": "issue-classification",
+      "description": "Issue types, importance levels, domain labels, and classification heuristics",
+      "agents": [
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Classifying or triaging a new issue or bug report",
+          "Determining issue type, importance, and domain labels"
+        ]
+      }
+    },
+    {
+      "name": "mobile-patterns",
+      "description": "Mobile development patterns — state management, offline-first, navigation, performance",
+      "agents": [
+        "fullstack"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Developing or reviewing iOS or Android application code",
+          "Working with mobile-specific patterns, navigation, or platform APIs"
+        ],
+        "paths": [
+          "**/ios/**",
+          "**/android/**",
+          "**/*.swift",
+          "**/*.kt"
+        ]
+      }
+    },
+    {
+      "name": "planning-template",
+      "description": "Plan format, tier rules, and template for writing implementation plans",
+      "agents": [
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Writing a new implementation plan",
+          "Structuring a plan with tier rules and verification steps"
+        ]
+      }
+    },
+    {
+      "name": "pr-creation",
+      "description": "How to create well-structured pull requests — branch naming, title conventions, body template, draft workflow",
+      "agents": [
+        "backend",
+        "frontend",
+        "fullstack",
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Creating a pull request with proper conventions",
+          "Setting up branch naming, PR title, and body template"
+        ]
+      }
+    },
+    {
+      "name": "review-checklist",
+      "description": "Structured code review checklist — correctness, security, performance, maintainability",
+      "agents": [
+        "reviewer",
+        "security",
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Performing a structured code review",
+          "Checking correctness, security, performance, and maintainability"
+        ]
+      }
+    },
+    {
+      "name": "test-strategy",
+      "description": "Test architecture — which tests to write, when, and why; pyramid, coverage, anti-patterns",
+      "agents": [
+        "backend",
+        "frontend",
+        "fullstack",
+        "qa"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Defining the overall testing approach for a feature or module",
+          "Deciding which test types to use and what to prioritize"
+        ],
+        "paths": [
+          "**/*_test.go",
+          "**/*.test.*",
+          "**/*.spec.*"
+        ]
+      }
+    },
+    {
+      "name": "testing",
+      "description": "Testing conventions — frameworks, patterns, coverage requirements",
+      "agents": [
+        "backend",
+        "frontend",
+        "fullstack",
+        "security"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Writing or reviewing unit tests, integration tests, or test fixtures",
+          "Evaluating test coverage or test quality"
+        ],
+        "paths": [
+          "**/*_test.go",
+          "**/*.test.*",
+          "**/*.spec.*",
+          "**/test/**"
+        ]
+      }
+    },
+    {
+      "name": "workspace-guide",
+      "description": "Bonsai workspace operational guide — how to use workflows, skills, routines, sensors, and the Playbook effectively",
+      "agents": "all",
+      "triggers": {
+        "scenarios": [
+          "Learning how this agent workspace is organized",
+          "Understanding workspace conventions and file purposes"
+        ]
+      }
+    }
+  ],
+  "workflows": [
+    {
+      "name": "api-development",
+      "description": "Spec-first API development — define contract, generate scaffolding, implement, test, document",
+      "agents": [
+        "backend",
+        "fullstack"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Building a new API endpoint or service from requirements",
+          "Implementing CRUD operations, middleware, or API integrations"
+        ],
+        "examples": [
+          {
+            "prompt": "Build the user management API",
+            "action": "Load api-development workflow, design endpoints, implement handlers"
+          }
+        ]
+      }
+    },
+    {
+      "name": "code-review",
+      "description": "Review agent output against the plan — correctness, standards, security",
+      "agents": [
+        "security",
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Reviewing agent output against the plan for correctness and standards",
+          "Checking implementation changes before merging"
+        ],
+        "examples": [
+          {
+            "prompt": "Review the changes on the feature branch",
+            "action": "Load code-review workflow, diff branch against main, check plan compliance"
+          }
+        ]
+      }
+    },
+    {
+      "name": "issue-to-implementation",
+      "description": "End-to-end autonomous workflow — issue intake, analysis, research, planning, agent dispatch, review loop, logging, audit, and close",
+      "agents": [
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Taking an issue from intake through to shipped code",
+          "Running the full autonomous implementation workflow"
+        ],
+        "examples": [
+          {
+            "prompt": "Pick up issue #15 and ship it",
+            "action": "Load issue-to-implementation workflow, analyze issue, plan, dispatch, review, merge"
+          }
+        ]
+      }
+    },
+    {
+      "name": "plan-execution",
+      "description": "Execute an assigned plan step by step — implement, test, report",
+      "agents": [
+        "backend",
+        "devops",
+        "frontend",
+        "fullstack"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Executing an approved implementation plan step by step",
+          "Dispatching agents and tracking plan completion"
+        ],
+        "examples": [
+          {
+            "prompt": "Execute plan 08 phase A",
+            "action": "Load plan-execution workflow, read plan, dispatch agents, track progress"
+          }
+        ]
+      }
+    },
+    {
+      "name": "planning",
+      "description": "End-to-end planning process — from request to dispatch-ready plan",
+      "agents": [
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Starting end-to-end planning for a new feature or task",
+          "Translating requirements into a structured implementation plan"
+        ],
+        "examples": [
+          {
+            "prompt": "Plan the new caching layer",
+            "action": "Load planning workflow, analyze requirements, write plan to Plans/Active/"
+          }
+        ]
+      }
+    },
+    {
+      "name": "pr-review",
+      "description": "Review a pull request — context, scope, correctness, security, performance, standards",
+      "agents": [
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Reviewing a pull request for correctness, security, and standards",
+          "Evaluating PR scope, changes, and test coverage"
+        ],
+        "examples": [
+          {
+            "prompt": "Review PR #42",
+            "action": "Load pr-review workflow, fetch PR details, review against checklist"
+          }
+        ]
+      }
+    },
+    {
+      "name": "reporting",
+      "description": "Completion report format — what was done, tested, issues encountered",
+      "agents": [
+        "backend",
+        "devops",
+        "frontend",
+        "fullstack",
+        "security"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Generating a structured completion or status report",
+          "Documenting project progress, findings, or audit results"
+        ],
+        "examples": [
+          {
+            "prompt": "Write the completion report for this task",
+            "action": "Load reporting workflow, compile findings, write to Reports/Pending/"
+          }
+        ]
+      }
+    },
+    {
+      "name": "security-audit",
+      "description": "Security audit — secrets scan, dependency audit, SAST, config review, access control, infrastructure",
+      "agents": [
+        "devops",
+        "security",
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Running a security audit on the codebase or recent changes",
+          "Checking for secrets, vulnerable dependencies, or unsafe patterns"
+        ],
+        "examples": [
+          {
+            "prompt": "Check the project for security issues",
+            "action": "Load security-audit workflow, scan secrets, audit deps, review config"
+          }
+        ]
+      }
+    },
+    {
+      "name": "session-logging",
+      "description": "End-of-session log — what was done, decisions made, open items",
+      "agents": "all",
+      "triggers": {
+        "scenarios": [
+          "Writing an end-of-session log entry",
+          "Recording decisions made and open items from the current session"
+        ],
+        "examples": [
+          {
+            "prompt": "Log what we did today",
+            "action": "Load session-logging workflow, compile session summary, append to logs"
+          }
+        ]
+      }
+    },
+    {
+      "name": "test-plan",
+      "description": "Design a structured test plan for a feature — scope, prioritize, allocate test types",
+      "agents": [
+        "tech-lead"
+      ],
+      "triggers": {
+        "scenarios": [
+          "Designing a structured test plan for a feature or module",
+          "Deciding test scope, priorities, and test type allocation"
+        ],
+        "examples": [
+          {
+            "prompt": "Plan the tests for the new API endpoints",
+            "action": "Load test-plan workflow, analyze feature, design test coverage strategy"
+          }
+        ]
+      }
+    }
+  ],
+  "protocols": [
+    {
+      "name": "memory",
+      "description": "How to read, write, and maintain working memory between sessions",
+      "agents": "all",
+      "required": "all"
+    },
+    {
+      "name": "scope-boundaries",
+      "description": "What you own, what you never touch, workspace boundaries",
+      "agents": "all",
+      "required": "all"
+    },
+    {
+      "name": "security",
+      "description": "Security enforcement — hard stops and hard enforcers",
+      "agents": "all",
+      "required": "all"
+    },
+    {
+      "name": "session-start",
+      "description": "Ordered startup sequence — what to read and check every session",
+      "agents": "all",
+      "required": "all"
+    }
+  ],
+  "sensors": [
+    {
+      "name": "agent-review",
+      "description": "Outputs a review checklist after a dispatched agent completes work",
+      "agents": [
+        "tech-lead"
+      ],
+      "event": "PostToolUse",
+      "matcher": "Agent",
+      "required": null
+    },
+    {
+      "name": "api-security-check",
+      "description": "Detects security anti-patterns in code changes — SQL injection, hardcoded secrets, eval, CORS wildcards",
+      "agents": [
+        "backend",
+        "fullstack",
+        "security"
+      ],
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "required": null
+    },
+    {
+      "name": "context-guard",
+      "description": "Injects context-aware behavioral constraints and detects session wrap-up trigger words before each prompt",
+      "agents": "all",
+      "event": "UserPromptSubmit",
+      "matcher": null,
+      "required": "all"
+    },
+    {
+      "name": "dispatch-guard",
+      "description": "Validates code agent dispatches — requires worktree isolation, plan reference, and plan existence before execution",
+      "agents": [
+        "tech-lead"
+      ],
+      "event": "PreToolUse",
+      "matcher": "Agent",
+      "required": null
+    },
+    {
+      "name": "iac-safety-guard",
+      "description": "Blocks dangerous infrastructure commands — terraform destroy, kubectl delete namespace, unsafe docker ops",
+      "agents": [
+        "devops"
+      ],
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "required": null
+    },
+    {
+      "name": "routine-check",
+      "description": "Checks routine dashboard at session start and flags overdue maintenance routines",
+      "agents": "all",
+      "event": "SessionStart",
+      "matcher": null,
+      "required": null
+    },
+    {
+      "name": "scope-guard-commands",
+      "description": "Blocks agent from running application execution commands (tests, builds, servers)",
+      "agents": [
+        "security",
+        "tech-lead"
+      ],
+      "event": "PreToolUse",
+      "matcher": "Bash",
+      "required": null
+    },
+    {
+      "name": "scope-guard-files",
+      "description": "Blocks agent from editing files outside its workspace",
+      "agents": "all",
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "required": "all"
+    },
+    {
+      "name": "session-context",
+      "description": "Injects core identity, memory, protocols, and project status at session start",
+      "agents": "all",
+      "event": "SessionStart",
+      "matcher": null,
+      "required": "all"
+    },
+    {
+      "name": "status-bar",
+      "description": "Persistent status line showing context usage, session health, and git state after every response",
+      "agents": "all",
+      "event": "Stop",
+      "matcher": null,
+      "required": "all"
+    },
+    {
+      "name": "subagent-stop-review",
+      "description": "Outputs a structured review checklist when a dispatched agent finishes work",
+      "agents": [
+        "tech-lead"
+      ],
+      "event": "SubagentStop",
+      "matcher": null,
+      "required": null
+    },
+    {
+      "name": "test-integrity-guard",
+      "description": "Detects test quality issues — removed assertions, .skip/.only, empty test bodies, debug artifacts",
+      "agents": [
+        "backend",
+        "frontend",
+        "fullstack"
+      ],
+      "event": "PreToolUse",
+      "matcher": "Edit|Write",
+      "required": null
+    }
+  ],
+  "routines": [
+    {
+      "name": "backlog-hygiene",
+      "description": "Review and maintain Playbook/Backlog.md — flag stale items, escalate P0s, cross-reference with Status and Roadmap",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "7 days"
+    },
+    {
+      "name": "dependency-audit",
+      "description": "Scan dependencies for known vulnerabilities and unmaintained packages",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "7 days"
+    },
+    {
+      "name": "doc-freshness-check",
+      "description": "Detect documentation drift — docs that are stale relative to recent code changes",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "7 days"
+    },
+    {
+      "name": "infra-drift-check",
+      "description": "Detect infrastructure drift — compare declared IaC state against actual cloud resources",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "7 days"
+    },
+    {
+      "name": "memory-consolidation",
+      "description": "Bridge Claude Code auto-memory into agent/Core/memory.md — validate facts, clean redundant entries",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "5 days"
+    },
+    {
+      "name": "roadmap-accuracy",
+      "description": "Ensure Playbook/Roadmap.md reflects what's actually built and what's actually next",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "14 days"
+    },
+    {
+      "name": "status-hygiene",
+      "description": "Keep Playbook/Status.md clean — archive old Done items, validate Pending items",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "5 days"
+    },
+    {
+      "name": "vulnerability-scan",
+      "description": "SAST scan, secrets scan, and dependency audit — flag new, resolved, and persistent vulnerabilities",
+      "agents": [
+        "tech-lead"
+      ],
+      "frequency": "7 days"
+    }
+  ]
+}

--- a/website/scripts/generate-catalog.mjs
+++ b/website/scripts/generate-catalog.mjs
@@ -1,0 +1,446 @@
+#!/usr/bin/env node
+
+/**
+ * generate-catalog.mjs
+ *
+ * Reads catalog/meta.yaml and catalog/agents/agent.yaml source files,
+ * then updates the docs site catalog pages (between marker comments)
+ * and writes website/public/catalog.json.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import yaml from 'js-yaml';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const WEBSITE_DIR = path.resolve(__dirname, '..');
+const CATALOG_DIR = path.resolve(WEBSITE_DIR, '..', 'catalog');
+const DOCS_DIR = path.join(WEBSITE_DIR, 'src', 'content', 'docs', 'catalog');
+const PUBLIC_DIR = path.join(WEBSITE_DIR, 'public');
+
+// Workflows that have slash commands (from internal/generate/generate.go:CuratedSlashWorkflows)
+const CURATED_SLASH_WORKFLOWS = new Set([
+  'planning',
+  'code-review',
+  'pr-review',
+  'security-audit',
+  'issue-to-implementation',
+  'test-plan',
+  'plan-execution',
+]);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function readYamlDir(dir, filename = 'meta.yaml') {
+  const items = [];
+  if (!fs.existsSync(dir)) return items;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const yamlPath = path.join(dir, entry.name, filename);
+    if (!fs.existsSync(yamlPath)) continue;
+    const data = yaml.load(fs.readFileSync(yamlPath, 'utf8'));
+    items.push(data);
+  }
+  return items.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function displayName(name) {
+  return name
+    .split('-')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+function formatAgents(agents) {
+  if (agents === 'all') return 'all';
+  if (Array.isArray(agents)) return agents.sort().join(', ');
+  return String(agents);
+}
+
+function formatRequired(item) {
+  if (item.name === 'routine-check') return 'Auto-managed';
+  if (item.required === 'all') return 'Yes (all)';
+  if (item.required) return `Yes (${formatAgents(item.required)})`;
+  return 'No';
+}
+
+/**
+ * Replace content between marker comments in a file.
+ * Returns true if the file was modified.
+ */
+function replaceMarkerContent(filePath, startMarker, endMarker, newContent) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const startIdx = text.indexOf(startMarker);
+  const endIdx = text.indexOf(endMarker);
+  if (startIdx === -1 || endIdx === -1) {
+    console.warn(`  WARNING: Markers not found in ${path.basename(filePath)}: ${startMarker}`);
+    return false;
+  }
+  const before = text.slice(0, startIdx + startMarker.length);
+  const after = text.slice(endIdx);
+  const updated = before + '\n' + newContent + '\n' + after;
+  if (updated !== text) {
+    fs.writeFileSync(filePath, updated, 'utf8');
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Update the frontmatter description line to reflect accurate count.
+ * Looks for a pattern like "All N Bonsai {type}" and replaces N.
+ */
+function updateFrontmatterCount(filePath, count, typeWord) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const pattern = new RegExp(`(All )\\d+( Bonsai ${typeWord})`, 'i');
+  if (pattern.test(text)) {
+    const updated = text.replace(pattern, `$1${count}$2`);
+    if (updated !== text) {
+      fs.writeFileSync(filePath, updated, 'utf8');
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Load all catalog data
+// ---------------------------------------------------------------------------
+
+const skills = readYamlDir(path.join(CATALOG_DIR, 'skills'));
+const workflows = readYamlDir(path.join(CATALOG_DIR, 'workflows'));
+const protocols = readYamlDir(path.join(CATALOG_DIR, 'protocols'));
+const sensors = readYamlDir(path.join(CATALOG_DIR, 'sensors'));
+const routines = readYamlDir(path.join(CATALOG_DIR, 'routines'));
+const agents = readYamlDir(path.join(CATALOG_DIR, 'agents'), 'agent.yaml');
+
+console.log('Catalog loaded:');
+console.log(`  Agents:    ${agents.length}`);
+console.log(`  Skills:    ${skills.length}`);
+console.log(`  Workflows: ${workflows.length}`);
+console.log(`  Protocols: ${protocols.length}`);
+console.log(`  Sensors:   ${sensors.length}`);
+console.log(`  Routines:  ${routines.length}`);
+console.log(`  Total:     ${agents.length + skills.length + workflows.length + protocols.length + sensors.length + routines.length}`);
+console.log();
+
+// ---------------------------------------------------------------------------
+// Generate: Skills table
+// ---------------------------------------------------------------------------
+
+{
+  const lines = [
+    '| Name | Description | Compatible Agents |',
+    '|:-----|:-----------|:-----------------|',
+  ];
+  for (const s of skills) {
+    lines.push(`| ${s.name} | ${s.description} | ${formatAgents(s.agents)} |`);
+  }
+  const filePath = path.join(DOCS_DIR, 'skills.mdx');
+  const changed = replaceMarkerContent(filePath, '{/* CATALOG-TABLE-START */}', '{/* CATALOG-TABLE-END */}', lines.join('\n'));
+  updateFrontmatterCount(filePath, skills.length, 'skills');
+  console.log(`skills.mdx: ${changed ? 'updated' : 'no changes'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Generate: Workflows table
+// ---------------------------------------------------------------------------
+
+{
+  const lines = [
+    '| Name | Description | Compatible Agents | Slash Command |',
+    '|:-----|:-----------|:-----------------|:-------------|',
+  ];
+  for (const w of workflows) {
+    const slash = CURATED_SLASH_WORKFLOWS.has(w.name) ? `\`/${w.name}\`` : '';
+    lines.push(`| ${w.name} | ${w.description} | ${formatAgents(w.agents)} | ${slash} |`);
+  }
+  const filePath = path.join(DOCS_DIR, 'workflows.mdx');
+  const changed = replaceMarkerContent(filePath, '{/* CATALOG-TABLE-START */}', '{/* CATALOG-TABLE-END */}', lines.join('\n'));
+  updateFrontmatterCount(filePath, workflows.length, 'workflows');
+  console.log(`workflows.mdx: ${changed ? 'updated' : 'no changes'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Generate: Protocols table
+// ---------------------------------------------------------------------------
+
+{
+  const lines = [
+    '| Name | Description | Required |',
+    '|:-----|:-----------|:---------|',
+  ];
+  for (const p of protocols) {
+    lines.push(`| ${p.name} | ${p.description} | ${formatRequired(p)} |`);
+  }
+  const filePath = path.join(DOCS_DIR, 'protocols.mdx');
+  const changed = replaceMarkerContent(filePath, '{/* CATALOG-TABLE-START */}', '{/* CATALOG-TABLE-END */}', lines.join('\n'));
+  updateFrontmatterCount(filePath, protocols.length, 'protocols');
+  console.log(`protocols.mdx: ${changed ? 'updated' : 'no changes'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Generate: Sensors table
+// ---------------------------------------------------------------------------
+
+{
+  const lines = [
+    '| Name | Description | Event | Matcher | Compatible Agents | Required |',
+    '|:-----|:-----------|:------|:--------|:-----------------|:---------|',
+  ];
+  for (const s of sensors) {
+    lines.push(
+      `| ${s.name} | ${s.description} | ${s.event} | ${s.matcher || ''} | ${formatAgents(s.agents)} | ${formatRequired(s)} |`
+    );
+  }
+  const filePath = path.join(DOCS_DIR, 'sensors.mdx');
+  const changed = replaceMarkerContent(filePath, '{/* CATALOG-TABLE-START */}', '{/* CATALOG-TABLE-END */}', lines.join('\n'));
+  updateFrontmatterCount(filePath, sensors.length, 'sensors');
+  console.log(`sensors.mdx: ${changed ? 'updated' : 'no changes'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Generate: Routines table
+// ---------------------------------------------------------------------------
+
+{
+  const lines = [
+    '| Name | Description | Frequency | Compatible Agents |',
+    '|:-----|:-----------|:----------|:-----------------|',
+  ];
+  for (const r of routines) {
+    lines.push(`| ${r.name} | ${r.description} | ${r.frequency} | ${formatAgents(r.agents)} |`);
+  }
+  const filePath = path.join(DOCS_DIR, 'routines.mdx');
+  const changed = replaceMarkerContent(filePath, '{/* CATALOG-TABLE-START */}', '{/* CATALOG-TABLE-END */}', lines.join('\n'));
+  updateFrontmatterCount(filePath, routines.length, 'routines');
+  console.log(`routines.mdx: ${changed ? 'updated' : 'no changes'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Generate: Agent Types page
+// ---------------------------------------------------------------------------
+
+{
+  // Sort: tech-lead first, then alphabetical
+  const techLead = agents.find((a) => a.name === 'tech-lead');
+  const codeAgents = agents.filter((a) => a.name !== 'tech-lead').sort((a, b) => a.name.localeCompare(b.name));
+
+  function agentDefaultsList(defaults, category) {
+    const items = defaults?.[category];
+    if (!items || items.length === 0) {
+      // Special case: tech-lead routines
+      if (category === 'routines' && techLead) {
+        return `_(none by default — all ${routines.length} catalog routines are compatible)_`;
+      }
+      return '_(none)_';
+    }
+    return items.join(', ');
+  }
+
+  function generateAgentSection(agent, heading) {
+    const dn = agent.display_name || displayName(agent.name);
+    const lines = [];
+    lines.push(`### ${dn}`);
+    lines.push('');
+    lines.push(`**Description:** ${agent.description}`);
+    lines.push('');
+
+    // Generate "Best for" from the description
+    const bestFor = generateBestFor(agent);
+    lines.push(`**Best for:** ${bestFor}`);
+    lines.push('');
+
+    if (agent.name === 'tech-lead') {
+      lines.push('<Aside type="caution">');
+      lines.push(
+        'The Tech Lead never writes application code directly. It creates plans, dispatches them to code agents via worktree-isolated subagents, and reviews the results.'
+      );
+      lines.push('</Aside>');
+      lines.push('');
+    }
+
+    lines.push('| Category | Defaults |');
+    lines.push('|:---------|:---------|');
+
+    const isThisAgent = agent.name === techLead?.name;
+
+    for (const cat of ['skills', 'workflows', 'protocols', 'sensors', 'routines']) {
+      let val;
+      const items = agent.defaults?.[cat];
+      if (!items || items.length === 0) {
+        if (cat === 'routines' && isThisAgent) {
+          val = `_(none by default — all ${routines.length} catalog routines are compatible)_`;
+        } else {
+          val = '_(none)_';
+        }
+      } else {
+        val = items.join(', ');
+      }
+      lines.push(`| **${cat.charAt(0).toUpperCase() + cat.slice(1)}** | ${val} |`);
+    }
+
+    return lines.join('\n');
+  }
+
+  function generateBestFor(agent) {
+    const bestForMap = {
+      'tech-lead':
+        'Project leads who need an agent that plans features, dispatches work to code agents, and reviews their output.',
+      backend: 'API development, database work, server-side business logic, and backend infrastructure.',
+      frontend: 'UI component development, state management, CSS/styling, and frontend architecture.',
+      fullstack:
+        'Features that span the entire stack, when you want one agent handling frontend through database.',
+      devops: 'Terraform, Docker, Kubernetes, CI/CD pipelines, and deployment configuration.',
+      security:
+        'Security audits, vulnerability scanning, dependency review, and auth pattern enforcement.',
+    };
+    return bestForMap[agent.name] || agent.description;
+  }
+
+  const sections = [];
+
+  // Orchestrator section
+  sections.push('## The Orchestrator');
+  sections.push('');
+  sections.push(generateAgentSection(techLead, '###'));
+  sections.push('');
+  sections.push('---');
+  sections.push('');
+  sections.push('## Code Agents');
+  sections.push('');
+  sections.push(
+    'Code agents execute plans created by the Tech Lead. Each has domain-specific skills and a focused scope.'
+  );
+
+  for (let i = 0; i < codeAgents.length; i++) {
+    sections.push('');
+    sections.push(generateAgentSection(codeAgents[i], '###'));
+    if (i < codeAgents.length - 1) {
+      sections.push('');
+      sections.push('---');
+    }
+  }
+
+  const filePath = path.join(DOCS_DIR, 'agent-types.mdx');
+  const changed = replaceMarkerContent(
+    filePath,
+    '{/* AGENT-DEFAULTS-START */}',
+    '{/* AGENT-DEFAULTS-END */}',
+    sections.join('\n')
+  );
+  console.log(`agent-types.mdx: ${changed ? 'updated' : 'no changes'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Generate: Overview page counts
+// ---------------------------------------------------------------------------
+
+{
+  const filePath = path.join(DOCS_DIR, 'overview.mdx');
+  const countLines = [
+    '<CardGrid>',
+    '  <Card title="Agent Types" icon="rocket">',
+    `    **${agents.length} agents** — ${agents.map((a) => a.display_name || displayName(a.name)).join(', ')}. Each has a specialized identity, defaults, and role.`,
+    '',
+    '    [Browse agent types](/Bonsai/catalog/agent-types/)',
+    '  </Card>',
+    '  <Card title="Skills" icon="open-book">',
+    `    **${skills.length} skills** — Domain knowledge and standards. Coding conventions, API design, testing strategy, infrastructure patterns, and more.`,
+    '',
+    '    [Browse skills](/Bonsai/catalog/skills/)',
+    '  </Card>',
+    '  <Card title="Workflows" icon="list-format">',
+    `    **${workflows.length} workflows** — Step-by-step procedures for planning, code review, security audits, PR review, reporting, and implementation.`,
+    '',
+    '    [Browse workflows](/Bonsai/catalog/workflows/)',
+    '  </Card>',
+    '  <Card title="Protocols" icon="warning">',
+    `    **${protocols.length} protocols** — Hard rules that every agent must follow. Memory management, scope boundaries, security enforcement, and session startup.`,
+    '',
+    '    [Browse protocols](/Bonsai/catalog/protocols/)',
+    '  </Card>',
+    '  <Card title="Sensors" icon="seti:config">',
+    `    **${sensors.length} sensors** — Automated hook scripts that enforce boundaries, inject context, review output, and monitor code quality.`,
+    '',
+    '    [Browse sensors](/Bonsai/catalog/sensors/)',
+    '  </Card>',
+    '  <Card title="Routines" icon="seti:clock">',
+    `    **${routines.length} routines** — Periodic self-maintenance tasks. Backlog hygiene, dependency audits, doc freshness checks, vulnerability scans, and more.`,
+    '',
+    '    [Browse routines](/Bonsai/catalog/routines/)',
+    '  </Card>',
+    '</CardGrid>',
+  ];
+  const changed = replaceMarkerContent(
+    filePath,
+    '{/* CATALOG-COUNTS-START */}',
+    '{/* CATALOG-COUNTS-END */}',
+    countLines.join('\n')
+  );
+  console.log(`overview.mdx: ${changed ? 'updated' : 'no changes'}`);
+}
+
+// ---------------------------------------------------------------------------
+// Generate: catalog.json
+// ---------------------------------------------------------------------------
+
+{
+  const catalogJson = {
+    generated: new Date().toISOString(),
+    counts: {
+      agents: agents.length,
+      skills: skills.length,
+      workflows: workflows.length,
+      protocols: protocols.length,
+      sensors: sensors.length,
+      routines: routines.length,
+    },
+    agents: agents.map((a) => ({
+      name: a.name,
+      display_name: a.display_name || displayName(a.name),
+      description: a.description,
+      defaults: a.defaults || {},
+    })),
+    skills: skills.map((s) => ({
+      name: s.name,
+      description: s.description,
+      agents: s.agents,
+      ...(s.triggers ? { triggers: s.triggers } : {}),
+    })),
+    workflows: workflows.map((w) => ({
+      name: w.name,
+      description: w.description,
+      agents: w.agents,
+      ...(w.triggers ? { triggers: w.triggers } : {}),
+    })),
+    protocols: protocols.map((p) => ({
+      name: p.name,
+      description: p.description,
+      agents: p.agents,
+      required: p.required || null,
+    })),
+    sensors: sensors.map((s) => ({
+      name: s.name,
+      description: s.description,
+      agents: s.agents,
+      event: s.event,
+      matcher: s.matcher || null,
+      required: s.required || null,
+    })),
+    routines: routines.map((r) => ({
+      name: r.name,
+      description: r.description,
+      agents: r.agents,
+      frequency: r.frequency,
+    })),
+  };
+
+  const outPath = path.join(PUBLIC_DIR, 'catalog.json');
+  fs.writeFileSync(outPath, JSON.stringify(catalogJson, null, 2) + '\n', 'utf8');
+  console.log(`catalog.json: written to ${path.relative(WEBSITE_DIR, outPath)}`);
+}
+
+console.log('\nDone.');

--- a/website/src/content/docs/catalog/agent-types.mdx
+++ b/website/src/content/docs/catalog/agent-types.mdx
@@ -7,11 +7,12 @@ import { Aside } from '@astrojs/starlight/components';
 
 Bonsai ships with 6 agent types, each specialized for a different role. One orchestrates; the rest execute.
 
+{/* AGENT-DEFAULTS-START */}
 ## The Orchestrator
 
 ### Tech Lead Agent
 
-**Description:** Architects the system, writes plans, reviews agent output — never writes application code.
+**Description:** Architects the system, writes plans, reviews agent output — never writes application code
 
 **Best for:** Project leads who need an agent that plans features, dispatches work to code agents, and reviews their output.
 
@@ -35,7 +36,7 @@ Code agents execute plans created by the Tech Lead. Each has domain-specific ski
 
 ### Backend Agent
 
-**Description:** Executes backend plans — API, database, server-side logic.
+**Description:** Executes backend plans — API, database, server-side logic
 
 **Best for:** API development, database work, server-side business logic, and backend infrastructure.
 
@@ -49,9 +50,25 @@ Code agents execute plans created by the Tech Lead. Each has domain-specific ski
 
 ---
 
+### DevOps Agent
+
+**Description:** Manages infrastructure-as-code, CI/CD pipelines, containers, and deployment automation
+
+**Best for:** Terraform, Docker, Kubernetes, CI/CD pipelines, and deployment configuration.
+
+| Category | Defaults |
+|:---------|:---------|
+| **Skills** | coding-standards, iac-conventions, container-standards |
+| **Workflows** | plan-execution, reporting, session-logging, security-audit |
+| **Protocols** | session-start, security, scope-boundaries |
+| **Sensors** | session-context, scope-guard-files, iac-safety-guard |
+| **Routines** | dependency-audit, infra-drift-check |
+
+---
+
 ### Frontend Agent
 
-**Description:** Executes frontend plans — UI components, state management, styling.
+**Description:** Executes frontend plans — UI components, state management, styling
 
 **Best for:** UI component development, state management, CSS/styling, and frontend architecture.
 
@@ -67,7 +84,7 @@ Code agents execute plans created by the Tech Lead. Each has domain-specific ski
 
 ### Full-Stack Agent
 
-**Description:** Implements full-stack features end-to-end — UI, API routes, database, auth, tests.
+**Description:** Implements full-stack features end-to-end — UI, API routes, database, auth, tests
 
 **Best for:** Features that span the entire stack, when you want one agent handling frontend through database.
 
@@ -81,25 +98,9 @@ Code agents execute plans created by the Tech Lead. Each has domain-specific ski
 
 ---
 
-### DevOps Agent
-
-**Description:** Manages infrastructure-as-code, CI/CD pipelines, containers, and deployment automation.
-
-**Best for:** Terraform, Docker, Kubernetes, CI/CD pipelines, and deployment configuration.
-
-| Category | Defaults |
-|:---------|:---------|
-| **Skills** | coding-standards, iac-conventions, container-standards |
-| **Workflows** | plan-execution, reporting, session-logging, security-audit |
-| **Protocols** | session-start, security, scope-boundaries |
-| **Sensors** | session-context, scope-guard-files, iac-safety-guard |
-| **Routines** | dependency-audit, infra-drift-check |
-
----
-
 ### Security Agent
 
-**Description:** Audits code for vulnerabilities, reviews auth patterns, scans dependencies, enforces security standards.
+**Description:** Audits code for vulnerabilities, reviews auth patterns, scans dependencies, enforces security standards
 
 **Best for:** Security audits, vulnerability scanning, dependency review, and auth pattern enforcement.
 
@@ -110,6 +111,7 @@ Code agents execute plans created by the Tech Lead. Each has domain-specific ski
 | **Protocols** | session-start, security, scope-boundaries |
 | **Sensors** | session-context, scope-guard-files, scope-guard-commands, api-security-check |
 | **Routines** | vulnerability-scan, dependency-audit |
+{/* AGENT-DEFAULTS-END */}
 
 ---
 

--- a/website/src/content/docs/catalog/overview.mdx
+++ b/website/src/content/docs/catalog/overview.mdx
@@ -9,9 +9,10 @@ The Bonsai catalog is the embedded collection of agents, abilities, and automati
 
 ## What's in the Catalog
 
+{/* CATALOG-COUNTS-START */}
 <CardGrid>
   <Card title="Agent Types" icon="rocket">
-    **6 agents** — Tech Lead, Backend, Frontend, Full-Stack, DevOps, Security. Each has a specialized identity, defaults, and role.
+    **6 agents** — Backend Agent, DevOps Agent, Frontend Agent, Full-Stack Agent, Security Agent, Tech Lead Agent. Each has a specialized identity, defaults, and role.
 
     [Browse agent types](/Bonsai/catalog/agent-types/)
   </Card>
@@ -41,6 +42,7 @@ The Bonsai catalog is the embedded collection of agents, abilities, and automati
     [Browse routines](/Bonsai/catalog/routines/)
   </Card>
 </CardGrid>
+{/* CATALOG-COUNTS-END */}
 
 ## How to Browse the Catalog
 

--- a/website/src/content/docs/catalog/protocols.mdx
+++ b/website/src/content/docs/catalog/protocols.mdx
@@ -13,12 +13,14 @@ All 4 protocols are **required for all agent types**. They are auto-installed du
 
 ## All Protocols
 
+{/* CATALOG-TABLE-START */}
 | Name | Description | Required |
 |:-----|:-----------|:---------|
-| memory | How to read, write, and maintain working memory between sessions | Yes (all agents) |
-| scope-boundaries | What you own, what you never touch, workspace boundaries | Yes (all agents) |
-| security | Security enforcement — hard stops and hard enforcers | Yes (all agents) |
-| session-start | Ordered startup sequence — what to read and check every session | Yes (all agents) |
+| memory | How to read, write, and maintain working memory between sessions | Yes (all) |
+| scope-boundaries | What you own, what you never touch, workspace boundaries | Yes (all) |
+| security | Security enforcement — hard stops and hard enforcers | Yes (all) |
+| session-start | Ordered startup sequence — what to read and check every session | Yes (all) |
+{/* CATALOG-TABLE-END */}
 
 ## Protocol Details
 

--- a/website/src/content/docs/catalog/routines.mdx
+++ b/website/src/content/docs/catalog/routines.mdx
@@ -13,6 +13,7 @@ Most routines are currently designed for the **Tech Lead** agent, which manages 
 
 ## All Routines
 
+{/* CATALOG-TABLE-START */}
 | Name | Description | Frequency | Compatible Agents |
 |:-----|:-----------|:----------|:-----------------|
 | backlog-hygiene | Review and maintain Playbook/Backlog.md — flag stale items, escalate P0s, cross-reference with Status and Roadmap | 7 days | tech-lead |
@@ -23,6 +24,7 @@ Most routines are currently designed for the **Tech Lead** agent, which manages 
 | roadmap-accuracy | Ensure Playbook/Roadmap.md reflects what's actually built and what's actually next | 14 days | tech-lead |
 | status-hygiene | Keep Playbook/Status.md clean — archive old Done items, validate Pending items | 5 days | tech-lead |
 | vulnerability-scan | SAST scan, secrets scan, and dependency audit — flag new, resolved, and persistent vulnerabilities | 7 days | tech-lead |
+{/* CATALOG-TABLE-END */}
 
 ## Routine Details
 

--- a/website/src/content/docs/catalog/sensors.mdx
+++ b/website/src/content/docs/catalog/sensors.mdx
@@ -13,20 +13,22 @@ Sensors marked as **required** are auto-installed for all compatible agents and 
 
 ## All Sensors
 
+{/* CATALOG-TABLE-START */}
 | Name | Description | Event | Matcher | Compatible Agents | Required |
 |:-----|:-----------|:------|:--------|:-----------------|:---------|
-| context-guard | Injects context-aware behavioral constraints and detects session wrap-up trigger words before each prompt | UserPromptSubmit | | all | Yes (all) |
-| scope-guard-files | Blocks agent from editing files outside its workspace | PreToolUse | Edit\|Write | all | Yes (all) |
-| session-context | Injects core identity, memory, protocols, and project status at session start | SessionStart | | all | Yes (all) |
-| status-bar | Persistent status line showing context usage, session health, and git state after every response | Stop | | all | Yes (all) |
-| routine-check | Checks routine dashboard at session start and flags overdue maintenance routines | SessionStart | | all | Auto-managed |
-| scope-guard-commands | Blocks agent from running application execution commands (tests, builds, servers) | PreToolUse | Bash | security, tech-lead | No |
-| dispatch-guard | Validates code agent dispatches — requires worktree isolation, plan reference, and plan existence before execution | PreToolUse | Agent | tech-lead | No |
 | agent-review | Outputs a review checklist after a dispatched agent completes work | PostToolUse | Agent | tech-lead | No |
-| subagent-stop-review | Outputs a structured review checklist when a dispatched agent finishes work | SubagentStop | | tech-lead | No |
-| api-security-check | Detects security anti-patterns in code changes — SQL injection, hardcoded secrets, eval, CORS wildcards | PreToolUse | Edit\|Write | backend, fullstack, security | No |
+| api-security-check | Detects security anti-patterns in code changes — SQL injection, hardcoded secrets, eval, CORS wildcards | PreToolUse | Edit|Write | backend, fullstack, security | No |
+| context-guard | Injects context-aware behavioral constraints and detects session wrap-up trigger words before each prompt | UserPromptSubmit |  | all | Yes (all) |
+| dispatch-guard | Validates code agent dispatches — requires worktree isolation, plan reference, and plan existence before execution | PreToolUse | Agent | tech-lead | No |
 | iac-safety-guard | Blocks dangerous infrastructure commands — terraform destroy, kubectl delete namespace, unsafe docker ops | PreToolUse | Bash | devops | No |
-| test-integrity-guard | Detects test quality issues — removed assertions, .skip/.only, empty test bodies, debug artifacts | PreToolUse | Edit\|Write | backend, frontend, fullstack | No |
+| routine-check | Checks routine dashboard at session start and flags overdue maintenance routines | SessionStart |  | all | Auto-managed |
+| scope-guard-commands | Blocks agent from running application execution commands (tests, builds, servers) | PreToolUse | Bash | security, tech-lead | No |
+| scope-guard-files | Blocks agent from editing files outside its workspace | PreToolUse | Edit|Write | all | Yes (all) |
+| session-context | Injects core identity, memory, protocols, and project status at session start | SessionStart |  | all | Yes (all) |
+| status-bar | Persistent status line showing context usage, session health, and git state after every response | Stop |  | all | Yes (all) |
+| subagent-stop-review | Outputs a structured review checklist when a dispatched agent finishes work | SubagentStop |  | tech-lead | No |
+| test-integrity-guard | Detects test quality issues — removed assertions, .skip/.only, empty test bodies, debug artifacts | PreToolUse | Edit|Write | backend, frontend, fullstack | No |
+{/* CATALOG-TABLE-END */}
 
 ## Sensors by Function
 

--- a/website/src/content/docs/catalog/skills.mdx
+++ b/website/src/content/docs/catalog/skills.mdx
@@ -9,6 +9,7 @@ Skills are domain knowledge files that agents load as reference material when do
 
 ## All Skills
 
+{/* CATALOG-TABLE-START */}
 | Name | Description | Compatible Agents |
 |:-----|:-----------|:-----------------|
 | api-design-standards | REST API design conventions — URLs, methods, errors, pagination, versioning | backend, fullstack, tech-lead |
@@ -17,17 +18,18 @@ Skills are domain knowledge files that agents load as reference material when do
 | coding-standards | Language-specific coding standards — formatting, linting, patterns | backend, devops, frontend, fullstack, security |
 | container-standards | Container and orchestration standards — Docker multi-stage builds, image security, Kubernetes manifests | devops |
 | database-conventions | SQL naming, migration patterns, schema design rules | backend, fullstack, tech-lead |
-| design-guide | UI/UX design patterns, component conventions, accessibility rules | frontend, fullstack |
+| design-guide | Bonsai CLI design system — palette, spacing, panels, errors, command flow | backend, frontend, fullstack, tech-lead |
 | dispatch | How to dispatch work to code agents — triage rules, prompt structure, iteration tracking | tech-lead |
 | iac-conventions | Infrastructure-as-code conventions — Terraform naming, state management, modules, tagging | devops |
 | issue-classification | Issue types, importance levels, domain labels, and classification heuristics | tech-lead |
 | mobile-patterns | Mobile development patterns — state management, offline-first, navigation, performance | fullstack |
 | planning-template | Plan format, tier rules, and template for writing implementation plans | tech-lead |
-| pr-creation | How to create well-structured pull requests — branch naming, title conventions, body template, draft workflow | tech-lead, fullstack, backend, frontend |
-| review-checklist | Structured code review checklist — correctness, security, performance, maintainability | security, tech-lead |
-| test-strategy | Test architecture — which tests to write, when, and why; pyramid, coverage, anti-patterns | backend, frontend, fullstack |
+| pr-creation | How to create well-structured pull requests — branch naming, title conventions, body template, draft workflow | backend, frontend, fullstack, tech-lead |
+| review-checklist | Structured code review checklist — correctness, security, performance, maintainability | reviewer, security, tech-lead |
+| test-strategy | Test architecture — which tests to write, when, and why; pyramid, coverage, anti-patterns | backend, frontend, fullstack, qa |
 | testing | Testing conventions — frameworks, patterns, coverage requirements | backend, frontend, fullstack, security |
 | workspace-guide | Bonsai workspace operational guide — how to use workflows, skills, routines, sensors, and the Playbook effectively | all |
+{/* CATALOG-TABLE-END */}
 
 ## Skills by Domain
 

--- a/website/src/content/docs/catalog/workflows.mdx
+++ b/website/src/content/docs/catalog/workflows.mdx
@@ -9,18 +9,20 @@ Workflows are step-by-step procedures that agents follow when performing multi-s
 
 ## All Workflows
 
+{/* CATALOG-TABLE-START */}
 | Name | Description | Compatible Agents | Slash Command |
 |:-----|:-----------|:-----------------|:-------------|
-| api-development | Spec-first API development — define contract, generate scaffolding, implement, test, document | backend, fullstack | |
+| api-development | Spec-first API development — define contract, generate scaffolding, implement, test, document | backend, fullstack |  |
 | code-review | Review agent output against the plan — correctness, standards, security | security, tech-lead | `/code-review` |
 | issue-to-implementation | End-to-end autonomous workflow — issue intake, analysis, research, planning, agent dispatch, review loop, logging, audit, and close | tech-lead | `/issue-to-implementation` |
 | plan-execution | Execute an assigned plan step by step — implement, test, report | backend, devops, frontend, fullstack | `/plan-execution` |
 | planning | End-to-end planning process — from request to dispatch-ready plan | tech-lead | `/planning` |
 | pr-review | Review a pull request — context, scope, correctness, security, performance, standards | tech-lead | `/pr-review` |
-| reporting | Completion report format — what was done, tested, issues encountered | backend, devops, frontend, fullstack, security | |
+| reporting | Completion report format — what was done, tested, issues encountered | backend, devops, frontend, fullstack, security |  |
 | security-audit | Security audit — secrets scan, dependency audit, SAST, config review, access control, infrastructure | devops, security, tech-lead | `/security-audit` |
-| session-logging | End-of-session log — what was done, decisions made, open items | all | |
+| session-logging | End-of-session log — what was done, decisions made, open items | all |  |
 | test-plan | Design a structured test plan for a feature — scope, prioritize, allocate test types | tech-lead | `/test-plan` |
+{/* CATALOG-TABLE-END */}
 
 ## Slash Commands
 


### PR DESCRIPTION
## Summary
Add a catalog generation script that reads `catalog/*/meta.yaml` source files and auto-generates data tables in the docs site catalog pages, plus a machine-readable `catalog.json`. Configure the `starlight-llms-txt` plugin with curated Bonsai-specific content and 4 custom topic bundles.

## Changes
- `website/scripts/generate-catalog.mjs` — Node.js script that reads all catalog meta.yaml/agent.yaml files, regenerates tables between MDX marker comments in 7 catalog pages, and outputs `public/catalog.json`
- `website/package.json` — Added `generate:catalog` npm script
- `website/astro.config.mjs` — Configured `starlightLlmsTxt()` with project name, description, details, and 4 custom sets (Concepts, Commands, Catalog, Configuration)
- `website/public/catalog.json` — Generated JSON dump of all 57 catalog items with full metadata
- `website/src/content/docs/catalog/*.mdx` — Added `{/* CATALOG-TABLE-START/END */}` markers around data tables; fixed data drift in skills.mdx (design-guide description/agents, review-checklist agents, test-strategy agents); sorted sensor table alphabetically

## Plan
Plan 10, Phase C: station/Playbook/Plans/Active/10-docs-site.md

## Verification
- [x] `npm run generate:catalog` — runs cleanly, reports 57 items
- [x] `npm run build` — builds without errors (45 pages, all links valid)
- [x] Catalog tables match source meta.yaml (design-guide, review-checklist, test-strategy drift fixed)
- [x] catalog.json contains all 57 items (6 agents + 17 skills + 10 workflows + 4 protocols + 12 sensors + 8 routines)
- [x] llms.txt has curated Bonsai content (custom description, install instructions, agent types)
- [x] Custom set bundles generated: `_llms-txt/concepts.txt`, `commands.txt`, `catalog.txt`, `configuration.txt`
- [x] Script is idempotent — second run produces no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)