### PR TITLE
feat(ui): Phase 2 consistency — ordering, counts, hints, Up to date, ErrorDetail

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -85,7 +85,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	// Require tech-lead before adding other agents
 	if agentType != "tech-lead" {
 		if _, hasTechLead := cfg.Agents["tech-lead"]; !hasTechLead {
-			tui.ErrorPanel("Tech Lead agent must be installed first.\nRun bonsai init to set up your project with Tech Lead.")
+			tui.ErrorDetail("Tech Lead required", "No tech-lead agent is installed yet.", "Run: bonsai init")
 			return nil
 		}
 	}
@@ -225,6 +225,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	showWriteResults(&wr, workspace)
 
 	tui.Success(fmt.Sprintf("Added %s at %s", agentDef.DisplayName, workspace))
+	tui.Hint("Run: bonsai list to see your full setup.")
 	tui.Blank()
 	return nil
 }
@@ -289,7 +290,7 @@ func runAddItems(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog
 
 	totalAvailable := len(newSkills) + len(newWorkflows) + len(newProtocols) + len(newSensors) + len(newRoutines)
 	if totalAvailable == 0 {
-		tui.SuccessPanel("All available abilities are already installed.", "")
+		tui.EmptyPanel("All available abilities are already installed.\nBrowse more with: bonsai catalog")
 		return nil
 	}
 
@@ -393,6 +394,7 @@ func runAddItems(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog
 	showWriteResults(&wr, installed.Workspace)
 
 	tui.Success(fmt.Sprintf("Added %d abilities to %s", totalSelected, agentDef.DisplayName))
+	tui.Hint("Run: bonsai list to see your full setup.")
 	tui.Blank()
 	return nil
 }

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/LastStep/Bonsai/internal/tui"
@@ -22,24 +24,23 @@ func runCatalog(cmd *cobra.Command, args []string) error {
 	agentFilter, _ := cmd.Flags().GetString("agent")
 
 	// Agents
-	tui.SectionHeader("Agents")
+	tui.SectionHeader(fmt.Sprintf("Agents (%d)", len(cat.Agents)))
 	var agentRows [][]string
 	for _, a := range cat.Agents {
 		agentRows = append(agentRows, []string{a.DisplayName, a.Description})
 	}
 	tui.CatalogTable([]string{"Name", "Description"}, agentRows)
 
-	suffix := ""
-	if agentFilter != "" {
-		suffix = " " + tui.StyleMuted.Render("(for "+agentFilter+")")
-	}
-
 	// Skills
 	skills := cat.Skills
 	if agentFilter != "" {
 		skills = cat.SkillsFor(agentFilter)
 	}
-	tui.SectionHeader("Skills" + suffix)
+	skillsSuffix := fmt.Sprintf(" (%d)", len(skills))
+	if agentFilter != "" {
+		skillsSuffix = fmt.Sprintf(" (%d for %s)", len(skills), agentFilter)
+	}
+	tui.SectionHeader("Skills" + skillsSuffix)
 	var skillRows [][]string
 	for _, s := range skills {
 		skillRows = append(skillRows, []string{s.DisplayName, s.Description, s.Agents.String(), s.Required.String()})
@@ -51,7 +52,11 @@ func runCatalog(cmd *cobra.Command, args []string) error {
 	if agentFilter != "" {
 		workflows = cat.WorkflowsFor(agentFilter)
 	}
-	tui.SectionHeader("Workflows" + suffix)
+	workflowsSuffix := fmt.Sprintf(" (%d)", len(workflows))
+	if agentFilter != "" {
+		workflowsSuffix = fmt.Sprintf(" (%d for %s)", len(workflows), agentFilter)
+	}
+	tui.SectionHeader("Workflows" + workflowsSuffix)
 	var wfRows [][]string
 	for _, w := range workflows {
 		wfRows = append(wfRows, []string{w.DisplayName, w.Description, w.Agents.String(), w.Required.String()})
@@ -63,7 +68,11 @@ func runCatalog(cmd *cobra.Command, args []string) error {
 	if agentFilter != "" {
 		protocols = cat.ProtocolsFor(agentFilter)
 	}
-	tui.SectionHeader("Protocols" + suffix)
+	protocolsSuffix := fmt.Sprintf(" (%d)", len(protocols))
+	if agentFilter != "" {
+		protocolsSuffix = fmt.Sprintf(" (%d for %s)", len(protocols), agentFilter)
+	}
+	tui.SectionHeader("Protocols" + protocolsSuffix)
 	var protoRows [][]string
 	for _, p := range protocols {
 		protoRows = append(protoRows, []string{p.DisplayName, p.Description, p.Agents.String(), p.Required.String()})
@@ -75,7 +84,11 @@ func runCatalog(cmd *cobra.Command, args []string) error {
 	if agentFilter != "" {
 		sensors = cat.SensorsFor(agentFilter)
 	}
-	tui.SectionHeader("Sensors" + suffix)
+	sensorsSuffix := fmt.Sprintf(" (%d)", len(sensors))
+	if agentFilter != "" {
+		sensorsSuffix = fmt.Sprintf(" (%d for %s)", len(sensors), agentFilter)
+	}
+	tui.SectionHeader("Sensors" + sensorsSuffix)
 	var sensorRows [][]string
 	for _, s := range sensors {
 		event := s.Event
@@ -91,7 +104,11 @@ func runCatalog(cmd *cobra.Command, args []string) error {
 	if agentFilter != "" {
 		routines = cat.RoutinesFor(agentFilter)
 	}
-	tui.SectionHeader("Routines" + suffix)
+	routinesSuffix := fmt.Sprintf(" (%d)", len(routines))
+	if agentFilter != "" {
+		routinesSuffix = fmt.Sprintf(" (%d for %s)", len(routines), agentFilter)
+	}
+	tui.SectionHeader("Routines" + routinesSuffix)
 	var routineRows [][]string
 	for _, r := range routines {
 		routineRows = append(routineRows, []string{r.DisplayName, r.Description, r.Frequency, r.Agents.String(), r.Required.String()})
@@ -99,7 +116,7 @@ func runCatalog(cmd *cobra.Command, args []string) error {
 	tui.CatalogTable([]string{"Name", "Description", "Frequency", "Agents", "Required"}, routineRows)
 
 	// Scaffolding
-	tui.SectionHeader("Scaffolding")
+	tui.SectionHeader(fmt.Sprintf("Scaffolding (%d)", len(cat.Scaffolding)))
 	var scaffoldRows [][]string
 	for _, s := range cat.Scaffolding {
 		req := ""

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -59,7 +61,14 @@ func runList(cmd *cobra.Command, args []string) error {
 		return strings.Join(display, ", ")
 	}
 
-	for name, agent := range cfg.Agents {
+	agentNames := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		agentNames = append(agentNames, name)
+	}
+	sort.Strings(agentNames)
+
+	for _, name := range agentNames {
+		agent := cfg.Agents[name]
 		displayName := name
 		if agentDef := cat.GetAgent(name); agentDef != nil {
 			displayName = agentDef.DisplayName
@@ -111,6 +120,32 @@ func runList(cmd *cobra.Command, args []string) error {
 		tui.TitledPanel(displayName, content, tui.Water)
 	}
 
+	totalSkills, totalWorkflows, totalProtocols, totalSensors, totalRoutines := 0, 0, 0, 0, 0
+	for _, a := range cfg.Agents {
+		totalSkills += len(a.Skills)
+		totalWorkflows += len(a.Workflows)
+		totalProtocols += len(a.Protocols)
+		totalSensors += len(a.Sensors)
+		totalRoutines += len(a.Routines)
+	}
+
+	parts := []string{
+		pluralize(len(cfg.Agents), "agent", "agents"),
+		pluralize(totalSkills, "skill", "skills"),
+		pluralize(totalWorkflows, "workflow", "workflows"),
+		pluralize(totalProtocols, "protocol", "protocols"),
+		pluralize(totalSensors, "sensor", "sensors"),
+		pluralize(totalRoutines, "routine", "routines"),
+	}
+	fmt.Println("\n  " + tui.StyleMuted.Render(strings.Join(parts, " "+tui.GlyphDot+" ")))
+
 	tui.Blank()
 	return nil
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
 }

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -56,7 +56,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	// Prevent removing tech-lead while other agents depend on it
 	if agentName == "tech-lead" && len(cfg.Agents) > 1 {
-		tui.ErrorPanel("Cannot remove Tech Lead while other agents are installed.\nRemove other agents first.")
+		tui.ErrorDetail("Tech Lead in use", "Other agents depend on Tech Lead. Remove them first.", "Run: bonsai list")
 		return nil
 	}
 
@@ -197,7 +197,7 @@ type agentMatch struct {
 func runRemoveItem(name string, it itemType) error {
 	// Block auto-managed sensors
 	if it.singular == "sensor" && name == "routine-check" {
-		tui.ErrorPanel("routine-check is auto-managed.\nIt is added/removed automatically when routines change.")
+		tui.ErrorDetail("Auto-managed sensor", "routine-check is added and removed automatically when routines change.", "")
 		return nil
 	}
 
@@ -225,7 +225,7 @@ func runRemoveItem(name string, it itemType) error {
 	}
 
 	if len(matches) == 0 {
-		tui.ErrorPanel(fmt.Sprintf("%s %q is not installed in any agent.", it.singular, name))
+		tui.ErrorDetail(it.singular+" not installed", fmt.Sprintf("%q is not in any agent.", name), "Run: bonsai list")
 		return nil
 	}
 
@@ -269,7 +269,7 @@ func runRemoveItem(name string, it itemType) error {
 		}
 	}
 	if len(allowed) == 0 {
-		tui.ErrorPanel(fmt.Sprintf("%s is required and cannot be removed.", itemDisplayName(cat, name, it)))
+		tui.ErrorDetail("Required item", fmt.Sprintf("%s is required by all agents that have it.", itemDisplayName(cat, name, it)), "")
 		return nil
 	}
 	targets = allowed

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -179,6 +179,17 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		tui.Warning("Could not save lock file: " + err.Error())
 	}
 
+	created, updated, _, _, conflicts := wr.Summary()
+	hadChanges := configChanged || created > 0 || updated > 0 || conflicts > 0
+
+	if !hadChanges {
+		tui.TitledPanel("Up to date",
+			"Workspace is in sync with the catalog.\nNo files needed updating.",
+			tui.Moss)
+		tui.Blank()
+		return nil
+	}
+
 	showWriteResults(&wr, ".")
 
 	if configChanged {
@@ -186,6 +197,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	} else {
 		tui.Success("Update complete — workspace synced")
 	}
+	tui.Hint("Review changes with: bonsai list")
 	tui.Blank()
 	return nil
 }

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -139,11 +140,12 @@ var CuratedSlashWorkflows = map[string]bool{
 type FileAction int
 
 const (
-	ActionCreated  FileAction = iota // new file written
-	ActionUpdated                    // existing unmodified file overwritten
-	ActionSkipped                    // file already exists (scaffolding write-once)
-	ActionConflict                   // file modified by user, not overwritten
-	ActionForced                     // conflict overridden by user, overwritten
+	ActionCreated   FileAction = iota // new file written
+	ActionUpdated                     // existing unmodified file overwritten with new content
+	ActionUnchanged                   // existing file identical to rendered content — no write
+	ActionSkipped                     // file already exists (scaffolding write-once)
+	ActionConflict                    // file modified by user, not overwritten
+	ActionForced                      // conflict overridden by user, overwritten
 )
 
 // FileResult describes the outcome for one file.
@@ -187,13 +189,15 @@ func (wr *WriteResult) HasConflicts() bool {
 }
 
 // Summary returns counts by action type.
-func (wr *WriteResult) Summary() (created, updated, skipped, conflicts int) {
+func (wr *WriteResult) Summary() (created, updated, unchanged, skipped, conflicts int) {
 	for _, f := range wr.Files {
 		switch f.Action {
 		case ActionCreated:
 			created++
 		case ActionUpdated, ActionForced:
 			updated++
+		case ActionUnchanged:
+			unchanged++
 		case ActionSkipped:
 			skipped++
 		case ActionConflict:
@@ -272,6 +276,13 @@ func writeFile(projectRoot, relPath string, content []byte, source string, lock 
 
 	if modified && !force {
 		return FileResult{RelPath: relPath, Action: ActionConflict, Source: source, content: content}
+	}
+
+	// If file exists, is not user-modified, and content matches rendered output, skip the write.
+	if !modified {
+		if existing, err := os.ReadFile(absPath); err == nil && bytes.Equal(existing, content) {
+			return FileResult{RelPath: relPath, Action: ActionUnchanged, Source: source}
+		}
 	}
 
 	if err := os.WriteFile(absPath, content, 0644); err != nil {
@@ -814,6 +825,12 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 
 			fullContent := beforeMarkers + bonsaiStartMarker + "\n" + generatedContent + bonsaiEndMarker + afterMarkers
 			contentBytes := []byte(fullContent)
+
+			// Short-circuit if content is already identical
+			if bytes.Equal(existing, contentBytes) {
+				result.Add(FileResult{RelPath: relPath, Action: ActionUnchanged, Source: "generated:workspace-claude-md"})
+				return nil
+			}
 
 			if err := os.WriteFile(absPath, contentBytes, 0644); err != nil {
 				return err

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -189,12 +189,12 @@ func TestAgentWorkspaceUnmodifiedUpdate(t *testing.T) {
 	var wr1 WriteResult
 	_ = AgentWorkspace(tmpDir, agentDef, installed, cfg, cat, lock, &wr1, false)
 
-	// Run again — files are unmodified, should be Updated
+	// Run again — files are unmodified and content matches, should be Unchanged
 	var wr2 WriteResult
 	_ = AgentWorkspace(tmpDir, agentDef, installed, cfg, cat, lock, &wr2, false)
 	for _, f := range wr2.Files {
-		if f.Action != ActionUpdated {
-			t.Errorf("file %s action = %d, want Updated", f.RelPath, f.Action)
+		if f.Action != ActionUnchanged {
+			t.Errorf("file %s action = %d, want Unchanged", f.RelPath, f.Action)
 		}
 	}
 }
@@ -360,7 +360,7 @@ func TestWriteResultSummary(t *testing.T) {
 			{Action: ActionForced},
 		},
 	}
-	created, updated, skipped, conflicts := wr.Summary()
+	created, updated, _, skipped, conflicts := wr.Summary()
 	if created != 2 {
 		t.Errorf("created = %d, want 2", created)
 	}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -183,6 +183,19 @@ func FatalPanel(title, detail, hint string) {
 	os.Exit(1)
 }
 
+// ErrorDetail renders a structured non-fatal error. Same shape as FatalPanel but does not exit.
+// title: what happened (bold, error color). detail: why. hint: how to fix (muted).
+func ErrorDetail(title, detail, hint string) {
+	content := StyleError.Bold(true).Render(title)
+	if detail != "" {
+		content += "\n" + detail
+	}
+	if hint != "" {
+		content += "\n" + StyleMuted.Render(hint)
+	}
+	fmt.Println("\n" + indent(PanelError.Render(content), 2))
+}
+
 // WarningPanel renders a yellow-bordered panel.
 func WarningPanel(msg string) {
 	fmt.Println("\n" + indent(PanelWarning.Render(msg), 2))


### PR DESCRIPTION
## Summary
Closes Plan 12 — UI/UX Overhaul Phase 2 (Consistency).

Brings deterministic ordering, count badges, next-step hints on mutations, "Up to date" detection in `update`, structured non-fatal errors, and an empty-state panel in `add` — closing the seven consistency gaps from Plan 11 Phase 2 follow-up and RESEARCH-uiux-overhaul.md §9.

## Changes
- `cmd/list.go` — sort agents alphabetically; add summary line + `pluralize` helper
- `cmd/catalog.go` — section header counts (`Skills (12)`, `Skills (8 for backend)`)
- `cmd/add.go` — next-step hint on both add flows; `EmptyPanel` for all-installed; migrate tech-lead-required `ErrorPanel` to `ErrorDetail`
- `cmd/update.go` — next-step hint on success; "Up to date" panel for no-op runs
- `cmd/remove.go` — migrate four `ErrorPanel` callsites to `ErrorDetail`
- `internal/tui/styles.go` — new `ErrorDetail(title, detail, hint)` helper
- `internal/generate/generate.go` — `ActionUnchanged` enum value; content-equality short-circuit in `writeFile` and `WorkspaceClaudeMD`; `Summary()` adds `unchanged` return
- `internal/generate/generate_test.go` — update Summary() destructure; update `TestAgentWorkspaceUnmodifiedUpdate` to assert new `ActionUnchanged` semantic

## Plan
station/Playbook/Plans/Active/12-uiux-overhaul-phase2.md

## Verification
- [x] go build ./... — passes
- [x] go vet ./... — clean
- [x] gofmt -s -l . — clean
- [x] go test ./... — passes
- [x] go mod tidy — no changes
- [x] manual: `bonsai catalog` headers show counts (`Agents (6)`, `Skills (17)`, etc.)
- [x] manual: `bonsai catalog --agent backend` shows `Skills (10 for backend)` format
- [x] manual: `bonsai list` shows deterministic output and trailing summary line (`1 agent · 4 skills · …`)
- [ ] manual: `bonsai update` no-op "Up to date" panel — unit test `TestAgentWorkspaceUnmodifiedUpdate` covers the generator-level short-circuit; full end-to-end no-op run in a clean project not reproduced in this worktree (dogfooded station has prior conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)