### PR TITLE
ci: add Dependabot config for gomod + github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - go
+    commit-message:
+      prefix: "build(deps)"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "build(deps)"


### PR DESCRIPTION
## Summary
Enable Dependabot weekly version + security PRs for Go modules and GitHub Actions. Complements repo-level security alerts.

## Changes
- `.github/dependabot.yml` — gomod + github-actions ecosystems, weekly Monday schedule, 5 PR limit each, `build(deps)` commit prefix

## Plan
See `station/Playbook/Plans/Active/20-security-scanning-infra.md` — PR #2.

## Verification
- [x] YAML parses clean
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [ ] Post-merge: Dependabot tab populates with first-run state within 1 hour

🤖 Generated with [Claude Code](https://claude.com/claude-code)