### PR TITLE
build(deps): bump Go toolchain to 1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.11.4

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/LastStep/Bonsai
 
-go 1.24.2
+go 1.25.0
 
-toolchain go1.24.13
+toolchain go1.25.8
 
 // v0.1.0 has a case-insensitive file collision (station/index.md vs station/INDEX.md)
 // that prevents the Go module proxy from creating a valid zip.


### PR DESCRIPTION
## Summary
Bump Go toolchain from 1.24.13 to 1.25.8 to clear 2 reachable stdlib CVEs flagged by the 2026-04-21 vulnerability-scan routine. Bundles a paired golangci-lint pin bump (`v2.1` → `v2.11.4`) because the older `v2.1` binary is itself built on Go 1.24 and can't parse Go 1.25 targets.

- GO-2026-4602 (`os` FileInfo Root escape) — reachable via `internal/generate/scan.go:44`
- GO-2026-4601 (`net/url` IPv6 host literal parsing) — reachable via `cmd/guide.go:92`

Also clears 9 unreachable stdlib CVEs in the same release line.

## Changes
- `go.mod` — `go 1.25.0`, `toolchain go1.25.8`
- `.github/workflows/ci.yml` — golangci-lint pin `v2.1` → `v2.11.4` (Go 1.25 compatible)

## Plan
See `station/Playbook/Plans/Active/20-security-scanning-infra.md` — PR #1.

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean
- [x] `govulncheck ./...` — 0 reachable findings
- [ ] CI `lint` job green with v2.11.4 on Go 1.25.8 target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
