### PR TITLE
ci: add govulncheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,20 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.11.4
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...


### PR DESCRIPTION
## Summary
Add `govulncheck` as a CI job on PRs. Reachability-aware Go stdlib + module CVE scanner. Complements Dependabot (modules only) by catching stdlib CVEs.

## Changes
- `.github/workflows/ci.yml` — new `govulncheck` job under existing `lint`, using `go install golang.org/x/vuln/cmd/govulncheck@latest`

## Plan
See `station/Playbook/Plans/Active/20-security-scanning-infra.md` — PR #3.

## Verification
- [x] YAML parses
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [ ] CI `govulncheck` job green (Go 1.25.8 toolchain, expect 0 reachable findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)