### PR TITLE
ci: add CodeQL workflow for Go SAST

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '30 4 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"


### PR DESCRIPTION
## Summary
Add CodeQL SAST workflow for Go. Runs on PR, push to main, and weekly schedule. `security-and-quality` query suite (broader than default `security-extended`).

## Changes
- `.github/workflows/codeql.yml` — Go analysis, PR + push + weekly cron (Monday 04:30 UTC)

## Plan
See `station/Playbook/Plans/Active/20-security-scanning-infra.md` — PR #4.

## Verification
- [x] YAML parses
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [ ] Post-merge: initial scan completes within 15min, Security tab shows CodeQL results (0 findings expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)