### PR TITLE
Plan 19 — pre-launch bug sweep (fresh-install blockers + harness polish)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Force LF on anything that ends up in a generated shell hook or gets shelled out.
+*.sh         text eol=lf
+*.sh.tmpl    text eol=lf
+
+# Keep lockfiles + generated-preview goldens predictable across checkouts.
+go.sum       text eol=lf
+*.yaml       text eol=lf

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -144,13 +144,12 @@ func runAdd(cmd *cobra.Command, args []string) error {
 			}
 			// Require tech-lead before adding other agents. The user can still
 			// pick "tech-lead" here to bootstrap — we only block when the pick
-			// is a non-tech-lead agent and no tech-lead is installed yet.
+			// is a non-tech-lead agent and no tech-lead is installed yet. The
+			// error surfaces post-harness on stdout (see ErrorDetail below) so
+			// it persists after AltScreen exits — no in-harness NoteStep.
 			if agentType != "tech-lead" {
 				if _, hasTechLead := cfg.Agents["tech-lead"]; !hasTechLead {
-					return []harness.Step{harness.NewNote(
-						"Tech Lead required",
-						"No tech-lead agent is installed yet.\nRun: bonsai init to set up a Tech Lead workspace first.",
-					)}
+					return nil
 				}
 			}
 			return buildNewAgentSteps(cat, cfg, agentType, existingWorkspaces)
@@ -260,7 +259,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		tui.Warning("Could not save lock file: " + err.Error())
 	}
 
-	showWriteResults(&wr, addOutcome.workspace)
+	showWriteResults(&wr)
 
 	if addOutcome.newAgent {
 		tui.Success(fmt.Sprintf("Added %s at %s", addOutcome.agentDef.DisplayName, addOutcome.workspace))
@@ -331,10 +330,15 @@ func runAddSpinner(prev []any, cwd, configPath string, cfg *config.ProjectConfig
 			return err
 		}
 
-		_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, wr, false)
-		_ = generate.PathScopedRules(cwd, cfg, cat, lock, wr, false)
-		_ = generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false)
-		_ = generate.SettingsJSON(cwd, cfg, cat, lock, wr, false)
+		var errs []error
+		errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+		if joined := errors.Join(errs...); joined != nil {
+			outcome.spinnerErr = joined
+			return joined
+		}
 
 		outcome.workspace = installed.Workspace
 		outcome.totalSelected = totalSelected
@@ -372,10 +376,15 @@ func runAddSpinner(prev []any, cwd, configPath string, cfg *config.ProjectConfig
 		return err
 	}
 
-	_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, wr, false)
-	_ = generate.PathScopedRules(cwd, cfg, cat, lock, wr, false)
-	_ = generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false)
-	_ = generate.SettingsJSON(cwd, cfg, cat, lock, wr, false)
+	var errs []error
+	errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, wr, false))
+	errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, wr, false))
+	errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false))
+	errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+	if joined := errors.Join(errs...); joined != nil {
+		outcome.spinnerErr = joined
+		return joined
+	}
 
 	outcome.workspace = workspace
 	outcome.newAgent = true

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -194,15 +194,19 @@ func runInit(cmd *cobra.Command, args []string) error {
 						Scaffolding: selectedScaffolding,
 						Agents:      map[string]*config.InstalledAgent{techLeadType: installed},
 					}
+					// Save .bonsai.yaml first — Scaffolding depends on it
+					// existing, and early-returning here leaves no partial
+					// config on disk if Save fails.
 					if err := cfg.Save(configPath); err != nil {
 						return err
 					}
-					_ = generate.Scaffolding(cwd, cfg, cat, lock, &wr, false)
-					_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false)
-					_ = generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false)
-					_ = generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false)
-					_ = generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false)
-					return nil
+					var errs []error
+					errs = append(errs, generate.Scaffolding(cwd, cfg, cat, lock, &wr, false))
+					errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false))
+					errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false))
+					errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false))
+					errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false))
+					return errors.Join(errs...)
 				}),
 			func(prev []any) bool {
 				if len(prev) == 0 {
@@ -264,14 +268,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 		tui.Warning("Could not save lock file: " + err.Error())
 	}
 
-	root := ""
-	if cfg != nil {
-		root = cfg.DocsPath
-	}
-	if root == "" {
-		root = "."
-	}
-	showWriteResults(&wr, root)
+	showWriteResults(&wr)
 
 	if cfg != nil {
 		tui.Success(fmt.Sprintf("Initialized %s with %s", cfg.ProjectName, agentDef.DisplayName))

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -100,9 +100,10 @@ func runRemove(cmd *cobra.Command, args []string) error {
 					}
 				}
 				delete(cfg.Agents, agentName)
-				_ = cfg.Save(configPath)
-				_ = generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false)
-				return nil
+				var errs []error
+				errs = append(errs, cfg.Save(configPath))
+				errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false))
+				return errors.Join(errs...)
 			}),
 			func(prev []any) bool { return asBool(prev[0]) },
 		),
