### PR TITLE
chore(station): Group G Dependabot closeout — memory + backlog

### DIFF
--- a/station/Playbook/Backlog.md
+++ b/station/Playbook/Backlog.md
@@ -52,7 +52,8 @@ Items that should be worked together are tagged with a group letter. See the gro
 
 <!-- "Silent error swallowing in spinner callbacks" — fixed 2026-04-21 via Plan 19 / PR #27 (squash a44e447): errors.Join aggregation at all ~30 sites + Warning surfaces in init/add/remove/update -->
 <!-- "Upgrade Go toolchain 1.24.13 → 1.25.9" — shipped 2026-04-21 via Plan 20 / PR #28 (Go 1.25.8 + golangci-lint pin v2.11.4); govulncheck now 0 reachable findings in CI -->
-- **[debt] Triage Dependabot auto-PRs #32–#39** `[Group G]` — First weekly Dependabot run (triggered by Plan 20 PR #31 landing) opened 8 PRs: 3 gomod (x/term 0.36→0.42, charmbracelet/x/ansi 0.11.6→0.11.7, go-isatty 0.0.20→0.0.21) + 5 github-actions (golangci-lint-action 8→9, setup-go 5→6, setup-node 4→6, upload-pages-artifact 3→5, goreleaser-action 6→7). Review each for breaking changes, merge the trivial ones, hold or pin the majors (golangci-lint-action 9 may need config check; goreleaser-action 7 may need `.goreleaser.yaml` migration). *(added 2026-04-21, source: session — Plan 20 shipment)*
+<!-- "Triage Dependabot auto-PRs #32–#39" — completed 2026-04-21: 7 of 8 merged (#32 #33 #34 #35 #36 #38 #39); #37 (x/term 0.36→0.42) still in flight post-rebase. Release-notes review confirmed no breaking impact for our configs -->
+- **[debt] CodeQL Action v3 → v4** — GH deprecation notice: CodeQL Action v3 will be deprecated December 2026. Update `.github/workflows/codeql.yml` `github/codeql-action/{init,autobuild,analyze}` pins from `@v3` to `@v4` when v4 ships and Dependabot opens the bump PR. No urgency — lots of runway. *(added 2026-04-21, source: session — surfaced on PR #38 CI run)*
 <!-- "triggerSection() prepends before YAML frontmatter" — fixed 2026-04-17 via injectTriggerSection helper, Plan 17 / PR #24 -->
 <!-- "Upgrade Go toolchain from 1.24.3 to 1.24.13+" — fixed 2026-04-17, Plan 17 / PR #24 -->
 <!-- "Spinner error swallowing" — scope-deferred to Plan 15 harness work, 2026-04-17 -->

--- a/station/agent/Core/memory.md
+++ b/station/agent/Core/memory.md
@@ -13,11 +13,11 @@ description: Tech Lead Agent working memory — flags, work state, notes.
 
 ## Work State
 
-**Current task:** Idle. Plan 20 shipped; main `afbcd6d`.
+**Current task:** Idle. Dependabot Group G triage complete; main `3b03301`.
 **In flight (other tracks):** None.
 **Blocked on:** Nothing.
-**Loose ends (uncommitted):** None in station/. 8 Dependabot auto-PRs (#32-#39) open — triage queued as Backlog Group G [debt].
-**Last completed:** Plan 20 — Security scanning infrastructure (2026-04-21). 6 squash-merged PRs: #30 pre-flight, #29 golangci-lint v2, #28 Go 1.25.8 + lint pin v2.11.4, #31 Dependabot, #40 govulncheck, #41 CodeQL. gitleaks one-shot: 0 findings / 156 commits. govulncheck on main: 0 reachable. History tag-ready for OSS launch.
+**Loose ends (uncommitted):** Backlog.md + memory.md edits (Group G closeout + CodeQL v3→v4 deprecation note). Needs closeout PR.
+**Last completed:** Dependabot Group G (8 PRs squash-merged 2026-04-21): #39 ansi patch, #38 go-isatty patch, #37 x/term 0.36→0.42 (rebased 1×), #36 setup-node v6, #35 setup-go v6, #34 golangci-lint-action v9, #33 upload-pages-artifact v5, #32 goreleaser-action v7. Release-notes review confirmed no breaking impact (no `packageManager` field → setup-node auto-cache inactive; no dotfiles in dist → upload-pages-artifact v4 exclusion safe; goreleaser-action v7 inputs unchanged). Plan 20 core (6 PRs): #28 #29 #30 #31 #40 #41; wrap-up PR #42 `9cf577e`; gitleaks 0/156.
 
 Bundle: 4 Tier 1 fresh-install blockers (CRLF defence via .gitattributes + `normalizeShellLF`; `showWriteResults` cross-workspace bucket-by-top-segment; `applyCustomFileSelection` dedup via `appendUnique`; spinner `errors.Join` at ~30 sites + Warning surfaces) with 4 Tier 2 harness polish items (SpinnerStep goroutine `recover`; `NewConditional` nil-predicate guard; Esc-back predicate re-eval via harness SetPrior-before-Reset + `Conditional.Reset` re-evaluation; `bonsai add` drop duplicate NoteStep). Issue-to-implementation workflow end-to-end, worktree-isolated dispatch (general-purpose agent, ~15min wall), 6 new tests + 3 subtests all green. Plan doc: `Plans/Active/19-pre-launch-bug-sweep.md`. Session log: `Logs/2026-04-21-plan-19-bug-sweep.md`.
 


### PR DESCRIPTION
## Summary
Closeout doc commit for Dependabot Group G. All 8 weekly-drift PRs merged to main today (#32 #33 #34 #35 #36 #37 #38 #39).

## Changes
- \`Playbook/Backlog.md\` — comment out Group G item (shipped); add new [debt] entry: CodeQL Action v3 → v4 (Dec 2026 deprecation)
- \`agent/Core/memory.md\` — work state → Idle; last-completed reflects full 8/8 Group G + Plan 20 history

## Verification
- [x] Docs-only; no code/CI changes