### PR TITLE
docs: deployment pipeline and cross-references (Plan 10 Phase D)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'website/**'
       - 'catalog/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'HANDBOOK.md'
   workflow_dispatch:
 
 permissions:
@@ -30,6 +33,9 @@ jobs:
           cache-dependency-path: website/package-lock.json
 
       - run: npm ci
+        working-directory: website
+
+      - run: npm run generate:catalog
         working-directory: website
 
       - run: npm run build

--- a/HANDBOOK.md
+++ b/HANDBOOK.md
@@ -1,5 +1,7 @@
 # Bonsai Handbook
 
+> **Note:** The latest version of this handbook is at [laststep.github.io/Bonsai](https://laststep.github.io/Bonsai/concepts/how-bonsai-works/).
+
 A guide to understanding and using the agent workspaces Bonsai generates. If you haven't installed Bonsai yet, start with the [README](README.md).
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation
+
+The source files in this directory are migrated to the documentation site.
+
+**Visit the docs: [laststep.github.io/Bonsai](https://laststep.github.io/Bonsai/)**
+
+For the Starlight source, see [`website/`](../website/).

--- a/docs/custom-files.md
+++ b/docs/custom-files.md
@@ -155,3 +155,7 @@ After running `bonsai update`, the workflow appears in:
 | Re-renderable | Yes — templates re-rendered on update | No — your file is yours, never overwritten |
 | Tracked in config | Item name in skills/workflows/etc. list | Item name in list + metadata in `custom_items` |
 | Lock source | `catalog:skills/name` | `custom:skills/name` |
+
+---
+
+> **Full documentation:** For comprehensive guides on creating custom abilities, visit [laststep.github.io/Bonsai](https://laststep.github.io/Bonsai/guides/creating-custom-skills/).


### PR DESCRIPTION
## Summary
Add GitHub Pages deployment workflow and cross-reference updates for the docs site (Plan 10 Phase D).

## Changes
- `.github/workflows/docs.yml` — GitHub Actions workflow for auto-deploying docs on push to main
- `docs/README.md` — Redirect notice pointing to the live docs site
- `docs/custom-files.md` — Added docs site URL footer (shown by `bonsai guide`)
- `HANDBOOK.md` — Added redirect note to live docs site

## Plan
station/Playbook/Plans/Active/10-docs-site.md — Phase D

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `cd website && npm run build` — passes
- [x] `.github/workflows/docs.yml` — valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)