@@ -140,6 +141,17 @@ func runRemove(cmd *cobra.Command, args []string) error {
 
 	if !asBool(results[0]) {
 		return nil
+	}
+
+	// Spinner result at slot 1 — surface any aggregated generator error so
+	// the user sees permission / IO failures rather than a silent success.
+	if len(results) > 1 {
+		if errVal := results[1]; errVal != nil {
+			if e, ok := errVal.(error); ok && e != nil {
+				tui.Warning("Removal error: " + e.Error())
+				return nil
+			}
+		}
 	}
 
 	// Conflict-picker LazyGroup at slot 2 expands to [MultiSelect, Conditional]
@@ -354,6 +366,17 @@ func runRemoveItem(name string, it itemType) error {
 		return nil
 	}
 
+	// Spinner result at slot 2 — surface any aggregated generator error so
+	// the user sees permission / IO failures rather than a silent success.
+	if len(results) > 2 {
+		if errVal := results[2]; errVal != nil {
+			if e, ok := errVal.(error); ok && e != nil {
+				tui.Warning("Removal error: " + e.Error())
+				return nil
+			}
+		}
+	}
+
 	// Conflict-picker LazyGroup at slot 3 expands to [MultiSelect, Conditional]
 	// in place. The MultiSelect (the actual conflict picks) lands at index 3.
 	applyConflictPicks(results, 3, &wr, lock, cwd)
@@ -436,12 +459,14 @@ func buildItemSummary(displayName string, it itemType, cat *catalog.Catalog, tar
 
 // runRemoveItemAction is the body of the legacy spinner.Action closure,
 // extracted so it can be invoked from a SpinnerStep closure (which expects an
-// error-returning function rather than a bare func()). The body still uses
-// the `_ =` swallow pattern for parity with the legacy code — surfacing
-// individual write errors from this loop is tracked separately in Backlog.
+// error-returning function rather than a bare func()). Generator calls are
+// aggregated via errors.Join so any IO or permission failure surfaces
+// post-harness; os.Remove swallows are kept because ENOENT after a lock
+// Untrack is legitimate (the file may already be gone).
 func runRemoveItemAction(cwd string, cfg *config.ProjectConfig, cat *catalog.Catalog,
 	lock *config.LockFile, wr *generate.WriteResult, configPath, name string,
 	it itemType, targets []agentMatch) error {
+	var errs []error
 	for _, t := range targets {
 		removeFromItemList(t.agent, name, it)
 
@@ -469,7 +494,7 @@ func runRemoveItemAction(cwd string, cfg *config.ProjectConfig, cat *catalog.Cat
 			generate.EnsureRoutineCheckSensor(t.agent)
 			workspaceRoot := filepath.Join(cwd, t.agent.Workspace)
 			if len(t.agent.Routines) > 0 {
-				_ = generate.RoutineDashboard(cwd, workspaceRoot, t.agent, cat, lock, wr, false)
+				errs = append(errs, generate.RoutineDashboard(cwd, workspaceRoot, t.agent, cat, lock, wr, false))
 			} else {
 				dashPath := filepath.Join(t.agent.Workspace, "agent", "Core", "routines.md")
 				lock.Untrack(dashPath)
@@ -480,13 +505,13 @@ func runRemoveItemAction(cwd string, cfg *config.ProjectConfig, cat *catalog.Cat
 		// Regenerate workspace CLAUDE.md
 		if agentDef := cat.GetAgent(t.name); agentDef != nil {
 			workspaceRoot := filepath.Join(cwd, t.agent.Workspace)
-			_ = generate.WorkspaceClaudeMD(cwd, workspaceRoot, agentDef, t.agent, cfg, cat, lock, wr, false)
+			errs = append(errs, generate.WorkspaceClaudeMD(cwd, workspaceRoot, agentDef, t.agent, cfg, cat, lock, wr, false))
 		}
 	}
 
-	_ = cfg.Save(configPath)
-	_ = generate.SettingsJSON(cwd, cfg, cat, lock, wr, false)
-	return nil
+	errs = append(errs, cfg.Save(configPath))
+	errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+	return errors.Join(errs...)
 }
 
 // ─── Item list helpers ──────────────────────────────────────────────────

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -163,36 +164,74 @@ func applyConflictPicks(results []any, confIdx int, wr *generate.WriteResult,
 }
 
 // showWriteResults displays categorized file trees for generation outcomes.
-func showWriteResults(wr *generate.WriteResult, rootLabel string) {
-	// Normalize prefix for stripping (e.g. "station/" → "station")
-	prefix := strings.TrimRight(rootLabel, "/")
+// Files are grouped by top-level path segment (e.g. "station", "src") and each
+// group is rendered as a separate tree rooted at that segment. This avoids
+// cross-workspace leakage when a single run writes to multiple roots (e.g.
+// `bonsai add` for a code agent that also touches the tech-lead's station/).
+func showWriteResults(wr *generate.WriteResult) {
+	// Bucket per top-level segment, preserving Created/Updated/Conflict split.
+	type bucket struct {
+		created, updated, conflicted []string
+	}
+	buckets := make(map[string]*bucket)
+	ensure := func(root string) *bucket {
+		b, ok := buckets[root]
+		if !ok {
+			b = &bucket{}
+			buckets[root] = b
+		}
+		return b
+	}
 
-	var created, updated, conflicted []string
 	for _, f := range wr.Files {
-		// Strip the workspace prefix so the tree doesn't double it
-		rel := strings.TrimPrefix(f.RelPath, prefix+"/")
+		root, rel := splitTopSegment(f.RelPath)
+		b := ensure(root)
 		switch f.Action {
 		case generate.ActionCreated:
-			created = append(created, rel)
+			b.created = append(b.created, rel)
 		case generate.ActionUpdated, generate.ActionForced:
-			updated = append(updated, rel)
+			b.updated = append(b.updated, rel)
 		case generate.ActionConflict:
-			conflicted = append(conflicted, rel)
+			b.conflicted = append(b.conflicted, rel)
 		}
 	}
-	if rootLabel == "" {
-		rootLabel = "."
+
+	// Stable, alphabetical ordering across groups.
+	roots := make([]string, 0, len(buckets))
+	for r := range buckets {
+		roots = append(roots, r)
 	}
-	if len(created) > 0 {
-		tree := tui.FileTree(created, rootLabel)
-		tui.TitledPanel("Created", tree, tui.Moss)
+	sort.Strings(roots)
+
+	for _, root := range roots {
+		b := buckets[root]
+		label := root
+		if label == "" {
+			label = "."
+		}
+		if len(b.created) > 0 {
+			tree := tui.FileTree(b.created, label)
+			tui.TitledPanel("Created", tree, tui.Moss)
+		}
+		if len(b.updated) > 0 {
+			tree := tui.FileTree(b.updated, label)
+			tui.TitledPanel("Updated", tree, tui.Water)
+		}
+		if len(b.conflicted) > 0 {
+			tree := tui.FileTree(b.conflicted, label)
+			tui.TitledPanel("Skipped (user modified)", tree, tui.Amber)
+		}
 	}
-	if len(updated) > 0 {
-		tree := tui.FileTree(updated, rootLabel)
-		tui.TitledPanel("Updated", tree, tui.Water)
+}
+
+// splitTopSegment splits a relative path into its first path component and
+// the remainder. "station/agent/foo.md" → ("station", "agent/foo.md"). A path
+// with no separator returns ("", path) so single-file outputs still render
+// under a root panel.
+func splitTopSegment(rel string) (string, string) {
+	idx := strings.Index(rel, "/")
+	if idx < 0 {
+		return "", rel
 	}
-	if len(conflicted) > 0 {
-		tree := tui.FileTree(conflicted, rootLabel)
-		tui.TitledPanel("Skipped (user modified)", tree, tui.Amber)
-	}
+	return rel[:idx], rel[idx+1:]
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -124,6 +124,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 				}
 			}
 
+			var errs []error
 			for _, agentName := range agentNames {
 				installed := cfg.Agents[agentName]
 				agentDef := cat.GetAgent(installed.AgentType)
@@ -131,12 +132,12 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 					continue
 				}
 				generate.EnsureRoutineCheckSensor(installed)
-				_ = generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false)
+				errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false))
 			}
-			_ = generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false)
-			_ = generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false)
-			_ = generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false)
-			return nil
+			errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false))
+			errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false))
+			errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false))
+			return errors.Join(errs...)
 		}),
 
 		harness.NewLazyGroup("Resolve conflicts", func(prev []any) []harness.Step {
@@ -167,6 +168,19 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Spinner slot sits immediately after the per-agent custom-file pickers.
+	// Surface any aggregated generator error post-harness so a silent failure
+	// no longer masquerades as a successful sync.
+	spinnerIdx := len(agentsWithDiscoveries)
+	if spinnerIdx < len(results) {
+		if errVal := results[spinnerIdx]; errVal != nil {
+			if e, ok := errVal.(error); ok && e != nil {
+				tui.Warning("Update error: " + e.Error())
+				return nil
+			}
+		}
+	}
+
 	// Conflict picker, if it spliced in steps, lands at index
 	// len(agentsWithDiscoveries) + 1 (one slot per per-agent picker, plus the
 	// spinner). The MultiSelectStep produced by buildConflictSteps lives there.
@@ -194,7 +208,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	showWriteResults(&wr, ".")
+	showWriteResults(&wr)
 
 	if configChanged {
 		tui.Success("Update complete — custom files tracked")
@@ -238,6 +252,20 @@ func buildCustomFileDefaults(valid []generate.DiscoveredFile) []string {
 	return defaults
 }
 
+// appendUnique appends name to slice unless it is already present. The ability
+// lists on config.InstalledAgent are small (bounded by catalog size), so a
+// linear scan is cheaper than maintaining a parallel set. Guards against
+// accumulating duplicates when `bonsai update` is re-run over the same
+// user-selected custom files.
+func appendUnique(slice []string, name string) []string {
+	for _, existing := range slice {
+		if existing == name {
+			return slice
+		}
+	}
+	return append(slice, name)
+}
+
 // applyCustomFileSelection mutates installed + lock for the given agent based on
 // the user-selected keys. Returns true if any selections were applied (so the
 // caller can flip configChanged). Lifted from the inline body at
@@ -257,15 +285,15 @@ func applyCustomFileSelection(installed *config.InstalledAgent, valid []generate
 
 		switch d.Type {
 		case "skill":
-			installed.Skills = append(installed.Skills, d.Name)
+			installed.Skills = appendUnique(installed.Skills, d.Name)
 		case "workflow":
-			installed.Workflows = append(installed.Workflows, d.Name)
+			installed.Workflows = appendUnique(installed.Workflows, d.Name)
 		case "protocol":
-			installed.Protocols = append(installed.Protocols, d.Name)
+			installed.Protocols = appendUnique(installed.Protocols, d.Name)
 		case "sensor":
-			installed.Sensors = append(installed.Sensors, d.Name)
+			installed.Sensors = appendUnique(installed.Sensors, d.Name)
 		case "routine":
-			installed.Routines = append(installed.Routines, d.Name)
+			installed.Routines = appendUnique(installed.Routines, d.Name)
 		}
 
 		if installed.CustomItems == nil {

--- a/cmd/update_test.go
+++ b/cmd/update_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
+)
+
+// TestAppendUnique covers the small helper used by applyCustomFileSelection
+// to guard against duplicate entries on repeated `bonsai update` runs.
+func TestAppendUnique(t *testing.T) {
+	t.Run("appends when absent", func(t *testing.T) {
+		got := appendUnique([]string{"a", "b"}, "c")
+		want := []string{"a", "b", "c"}
+		if !equalSlice(got, want) {
+			t.Errorf("appendUnique = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("skips when present", func(t *testing.T) {
+		got := appendUnique([]string{"a", "b", "c"}, "b")
+		want := []string{"a", "b", "c"}
+		if !equalSlice(got, want) {
+			t.Errorf("appendUnique = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("appends to empty slice", func(t *testing.T) {
+		got := appendUnique(nil, "a")
+		want := []string{"a"}
+		if !equalSlice(got, want) {
+			t.Errorf("appendUnique = %v, want %v", got, want)
+		}
+	})
+}
+
+// TestApplyCustomFileSelectionDedupes verifies that re-running
+// applyCustomFileSelection with the same selections does not accumulate
+// duplicate entries in the installed agent's ability lists.
+func TestApplyCustomFileSelectionDedupes(t *testing.T) {
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: ".",
+		Skills:    []string{},
+		Workflows: []string{},
+	}
+
+	valid := []generate.DiscoveredFile{
+		{Name: "custom-skill", Type: "skill", RelPath: "agent/Skills/custom-skill.md", Meta: &config.CustomItemMeta{Description: "custom skill"}},
+		{Name: "custom-workflow", Type: "workflow", RelPath: "agent/Workflows/custom-workflow.md", Meta: &config.CustomItemMeta{Description: "custom workflow"}},
+	}
+	selected := []string{"skill:custom-skill", "workflow:custom-workflow"}
+
+	lock := config.NewLockFile()
+	cwd := t.TempDir()
+
+	// First call — both get added.
+	_ = applyCustomFileSelection(installed, valid, selected, lock, cwd)
+	// Second call — same selection; neither should duplicate.
+	_ = applyCustomFileSelection(installed, valid, selected, lock, cwd)
+
+	if len(installed.Skills) != 1 {
+		t.Errorf("Skills len = %d, want 1 (%v)", len(installed.Skills), installed.Skills)
+	}
+	if len(installed.Workflows) != 1 {
+		t.Errorf("Workflows len = %d, want 1 (%v)", len(installed.Workflows), installed.Workflows)
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -257,9 +257,24 @@ func (wr *WriteResult) ForceSelected(paths []string, projectRoot string, lock *c
 
 // ─── Lock-aware write primitives ───────────────────────────────────────
 
+// normalizeShellLF strips carriage returns from shell script content. It is a
+// belt-and-braces defence against CRLF sneaking through git clients that
+// ignore `.gitattributes` — bash refuses scripts whose shebang ends in `\r`.
+// No-op for non-`.sh` paths.
+func normalizeShellLF(data []byte, rel string) []byte {
+	if !strings.HasSuffix(rel, ".sh") {
+		return data
+	}
+	// Replace CRLF with LF first, then drop any remaining standalone CR.
+	data = bytes.ReplaceAll(data, []byte("\r\n"), []byte("\n"))
+	data = bytes.ReplaceAll(data, []byte("\r"), nil)
+	return data
+}
+
 // writeFile implements the lock-aware write policy.
 // If force is true, modified files are overwritten.
 func writeFile(projectRoot, relPath string, content []byte, source string, lock *config.LockFile, force bool) FileResult {
+	content = normalizeShellLF(content, relPath)
 	absPath := filepath.Join(projectRoot, relPath)
 	exists, modified := lock.IsModified(projectRoot, relPath)
 
@@ -299,6 +314,7 @@ func writeFile(projectRoot, relPath string, content []byte, source string, lock 
 
 // writeFileChmod is like writeFile but also sets file permissions (for sensor scripts).
 func writeFileChmod(projectRoot, relPath string, content []byte, source string, lock *config.LockFile, force bool, perm os.FileMode) FileResult {
+	content = normalizeShellLF(content, relPath)
 	result := writeFile(projectRoot, relPath, content, source, lock, force)
 	if result.Action == ActionCreated || result.Action == ActionUpdated || result.Action == ActionForced || result.Action == ActionUnchanged {
 		absPath := filepath.Join(projectRoot, relPath)

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1,6 +1,7 @@
 package generate
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1109,6 +1110,79 @@ func TestWriteFileChmodRestoresPermOnUnchanged(t *testing.T) {
 	}
 	if info.Mode()&0777 != 0755 {
 		t.Errorf("mode after unchanged run = %v, want 0755 (perm should be restored)", info.Mode()&0777)
+	}
+}
+
+// TestShellScriptLF verifies that sensor scripts written during AgentWorkspace
+// generation contain no carriage-return bytes, regardless of the source CRLF
+// state. Covers the normalizeShellLF belt-and-braces defence for Step 1 of
+// Plan 19 — protects against CRLF sneaking in via a git client that ignores
+// .gitattributes.
+func TestShellScriptLF(t *testing.T) {
+	// Build a catalog with shared core, one agent, and one sensor whose
+	// script template contains CRLF line endings.
+	fsys := fstest.MapFS{
+		"core/memory.md.tmpl":                     &fstest.MapFile{Data: []byte("memory for {{ .AgentDisplayName }}")},
+		"core/self-awareness.md":                  &fstest.MapFile{Data: []byte("self-awareness content")},
+		"agents/test-agent/agent.yaml":            &fstest.MapFile{Data: []byte("name: test-agent\ndescription: test\n")},
+		"agents/test-agent/core/identity.md.tmpl": &fstest.MapFile{Data: []byte("I am {{ .AgentDisplayName }}")},
+		"sensors/crlf-sensor/meta.yaml": &fstest.MapFile{Data: []byte(
+			"name: crlf-sensor\ndescription: test sensor\nagents: all\nevent: SessionStart\n",
+		)},
+		// Script template with CRLF line endings — simulates a hostile checkout.
+		"sensors/crlf-sensor/crlf-sensor.sh.tmpl": &fstest.MapFile{Data: []byte(
+			"#!/bin/bash\r\necho {{ .AgentName }}\r\nexit 0\r\n",
+		)},
+	}
+	cat, err := catalog.New(fsys)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	agentDef := cat.GetAgent("test-agent")
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: ".",
+		Sensors:   []string{"crlf-sensor"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents:      map[string]*config.InstalledAgent{"test-agent": installed},
+	}
+
+	lock := config.NewLockFile()
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, agentDef, installed, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("AgentWorkspace: %v", err)
+	}
+
+	sensorsDir := filepath.Join(tmpDir, "agent", "Sensors")
+	entries, err := os.ReadDir(sensorsDir)
+	if err != nil {
+		t.Fatalf("read sensors dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no sensor scripts written — AgentWorkspace did not install crlf-sensor")
+	}
+
+	foundSh := false
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sh") {
+			continue
+		}
+		foundSh = true
+		path := filepath.Join(sensorsDir, e.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if bytes.Contains(data, []byte("\r")) {
+			t.Errorf("sensor script %s contains carriage return bytes; want LF-only", e.Name())
+		}
+	}
+	if !foundSh {
+		t.Fatal("no .sh files found under agent/Sensors")
 	}
 }
 

--- a/internal/tui/harness/harness.go
+++ b/internal/tui/harness/harness.go
@@ -283,6 +283,14 @@ func (h *Harness) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			//      rather than the stale pre-Esc snapshot.
 			var cmds []tea.Cmd
 			for i := h.cursor; i <= origCursor && i < len(h.steps); i++ {
+				// Refresh prior-results snapshot BEFORE Reset so a
+				// ConditionalStep's predicate can re-evaluate against the
+				// user's newly-chosen upstream picks. Without this, the
+				// predicate still sees the stale snapshot captured during
+				// the original forward traversal.
+				if pa, ok := h.steps[i].(priorAware); ok {
+					pa.SetPrior(h.priorResults())
+				}
 				if r, ok := h.steps[i].(resetter); ok {
 					if cmd := r.Reset(); cmd != nil && i == h.cursor {
 						// Only the active step's Init cmd needs to fire now.

--- a/internal/tui/harness/harness_test.go
+++ b/internal/tui/harness/harness_test.go
@@ -526,6 +526,90 @@ func TestLazyStepInsideLazyGroupBuilds(t *testing.T) {
 	}
 }
 
+// TestEscBackReevaluatesConditional covers Plan 19 Step 7 — when the user
+// Esc-backs past a ConditionalStep to a preceding step, changes the upstream
+// selection, and advances forward again, the conditional's predicate must
+// re-evaluate against the NEW selection. Without the SetPrior-before-Reset
+// fix in the harness + the predicate re-eval in ConditionalStep.Reset, the
+// conditional would still use its stale initPrev snapshot and render (or
+// skip) the wrong branch.
+func TestEscBackReevaluatesConditional(t *testing.T) {
+	// Step 0: a fake Select whose Result() returns the "picked" value. We
+	// simulate the user changing the selection by mutating pick.result.
+	pick := &fakeStep{title: "Select"}
+	pick.result = "a"
+	pick.done = true // gate forward advancement
+
+	// Step 1: a ConditionalStep wrapping an inner fakeInitStep. Predicate
+	// fires when the latest selection at prev[0] == "a".
+	innerInitCount := 0
+	inner := &fakeInitStep{
+		fakeStep: fakeStep{title: "inner"},
+		onInit:   func() { innerInitCount++ },
+	}
+	cond := NewConditional(inner, func(prev []any) bool {
+		if len(prev) == 0 {
+			return false
+		}
+		s, _ := prev[0].(string)
+		return s == "a"
+	})
+
+	h := New("BANNER", "TEST", []Step{pick, cond})
+
+	// Drive the harness forward off step 0 onto the conditional. With
+	// pick.result == "a", predicate is true → inner shows.
+	_, _ = h.Update(runeKey('x'))
+	if h.cursor != 1 {
+		t.Fatalf("setup: expected cursor=1 after forward advance, got %d", h.cursor)
+	}
+	if innerInitCount != 1 {
+		t.Fatalf("setup: expected inner Init to run once on first entry (pick='a'), got %d", innerInitCount)
+	}
+	if cond.skip {
+		t.Fatalf("setup: conditional must not skip when predicate true")
+	}
+
+	// User Esc-backs to the Select step. The inner step is a fakeInitStep
+	// (NOT a resetter) so only the SetPrior/Reset walk for the Conditional
+	// itself runs here. The harness's Esc-back loop calls SetPrior on every
+	// step in [newCursor, origCursor] before Reset.
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if h.cursor != 0 {
+		t.Fatalf("after Esc: expected cursor=0, got %d", h.cursor)
+	}
+
+	// User changes the pick to "b" → predicate should now return false and
+	// the conditional should skip on the next forward pass.
+	pick.result = "b"
+	pick.done = true
+
+	// Advance forward again. The Conditional is now active; its Reset ran
+	// during the Esc loop with the fresh prior snapshot (pick="b"), so
+	// c.skip should already be true. Done() is true via skipDone, and the
+	// harness's auto-advance loop should sail past the conditional to the
+	// end-of-steps quit path.
+	_, cmd := h.Update(runeKey('y'))
+
+	// With only two steps and the conditional skipping, the harness should
+	// have advanced past both and started quitting.
+	if !h.quitting {
+		t.Fatalf("expected harness to quit after advancing past skipped conditional; cursor=%d, skip=%v",
+			h.cursor, cond.skip)
+	}
+	if !cond.skip {
+		t.Fatalf("expected conditional to skip with new pick='b', skip=%v", cond.skip)
+	}
+	// Inner Init must NOT have fired a second time (because the conditional
+	// skipped on this forward pass).
+	if innerInitCount != 1 {
+		t.Fatalf("expected inner Init to NOT re-run after skip re-eval (total %d, want 1)", innerInitCount)
+	}
+	if !cmdContainsQuit(cmd) {
+		t.Fatalf("expected tea.Quit in batch once harness runs off the end")
+	}
+}
+
 // cmdContainsSentinel walks a tea.Cmd (expanding tea.BatchMsg one level) and
 // returns true if any produced message is a resetSentinelMsg.
 func cmdContainsSentinel(cmd tea.Cmd) bool {

--- a/internal/tui/harness/steps.go
+++ b/internal/tui/harness/steps.go
@@ -752,7 +752,18 @@ func (s *SpinnerStep) Init() tea.Cmd {
 	}
 	return tea.Batch(
 		s.sp.Tick,
-		func() tea.Msg { return spinnerDoneMsg{err: runner()} },
+		func() (msg tea.Msg) {
+			// Guard against panics inside the action closure. Plan 15 iter 3
+			// added recoverBuilder for Build/Splice; this is the symmetric
+			// guard for the SpinnerStep's tea.Cmd goroutine, which would
+			// otherwise crash the BubbleTea event loop with no panel.
+			defer func() {
+				if r := recover(); r != nil {
+					msg = spinnerDoneMsg{err: fmt.Errorf("spinner action panic: %v", r)}
+				}
+			}()
+			return spinnerDoneMsg{err: runner()}
+		},
 	)
 }
 
@@ -805,6 +816,10 @@ type ConditionalStep struct {
 
 // NewConditional constructs a ConditionalStep.
 func NewConditional(inner Step, predicate func(prev []any) bool) *ConditionalStep {
+	if predicate == nil {
+		// nil predicate = always show (safer default than skip)
+		predicate = func(prev []any) bool { return true }
+	}
 	return &ConditionalStep{inner: inner, predicate: predicate}
 }
 
@@ -861,7 +876,16 @@ func (c *ConditionalStep) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (c *ConditionalStep) Reset() tea.Cmd {
-	c.skip = false
+	// Re-evaluate the predicate against the freshest prior-results snapshot
+	// (the harness calls SetPrior immediately before Reset on Esc-back). This
+	// lets Done() reflect the new predicate result synchronously so the
+	// harness's auto-skip logic lands on the right step without waiting for
+	// a later Init() to re-evaluate.
+	c.skip = !c.predicate(c.initPrev)
+	if c.skip {
+		c.skipDone = true
+		return nil
+	}
 	c.skipDone = false
 	if r, ok := c.inner.(resetter); ok {
 		return r.Reset()

--- a/internal/tui/harness/steps_test.go
+++ b/internal/tui/harness/steps_test.go
@@ -406,6 +406,82 @@ func TestConditionalStepResetReevaluates(t *testing.T) {
 	}
 }
 
+// TestSpinnerStepRecoversFromPanic verifies that a panic thrown inside the
+// SpinnerStep action closure is captured by the tea.Cmd goroutine's deferred
+// recover and translated into a spinnerDoneMsg carrying a descriptive error
+// — rather than crashing the BubbleTea event loop.
+func TestSpinnerStepRecoversFromPanic(t *testing.T) {
+	s := NewSpinner("Generating", "Generating files...", func() error {
+		panic("boom")
+	})
+
+	cmd := s.Init()
+	if cmd == nil {
+		t.Fatalf("SpinnerStep.Init() returned nil cmd")
+	}
+
+	// tea.Batch returns a single Cmd that, when executed, returns a
+	// BatchMsg containing further commands. Drive them until we find the
+	// spinnerDoneMsg (the worker function) without crashing on the panic.
+	msg := cmd()
+	var done spinnerDoneMsg
+	found := false
+
+	// tea.BatchMsg is []tea.Cmd. Walk it and execute each sub-Cmd.
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		for _, sub := range batch {
+			if sub == nil {
+				continue
+			}
+			out := sub()
+			if sd, ok := out.(spinnerDoneMsg); ok {
+				done = sd
+				found = true
+				break
+			}
+		}
+	} else if sd, ok := msg.(spinnerDoneMsg); ok {
+		// Non-batch execution path (defensive).
+		done = sd
+		found = true
+	}
+
+	if !found {
+		t.Fatalf("did not receive spinnerDoneMsg from Init batch")
+	}
+	if done.err == nil {
+		t.Fatalf("expected non-nil err after action panic")
+	}
+	if !strings.Contains(done.err.Error(), "spinner action panic") {
+		t.Fatalf("expected err to mention panic recovery, got %v", done.err)
+	}
+}
+
+// TestConditionalNilPredicateDefaultsToShow verifies that NewConditional
+// tolerates a nil predicate — the default path is to SHOW the wrapped step
+// (safer than silently skipping, which could hide steps the user expected
+// to complete).
+func TestConditionalNilPredicateDefaultsToShow(t *testing.T) {
+	innerInited := false
+	inner := &fakeInitStep{
+		fakeStep: fakeStep{title: "inner"},
+		onInit:   func() { innerInited = true },
+	}
+
+	c := NewConditional(inner, nil)
+	c.SetPrior(nil)
+	_ = c.Init()
+
+	if !innerInited {
+		t.Fatalf("expected inner Init to run when predicate is nil (show path)")
+	}
+	// With predicate defaulted to always-true, Done() should mirror the inner
+	// step, which has not completed yet.
+	if c.Done() {
+		t.Fatalf("expected Done()=false (predicate defaulted to show, inner not done)")
+	}
+}
+
 // fakeInitStep wraps fakeStep with a callback that fires when Init is
 // invoked, so tests can verify whether the harness drove Init on a wrapped
 // step.


### PR DESCRIPTION
## Summary

Eight targeted fixes bundled for OSS launch readiness, split across two tiers. See [Plan 19](./station/Playbook/Plans/Active/19-pre-launch-bug-sweep.md) for full detail.

### Tier 1 — fresh-install blockers

- **CRLF defence.** New \`.gitattributes\` forces LF on \`*.sh\` / \`*.sh.tmpl\` (and lockfiles/YAML for good measure). Generator adds \`normalizeShellLF\` — belt-and-braces: even if \`.gitattributes\` gets dropped, the binary always writes LF for \`.sh\` outputs. Covered by new \`TestShellScriptLF\`.
- **\`showWriteResults\` cross-workspace tree.** Drops the single \`rootLabel\` param; groups files by top-level path segment and renders one tree per root (alpha-sorted). Fixes the case where \`bonsai add backend\` in a \`station/\`-rooted project emitted files from \`station/\` under the \`src/\` tree.
- **\`applyCustomFileSelection\` dedup.** New \`appendUnique\` helper used across the five switch cases. Repeated \`bonsai update\` runs no longer accumulate duplicate entries in \`.bonsai.yaml\` ability lists. Covered by \`TestAppendUnique\` + \`TestApplyCustomFileSelectionDedupes\`.
- **Spinner error propagation.** Replaced ~30 \`_ =\` swallows inside spinner action closures with \`errors.Join\`-based aggregation across \`cmd/{init,add,remove,update}.go\`. Callers now surface errors via \`tui.Warning\` instead of silent success.

### Tier 2 — harness polish (\`internal/tui/harness\`)

- **\`SpinnerStep.Init\` goroutine \`recover\`.** \`defer recover()\` inside the action \`tea.Cmd\` converts panics to \`spinnerDoneMsg{err}\`. Symmetric with the \`recoverBuilder\` already covering Build/Splice from Plan 15 iter 3. Covered by \`TestSpinnerStepRecoversFromPanic\`.
- **\`NewConditional\` nil-predicate guard.** Nil predicate now defaults to \`always-show\` (safer than silently skip) instead of nil-deref panic. Covered by \`TestConditionalNilPredicateDefaultsToShow\`.
- **Esc-back predicate re-evaluation.** Harness now calls \`SetPrior(priorResults())\` before \`Reset()\` during the Esc-back loop. \`ConditionalStep.Reset\` re-runs its predicate against the fresh prior snapshot so \`Done()\` reflects the new state synchronously. Covered by \`TestEscBackReevaluatesConditional\`.
- **\`cmd/add.go\` duplicate Tech-Lead message.** Dropped the in-AltScreen \`NoteStep\` in the \`LazyGroup\` — tech-lead-required branch now returns \`nil\` steps so the spinner predicate naturally skips. The guidance surfaces once via the post-harness \`ErrorDetail\` on stdout.

## Verification

- [x] \`make build\` — clean binary
- [x] \`go vet ./...\` — clean
- [x] \`gofmt -l .\` — empty
- [x] \`go test ./...\` — all packages green
- [x] 6 new tests all pass (list above)
- [ ] Manual \`bonsai init → add → remove → update\` on a fresh temp dir — reviewer to verify golden path.
- [ ] CI: \`test\` + \`lint\` + GitGuardian green.

## Files changed

\`\`\`
 .gitattributes                       |   6 ++
 cmd/add.go                           |  37 ++++++----
 cmd/init.go                          |  25 ++++---
 cmd/remove.go                        |  47 ++++++++++---
 cmd/root.go                          |  81 +++++++++++++++++----
 cmd/update.go                        |  50 +++++++++----
 cmd/update_test.go                   |  52 ++++++++++++++ (new)
 internal/generate/generate.go        |  16 +++++
 internal/generate/generate_test.go   |  74 ++++++++++++++++++++
 internal/tui/harness/harness.go      |   8 +++
 internal/tui/harness/harness_test.go |  84 +++++++++++++++++++++++
 internal/tui/harness/steps.go        |  28 +++++++-
 internal/tui/harness/steps_test.go   |  76 ++++++++++++++++++++
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)