### PR TITLE
fix(build): lowercase go install binary via cmd/bonsai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Binary
-bonsai
-bonsai.exe
-Bonsai
+/bonsai
+/bonsai.exe
+/Bonsai
 
 # GoReleaser
 dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,7 +4,7 @@ project_name: bonsai
 
 builds:
   - id: bonsai
-    main: .
+    main: ./cmd/bonsai
     binary: bonsai
     env:
       - CGO_ENABLED=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ When you discover bugs, improvement ideas, tech debt, or feature requests outsid
 ```bash
 make build             # builds ./bonsai binary
 ./bonsai --help        # verify CLI works
-go install .           # install to $GOPATH/bin
+go install ./cmd/bonsai    # install to $GOPATH/bin
 ```
 
 ### Testing changes to abilities

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ VERSION ?= dev
 LDFLAGS := -s -w -X main.version=$(VERSION)
 
 build:
-	go build -ldflags "$(LDFLAGS)" -o bonsai .
+	go build -ldflags "$(LDFLAGS)" -o bonsai ./cmd/bonsai
 
 install:
-	go install -ldflags "$(LDFLAGS)" .
+	go install -ldflags "$(LDFLAGS)" ./cmd/bonsai
 
 clean:
 	rm -f bonsai

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ sudo mv bonsai /usr/local/bin/
 **From source** (Go 1.24+):
 
 ```bash
-go install github.com/LastStep/Bonsai@latest
+go install github.com/LastStep/Bonsai/cmd/bonsai@latest
 ```
 
 ---

--- a/cmd/bonsai/main.go
+++ b/cmd/bonsai/main.go
@@ -1,29 +1,23 @@
 package main
 
 import (
-	"embed"
 	"fmt"
 	"io/fs"
 	"os"
 
+	bonsai "github.com/LastStep/Bonsai"
 	"github.com/LastStep/Bonsai/cmd"
 )
 
 // version is set via ldflags at build time.
 var version = "dev"
 
-//go:embed all:catalog
-var catalogFS embed.FS
-
-//go:embed docs/custom-files.md
-var guideContent string
-
 func main() {
-	sub, err := fs.Sub(catalogFS, "catalog")
+	sub, err := fs.Sub(bonsai.CatalogFS, "catalog")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 	cmd.SetVersion(version)
-	cmd.Execute(sub, guideContent)
+	cmd.Execute(sub, bonsai.GuideContent)
 }

--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,12 @@
+// Package bonsai exposes the embedded catalog and guide content used by the
+// bonsai CLI. It exists so //go:embed directives stay at the repo root, where
+// the embedded paths (catalog/, docs/custom-files.md) live.
+package bonsai
+
+import "embed"
+
+//go:embed all:catalog
+var CatalogFS embed.FS
+
+//go:embed docs/custom-files.md
+var GuideContent string


### PR DESCRIPTION
## Summary

Fix `go install` producing a `Bonsai` (capital) binary that Linux's case-sensitive PATH can't resolve. Move `main.go` to `cmd/bonsai/main.go` so the install path is `github.com/LastStep/Bonsai/cmd/bonsai@latest`, yielding a `bonsai` (lowercase) binary.

**BREAKING:** install command changes. Old: `go install github.com/LastStep/Bonsai@latest`. New: `go install github.com/LastStep/Bonsai/cmd/bonsai@latest`. Homebrew and binary downloads are unaffected.

## Changes

- `embed.go` (new) — root library package holding `//go:embed` directives (required because `//go:embed` can't use `..` paths)
- `cmd/bonsai/main.go` (new) — thin main wrapper importing the root library
- `main.go` (deleted) — responsibilities split between the two new files
- `Makefile` — build/install targets point to `./cmd/bonsai`
- `.goreleaser.yaml` — `main: ./cmd/bonsai`
- `README.md` — updated `go install` command
- `CLAUDE.md` (repo root) — updated dev install command
- `.gitignore` — anchored binary patterns (`/bonsai`, `/bonsai.exe`, `/Bonsai`) to the repo root so the new `cmd/bonsai/` source directory is not ignored

## Plan

`station/Playbook/Plans/Active/16-go-install-binary-name.md`

## Verification

- [x] `make build` — passes; produces `./bonsai`
- [x] `./bonsai --version` — prints version (`bonsai version dev`)
- [x] `./bonsai --help` — lists subcommands
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean
- [x] `go install ./cmd/bonsai` — installs `bonsai` to `$GOPATH/bin` (verified `/home/rohan/go/bin/bonsai`, lowercase)
- [x] `git grep "Bonsai@latest"` — no matches
- [ ] `goreleaser build --snapshot --clean --single-target` — skipped; goreleaser not installed locally. CI will exercise on next tag.