### PR TITLE
ci: migrate golangci-lint v1 to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,6 @@ jobs:
           go-version-file: go.mod
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,26 +1,23 @@
-# golangci-lint v1 config
+# golangci-lint v2 config
 # https://golangci-lint.run/usage/configuration/
-# CI pins v1.64.x via golangci/golangci-lint-action@v6. The `version: latest`
-# input on that action resolves to the v1 latest, not v2. When we move to v2
-# (separate PR), this file needs the v2 schema (version/formatters/linters.default).
+version: "2"
 
 run:
   timeout: 3m
   tests: true
 
 linters:
-  disable-all: true
-  # Conservative initial set. `staticcheck` and `ineffassign` are intentionally
-  # omitted at release-prep time because they flag findings in pre-existing code
-  # that is out of scope for Plan 17. Enable in a follow-up PR alongside the
-  # code cleanups.
+  default: none
   enable:
-    - errcheck      # unchecked errors
-    - govet         # suspicious constructs
-    - unused        # unused code
-    - misspell      # typos in comments/strings
-    - gofmt         # formatting
-    - goimports     # import ordering
+    - errcheck
+    - govet
+    - unused
+    - misspell
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
## Summary
Migrate golangci-lint from v1 (EOL, built on Go 1.24) to v2 (Go 1.25 compatible). Unblocks Plan 20 PR #1 (Go toolchain bump to 1.25.8).

## Changes
- `.golangci.yml` — v2 schema (formatters split out of linters, `default: none` replaces `disable-all: true`)
- `.github/workflows/ci.yml` — `golangci/golangci-lint-action@v6` → `@v8`, `version: latest` → `version: v2.1`

## Plan
See `station/Playbook/Plans/Active/20-security-scanning-infra.md` — PR #1a (inserted after CI feedback on PR #28).

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean
- [ ] CI `lint` job green (v2.1 must run the same linter set on current Go 1.24.13 codebase with zero findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)