### PR TITLE
feat(tui): Plan 22 Phase 1 — RenderFileTree widget + palette tokens

### DIFF
--- a/internal/tui/filetree.go
+++ b/internal/tui/filetree.go
@@ -1,0 +1,326 @@
+package tui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// RenderFileTree draws a rich file-tree widget used by the redesigned
+// `bonsai init` cinematic flow (Planted + Observe stages). It is separate
+// from the flat FileTree helper at styles.go:462 — that helper is still used
+// by `add`/`remove`/`update` panels and must remain untouched.
+//
+// Rendering rules (locked by Plan 22, Phase 1):
+//   - Branch glyphs: "├─ " for intermediate siblings, "└─ " for the last.
+//   - Continuation prefixes: "│  " for non-last ancestors, "   " (three spaces)
+//     for last ancestors.
+//   - Name color:
+//     NodeDir  + NodeCurrent  → Leaf bold
+//     NodeDir  + *            → Bark bold
+//     NodeFile + NodeNew      → Leaf
+//     NodeFile + NodeRequired → Subtle bold
+//     else                    → Subtle
+//   - Status badges sit flush-right with 1 column of padding from the note
+//     (or name). Each badge reserves 9 visible columns including its trailing
+//     space — "NEW      " (Leaf) and "REQUIRED " (Bark).
+//   - Note text is muted, separated from the name by two spaces. When the
+//     full line would exceed opts.MaxWidth, the note is truncated with "…"
+//     using the same budget that reserves room for the trailing badge.
+//   - NodeCurrent additionally receives a 2-col left border "│ " in Leaf, and
+//     the full line (border + tree content) is wrapped in a leaf-tinted
+//     background.
+//   - Dense mode removes blank lines between siblings at every depth. Default
+//     (non-dense) mode inserts one blank line between each sibling.
+//   - When opts.Root is non-nil, a root label line renders above the children
+//     with the same name/note/badge conventions and the children hang below
+//     it using "│  " continuation.
+
+// NodeKind discriminates directories from files for rendering purposes.
+type NodeKind int
+
+const (
+	// NodeFile is a leaf (document).
+	NodeFile NodeKind = iota
+	// NodeDir is an internal directory node whose Children may be nested.
+	NodeDir
+)
+
+// NodeStatus styles a node and optionally attaches a right-aligned badge.
+type NodeStatus int
+
+const (
+	// NodeNormal renders the node with the default foreground colors; no badge.
+	NodeNormal NodeStatus = iota
+	// NodeNew marks newly-written files: Leaf-colored name + "NEW" badge.
+	NodeNew
+	// NodeRequired marks required files: bold Subtle name + "REQUIRED" badge.
+	NodeRequired
+	// NodeCurrent tints a whole subtree with a leaf border + background.
+	NodeCurrent
+)
+
+// TreeNode is one entry in the rendered tree. Kind=NodeFile entries ignore
+// Children. Status controls coloring and badge. Note is a one-line caption
+// rendered after the name in muted text.
+type TreeNode struct {
+	Name     string
+	Kind     NodeKind
+	Status   NodeStatus
+	Note     string
+	Children []TreeNode
+}
+
+// FileTreeOpts tunes the renderer.
+type FileTreeOpts struct {
+	// Root, when non-nil, renders a prefix line with the root's name and note
+	// above the main tree. The root itself is not counted as a sibling of the
+	// top-level nodes; its children (if any) are ignored.
+	Root *TreeNode
+	// Dense collapses sibling spacing to a single line each (no blank line
+	// between siblings at any depth).
+	Dense bool
+	// MaxWidth caps the rendered width of each row. 0 means auto-detect via
+	// the terminal width (falling back to 80).
+	MaxWidth int
+}
+
+// Badge column width — the label plus one trailing space, rendered to the
+// right of the line so all badges of the same kind stack. Kept as a constant
+// so tests can check alignment.
+const (
+	badgeNew      = "NEW"
+	badgeRequired = "REQUIRED"
+	badgeColWidth = 9 // longest badge ("REQUIRED") + one trailing space
+)
+
+// RenderFileTree renders nodes (and the optional Root) into a string safe to
+// embed inside AltScreen views.
+func RenderFileTree(nodes []TreeNode, opts FileTreeOpts) string {
+	width := opts.MaxWidth
+	if width <= 0 {
+		width = termWidth()
+	}
+
+	var buf strings.Builder
+
+	// Styles used across nodes. Foreground-only so they compose cleanly with
+	// the NodeCurrent background wrap below.
+	nameStyles := nameStyleMap()
+	noteStyle := lipgloss.NewStyle().Foreground(ColorMuted)
+	badgeNewStyle := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true)
+	badgeReqStyle := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
+
+	// Root label (if present).
+	if opts.Root != nil {
+		line := renderNodeLine(*opts.Root, "", "", width, nameStyles, noteStyle, badgeNewStyle, badgeReqStyle)
+		buf.WriteString(line)
+		buf.WriteString("\n")
+	}
+
+	// Children indent under root when a root is provided.
+	childPrefix := ""
+	if opts.Root != nil {
+		childPrefix = "│  "
+	}
+
+	for i, n := range nodes {
+		last := i == len(nodes)-1
+		renderSubtree(&buf, n, childPrefix, last, opts, width, nameStyles, noteStyle, badgeNewStyle, badgeReqStyle)
+		// Insert blank-line separator between siblings at the top level in
+		// non-dense mode. The separator is emitted after every sibling
+		// except the final one so trailing whitespace stays bounded.
+		if !opts.Dense && !last {
+			buf.WriteString("\n")
+		}
+	}
+
+	return buf.String()
+}
+
+// renderSubtree writes one TreeNode (plus its descendants) into buf. prefix
+// is the accumulated continuation string drawn before the branch glyph for
+// this node. last controls whether this node uses "└─ " / "   " instead of
+// "├─ " / "│  " for its descendants.
+func renderSubtree(
+	buf *strings.Builder,
+	n TreeNode,
+	prefix string,
+	last bool,
+	opts FileTreeOpts,
+	width int,
+	nameStyles map[nameKey]lipgloss.Style,
+	noteStyle, badgeNewStyle, badgeReqStyle lipgloss.Style,
+) {
+	branch := "├─ "
+	if last {
+		branch = "└─ "
+	}
+
+	line := renderNodeLine(n, prefix, branch, width, nameStyles, noteStyle, badgeNewStyle, badgeReqStyle)
+	buf.WriteString(line)
+	buf.WriteString("\n")
+
+	if n.Kind != NodeDir || len(n.Children) == 0 {
+		return
+	}
+
+	nextPrefix := prefix + "│  "
+	if last {
+		nextPrefix = prefix + "   "
+	}
+	for i, c := range n.Children {
+		childLast := i == len(n.Children)-1
+		renderSubtree(buf, c, nextPrefix, childLast, opts, width, nameStyles, noteStyle, badgeNewStyle, badgeReqStyle)
+		if !opts.Dense && !childLast {
+			buf.WriteString("\n")
+		}
+	}
+}
+
+// renderNodeLine builds a single row: [current-border] prefix + branch + name
+// + note + right-aligned badge, optionally wrapped in a leaf-tint background
+// when NodeCurrent is set.
+func renderNodeLine(
+	n TreeNode,
+	prefix, branch string,
+	width int,
+	nameStyles map[nameKey]lipgloss.Style,
+	noteStyle, badgeNewStyle, badgeReqStyle lipgloss.Style,
+) string {
+	// Stable plain-text tree scaffold — used both as the rendered leader and
+	// as the basis for width math (styles do not affect cell width).
+	leader := prefix + branch
+
+	name := n.Name
+	if n.Kind == NodeDir && !strings.HasSuffix(name, "/") {
+		name += "/"
+	}
+	styledName := nameStyles[nameKey{kind: n.Kind, status: n.Status}].Render(name)
+
+	// Badge.
+	var badgeRaw, badgeStyled string
+	switch n.Status {
+	case NodeNew:
+		badgeRaw = badgeNew
+		badgeStyled = badgeNewStyle.Render(badgeNew)
+	case NodeRequired:
+		badgeRaw = badgeRequired
+		badgeStyled = badgeReqStyle.Render(badgeRequired)
+	}
+
+	// Compute budgets in visible columns.
+	leftCols := lipgloss.Width(leader) + lipgloss.Width(name)
+	noteGap := 0
+	note := n.Note
+	if note != "" {
+		noteGap = 2 // two-space gap before the note
+	}
+
+	badgeCols := 0
+	if badgeRaw != "" {
+		badgeCols = badgeColWidth // badge + trailing space
+	}
+
+	// NodeCurrent consumes two extra visible columns for the "│ " left border.
+	currentCols := 0
+	if n.Status == NodeCurrent {
+		currentCols = 2
+	}
+
+	// Decide how much of the note we can show without overflowing the row.
+	// Budget = width - current-border - left-content - note-gap - badge-col.
+	noteBudget := width - currentCols - leftCols - noteGap - badgeCols
+	if noteBudget < 0 {
+		noteBudget = 0
+	}
+	if note != "" && lipgloss.Width(note) > noteBudget {
+		note = ansi.Truncate(note, noteBudget, "…")
+	}
+	styledNote := ""
+	if note != "" {
+		styledNote = strings.Repeat(" ", noteGap) + noteStyle.Render(note)
+	}
+
+	// Compose the visible line (without the optional current-border wrap).
+	row := leader + styledName + styledNote
+
+	if badgeRaw != "" {
+		// Badge block = label + trailing spaces = exactly badgeColWidth cols.
+		trailing := badgeColWidth - lipgloss.Width(badgeRaw)
+		if trailing < 1 {
+			trailing = 1
+		}
+		badgeBlock := badgeStyled + strings.Repeat(" ", trailing)
+
+		// Right-align the block so its trailing space sits at column
+		// (width - currentCols). Pad is whatever space remains between the
+		// row content and the badge block; always keep at least 1 column of
+		// visual breathing room.
+		rowVis := lipgloss.Width(row)
+		pad := width - currentCols - badgeColWidth - rowVis
+		if pad < 1 {
+			pad = 1
+		}
+		row += strings.Repeat(" ", pad) + badgeBlock
+	}
+
+	if n.Status == NodeCurrent {
+		// Prepend leaf-colored left border. The trailing row already carries
+		// no background; wrap the whole line in a Leaf-tint background so the
+		// highlight spans the width.
+		borderStyle := lipgloss.NewStyle().Foreground(ColorPrimary)
+		border := borderStyle.Render("│ ")
+		// Pad trailing spaces so the background stretches to width.
+		currentBg := lipgloss.NewStyle().Background(ColorLeafDim)
+		rowVis := lipgloss.Width(row)
+		pad := width - currentCols - rowVis
+		if pad < 0 {
+			pad = 0
+		}
+		highlight := currentBg.Render(row + strings.Repeat(" ", pad))
+		return border + highlight
+	}
+
+	return row
+}
+
+// nameKey indexes the precomputed name styles.
+type nameKey struct {
+	kind   NodeKind
+	status NodeStatus
+}
+
+// nameStyleMap returns the lookup used by renderNodeLine for name coloring.
+// Built on each Render call so that DisableColor() and palette swaps take
+// effect without package-init ordering surprises.
+func nameStyleMap() map[nameKey]lipgloss.Style {
+	leafBold := lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true)
+	barkBold := lipgloss.NewStyle().Foreground(ColorSecondary).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(ColorPrimary)
+	subtleBold := lipgloss.NewStyle().Foreground(ColorSubtle).Bold(true)
+	subtle := lipgloss.NewStyle().Foreground(ColorSubtle)
+
+	m := map[nameKey]lipgloss.Style{}
+	// Files
+	for _, st := range []NodeStatus{NodeNormal, NodeNew, NodeRequired, NodeCurrent} {
+		switch st {
+		case NodeNew:
+			m[nameKey{NodeFile, st}] = leaf
+		case NodeRequired:
+			m[nameKey{NodeFile, st}] = subtleBold
+		default:
+			m[nameKey{NodeFile, st}] = subtle
+		}
+	}
+	// Directories
+	for _, st := range []NodeStatus{NodeNormal, NodeNew, NodeRequired, NodeCurrent} {
+		if st == NodeCurrent {
+			m[nameKey{NodeDir, st}] = leafBold
+		} else {
+			m[nameKey{NodeDir, st}] = barkBold
+		}
+	}
+	return m
+}

--- a/internal/tui/filetree_test.go
+++ b/internal/tui/filetree_test.go
@@ -1,0 +1,268 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
+)
+
+// ansiVisible strips ANSI escape sequences so string assertions can focus on
+// the rendered glyph layer without caring about styling. Uses the same ansi
+// helper used by the rest of the TUI package.
+func ansiVisible(s string) string {
+	return ansi.Strip(s)
+}
+
+// forceColorProfile turns on a truecolor profile for the duration of a test,
+// then restores the prior profile. Useful for asserting ANSI escape presence
+// (NodeCurrent background) which otherwise gets stripped under the ASCII
+// profile installed by init() when stdout isn't a TTY.
+func forceColorProfile(t *testing.T, p termenv.Profile) {
+	t.Helper()
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(p)
+	t.Cleanup(func() {
+		lipgloss.SetColorProfile(prev)
+	})
+}
+
+func TestRenderFileTree_FlatBranchGlyphs(t *testing.T) {
+	nodes := []TreeNode{
+		{Name: "one.md", Kind: NodeFile},
+		{Name: "two.md", Kind: NodeFile},
+		{Name: "three.md", Kind: NodeFile},
+	}
+	out := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 60}))
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), out)
+	}
+	if !strings.HasPrefix(lines[0], "├─ ") {
+		t.Errorf("line 0 should start with intermediate branch glyph; got %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "├─ ") {
+		t.Errorf("line 1 should start with intermediate branch glyph; got %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "└─ ") {
+		t.Errorf("final line should start with last-branch glyph; got %q", lines[2])
+	}
+}
+
+func TestRenderFileTree_NestedContinuationPrefix(t *testing.T) {
+	nodes := []TreeNode{
+		{
+			Name: "station", Kind: NodeDir,
+			Children: []TreeNode{
+				{Name: "alpha.md", Kind: NodeFile},
+				{Name: "beta.md", Kind: NodeFile},
+			},
+		},
+		{Name: "README.md", Kind: NodeFile},
+	}
+	out := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 60}))
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	// Expect the station/ dir (non-last) to use │  continuation for its
+	// children, since it is followed by README.md at the top level.
+	want := []string{
+		"├─ station/",
+		"│  ├─ alpha.md",
+		"│  └─ beta.md",
+		"└─ README.md",
+	}
+	for i, w := range want {
+		if i >= len(lines) {
+			t.Fatalf("missing line %d; got:\n%s", i, out)
+		}
+		if !strings.HasPrefix(lines[i], w) {
+			t.Errorf("line %d: want prefix %q, got %q", i, w, lines[i])
+		}
+	}
+}
+
+func TestRenderFileTree_NestedLastDirSpaceContinuation(t *testing.T) {
+	// When the last top-level node is a directory, its grandchild continuation
+	// prefix should be three spaces ("   ") instead of "│  ".
+	nodes := []TreeNode{
+		{Name: "README.md", Kind: NodeFile},
+		{
+			Name: "station", Kind: NodeDir,
+			Children: []TreeNode{
+				{Name: "alpha.md", Kind: NodeFile},
+				{Name: "beta.md", Kind: NodeFile},
+			},
+		},
+	}
+	out := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 60}))
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+
+	// "   ├─ alpha.md" and "   └─ beta.md" under a last-dir parent.
+	if !strings.HasPrefix(lines[2], "   ├─ alpha.md") {
+		t.Errorf("expected three-space continuation before alpha; got %q", lines[2])
+	}
+	if !strings.HasPrefix(lines[3], "   └─ beta.md") {
+		t.Errorf("expected three-space continuation before beta; got %q", lines[3])
+	}
+}
+
+func TestRenderFileTree_NewBadgeAndLeafName(t *testing.T) {
+	forceColorProfile(t, termenv.TrueColor)
+	nodes := []TreeNode{
+		{Name: "log.md", Kind: NodeFile, Status: NodeNew, Note: "session rolling log"},
+	}
+	raw := RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 80})
+	visible := ansiVisible(raw)
+
+	if !strings.Contains(visible, "NEW") {
+		t.Errorf("expected NEW badge in output; got %q", visible)
+	}
+	if !strings.Contains(visible, "session rolling log") {
+		t.Errorf("expected note in output; got %q", visible)
+	}
+	// Badge ends exactly at MaxWidth (80), with a trailing space as part of
+	// the 9-col block. The trimmed line length must equal width - trailing
+	// spaces after the badge.
+	line := strings.Split(strings.TrimRight(visible, "\n"), "\n")[0]
+	if w := lipgloss.Width(line); w != 80 {
+		t.Errorf("expected rendered line width %d (MaxWidth), got %d (line=%q)", 80, w, line)
+	}
+	// Leaf foreground color ANSI should appear at least once (name + badge).
+	if !strings.Contains(raw, "\x1b[") {
+		t.Errorf("expected ANSI escape sequences when truecolor profile is forced; got %q", raw)
+	}
+}
+
+func TestRenderFileTree_RequiredBadge(t *testing.T) {
+	nodes := []TreeNode{
+		{Name: "CLAUDE.md", Kind: NodeFile, Status: NodeRequired},
+	}
+	out := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 60}))
+	if !strings.Contains(out, "REQUIRED") {
+		t.Errorf("expected REQUIRED badge in output; got %q", out)
+	}
+}
+
+func TestRenderFileTree_CurrentBorderAndBackground(t *testing.T) {
+	forceColorProfile(t, termenv.TrueColor)
+	nodes := []TreeNode{
+		{Name: "agent", Kind: NodeDir, Status: NodeCurrent, Children: []TreeNode{
+			{Name: "identity.md", Kind: NodeFile},
+		}},
+	}
+	raw := RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 60})
+	visible := ansiVisible(raw)
+
+	// Current node prepends "│ " (two visible cols) in Leaf.
+	lines := strings.Split(strings.TrimRight(visible, "\n"), "\n")
+	if !strings.HasPrefix(lines[0], "│ ") {
+		t.Errorf("NodeCurrent should prepend a 2-col leaf border; got %q", lines[0])
+	}
+	// Background ANSI sequence must be present (SGR code for background).
+	if !strings.Contains(raw, "\x1b[") {
+		t.Fatalf("expected ANSI escapes under truecolor profile; got %q", raw)
+	}
+	// Background code for lipgloss is either "48;" (truecolor) or "48;5;"
+	// (256-color). Either substring satisfies the assertion.
+	if !strings.Contains(raw, "\x1b[48;") && !strings.Contains(raw, "48;5;") {
+		t.Errorf("expected a background SGR code on NodeCurrent row; raw=%q", raw)
+	}
+}
+
+func TestRenderFileTree_DenseHasNoBlankSeparators(t *testing.T) {
+	nodes := []TreeNode{
+		{Name: "a.md", Kind: NodeFile},
+		{Name: "b.md", Kind: NodeFile},
+		{Name: "c.md", Kind: NodeFile},
+	}
+	dense := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 60}))
+	if strings.Contains(strings.TrimRight(dense, "\n"), "\n\n") {
+		t.Errorf("Dense mode should not contain blank separator lines; got:\n%s", dense)
+	}
+
+	spaced := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Dense: false, MaxWidth: 60}))
+	if !strings.Contains(spaced, "\n\n") {
+		t.Errorf("Non-dense mode should insert blank separator lines between siblings; got:\n%s", spaced)
+	}
+}
+
+func TestRenderFileTree_MaxWidthTrimsNote(t *testing.T) {
+	longNote := "this note is intentionally quite long and should be truncated with an ellipsis"
+	nodes := []TreeNode{
+		{Name: "f.md", Kind: NodeFile, Note: longNote},
+	}
+	out := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Dense: true, MaxWidth: 40}))
+	if !strings.Contains(out, "…") {
+		t.Errorf("expected truncation ellipsis when MaxWidth forces trim; got %q", out)
+	}
+	line := strings.Split(strings.TrimRight(out, "\n"), "\n")[0]
+	if w := lipgloss.Width(line); w > 40 {
+		t.Errorf("line should not exceed MaxWidth=40; got width=%d line=%q", w, line)
+	}
+}
+
+func TestRenderFileTree_RootLabel(t *testing.T) {
+	root := &TreeNode{Name: "station", Kind: NodeDir, Note: "workspace root"}
+	nodes := []TreeNode{
+		{Name: "alpha.md", Kind: NodeFile},
+		{Name: "beta.md", Kind: NodeFile},
+	}
+	out := ansiVisible(RenderFileTree(nodes, FileTreeOpts{Root: root, Dense: true, MaxWidth: 60}))
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+
+	if len(lines) < 3 {
+		t.Fatalf("expected at least root + 2 children; got %d:\n%s", len(lines), out)
+	}
+	// Root line first with station/ + note.
+	if !strings.Contains(lines[0], "station/") || !strings.Contains(lines[0], "workspace root") {
+		t.Errorf("root line missing name or note; got %q", lines[0])
+	}
+	// Children hang under the root with the │  continuation prefix.
+	if !strings.HasPrefix(lines[1], "│  ├─ alpha.md") {
+		t.Errorf("first child should hang under root with │  prefix; got %q", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "│  └─ beta.md") {
+		t.Errorf("last child should hang under root with │  prefix; got %q", lines[2])
+	}
+}
+
+// TestRenderFileTree_Demo prints a fully-populated tree so the rendered
+// output can be eyeballed against the design reference. Not an assertion
+// test — it is kept alongside the rule tests as a visual regression aid.
+// Run with:  go test ./internal/tui/... -v -run TestRenderFileTree_Demo
+func TestRenderFileTree_Demo(t *testing.T) {
+	forceColorProfile(t, termenv.TrueColor)
+
+	root := &TreeNode{
+		Name: "~/code/voyager-api",
+		Kind: NodeDir,
+		Note: "workspace root",
+	}
+	nodes := []TreeNode{
+		{Name: "CLAUDE.md", Kind: NodeFile, Status: NodeRequired, Note: "root-level agent directive"},
+		{Name: ".bonsai.yaml", Kind: NodeFile, Status: NodeNew, Note: "project config"},
+		{
+			Name: "station", Kind: NodeDir, Status: NodeCurrent,
+			Note: "agent workspace",
+			Children: []TreeNode{
+				{Name: "agents-index.md", Kind: NodeFile, Status: NodeRequired, Note: "directory of every agent"},
+				{Name: "session-log.md", Kind: NodeFile, Status: NodeNew, Note: "rolling per-session log"},
+				{
+					Name: "protocols", Kind: NodeDir,
+					Children: []TreeNode{
+						{Name: "memory.md", Kind: NodeFile, Status: NodeNew},
+						{Name: "security.md", Kind: NodeFile, Status: NodeNew},
+					},
+				},
+			},
+		},
+		{Name: "readme.md", Kind: NodeFile, Status: NodeNew, Note: "starter README"},
+	}
+
+	spaced := RenderFileTree(nodes, FileTreeOpts{Root: root, MaxWidth: 80})
+	dense := RenderFileTree(nodes, FileTreeOpts{Root: root, Dense: true, MaxWidth: 80})
+
+	t.Log("\n── DEMO (spaced, MaxWidth=80) ──\n" + spaced)
+	t.Log("\n── DEMO (dense,  MaxWidth=80) ──\n" + dense)
+}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -68,6 +68,16 @@ var (
 	ColorInfo      = Water // Info panels, review box
 )
 
+// Enso / rule chrome tokens — used by the init-flow chrome. Dimmer shades of
+// Leaf/Stone for at-rest rail segments and thin dividers. Kept separate from
+// the primary semantic tokens above so other commands keep their current
+// palette untouched.
+var (
+	ColorLeafDim lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#3A7253", Light: "#3D6D53"}
+	ColorRule    lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#3B4049", Light: "#D4D0CA"}
+	ColorRule2   lipgloss.TerminalColor = lipgloss.AdaptiveColor{Dark: "#4A4F58", Light: "#B9B5AF"}
+)
+
 // ─── Styles ───────────────────────────────────────────────────────────────
 
 var (


### PR DESCRIPTION
## Summary
Phase 1 of Plan 22 (`bonsai init` cinematic redesign) — adds a reusable rich file-tree renderer (`tui.RenderFileTree`) and three palette tokens for the upcoming init-flow chrome. No behavior change to any existing command.

## Changes
- `internal/tui/filetree.go` — new `RenderFileTree` + `TreeNode` types.
- `internal/tui/filetree_test.go` — unit tests covering every rendering rule + a visual demo test (`TestRenderFileTree_Demo`).
- `internal/tui/styles.go` — add `ColorLeafDim`, `ColorRule`, `ColorRule2` adaptive-color tokens.

## Plan
station/Playbook/Plans/Active/22-init-redesign.md — Phase 1.

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `gofmt -s -l .` — clean
- [x] `go vet ./...` — clean
- [x] Existing `tui.FileTree` callers unchanged (`cmd/root.go` add/remove/update panels still compile).