### PR TITLE
feat(init): Plan 22 Phase 2 — initflow package + Chromeless harness hook

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -118,6 +118,12 @@ func asBool(v any) bool {
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
+	// BONSAI_REDESIGN=1 routes to the in-progress cinematic flow (Plan 22).
+	// Default behaviour is unchanged until the redesign ships Phase 5.
+	if os.Getenv("BONSAI_REDESIGN") == "1" {
+		return runInitRedesign(cmd, args)
+	}
+
 	cwd := mustCwd()
 	configPath := filepath.Join(cwd, configFile)
 

--- a/cmd/init_redesign.go
+++ b/cmd/init_redesign.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/harness"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// runInitRedesign is the Phase-2 stub entry point for Plan 22's cinematic
+// `bonsai init` flow. It renders the persistent chrome (header + enso rail
+// + footer) around four placeholder stages that advance on Enter and pop
+// on Esc. No files are written — the generate + planted pipeline lands in
+// Phases 3–5.
+//
+// Routing: runInit at cmd/init.go:121 branches here when BONSAI_REDESIGN=1.
+// Without the env flag, the legacy flow runs unchanged.
+func runInitRedesign(cmd *cobra.Command, args []string) error {
+	// Capture the session start time once so every stage shares the same
+	// origin — the Planted stage (Phase 5) computes ELAPSED from here.
+	startedAt := time.Now()
+
+	cwd := mustCwd()
+	configPath := filepath.Join(cwd, configFile)
+
+	// Early-exit with the legacy warning copy so both flows respond
+	// identically to an existing config.
+	if _, err := os.Stat(configPath); err == nil {
+		tui.WarningPanel(configFile + " already exists. Skipping init.")
+		return nil
+	}
+
+	cat := loadCatalog()
+
+	const techLeadType = "tech-lead"
+	agentDef := cat.GetAgent(techLeadType)
+	if agentDef == nil {
+		tui.FatalPanel("Tech Lead agent not found",
+			"The built-in catalog is missing the tech-lead agent.",
+			"This is a bug — please report it.")
+	}
+
+	// Pull the display name with a derive-from-machine-name fallback so the
+	// Observe stage (Phase 5) can always render AGENT row correctly.
+	agentDisplay := agentDef.DisplayName
+	if agentDisplay == "" {
+		agentDisplay = catalog.DisplayNameFrom(agentDef.Name)
+	}
+
+	// Shared context stamped on every stage. Station defaults to "station/"
+	// until Phase 3's VesselStage captures a user-entered value.
+	ctx := initflow.StageContext{
+		Version:      Version,
+		ProjectDir:   cwd,
+		StationDir:   "station/",
+		AgentDisplay: agentDisplay,
+		StartedAt:    startedAt,
+	}
+
+	steps := []harness.Step{
+		initflow.NewStubStage(0, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
+		initflow.NewStubStage(1, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
+		initflow.NewStubStage(2, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
+		initflow.NewStubStage(3, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
+	}
+
+	bannerLine := "BONSAI"
+	if Version != "" && Version != "dev" {
+		bannerLine = fmt.Sprintf("BONSAI v%s", Version)
+	}
+
+	_, err := harness.Run(bannerLine, "Initializing new project (redesign)", steps)
+	if err != nil {
+		if errors.Is(err, harness.ErrAborted) {
+			// Ctrl-C — no config / files written in Phase 2 either way.
+			return nil
+		}
+		var bpe *harness.BuilderPanicError
+		if errors.As(err, &bpe) {
+			tui.FatalPanel("Harness builder panic",
+				fmt.Sprintf("Step %q: %v", bpe.Step, bpe.Value),
+				"This is a bug — please report it.")
+			return nil
+		}
+		return err
+	}
+
+	// Phase 2 does not write files, save config, or run a conflict picker —
+	// those wire up in Phases 3–5. Returning cleanly after the flow exits
+	// AltScreen is the expected behaviour for this phase.
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/mattn/go-isatty v0.0.21
+	github.com/mattn/go-runewidth v0.0.23
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.42.0
@@ -42,7 +43,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.23 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/internal/tui/harness/harness.go
+++ b/internal/tui/harness/harness.go
@@ -102,6 +102,16 @@ type resetter interface {
 	Reset() tea.Cmd
 }
 
+// Chromeless is an optional Step capability. When a step returns true, the
+// harness skips rendering its default header/footer and yields the full frame
+// to Step.View(). The step is responsible for drawing its own chrome (banner,
+// breadcrumb, progress, footer keys). Used by the `internal/tui/initflow`
+// cinematic stages so they can own the entire AltScreen while still plugging
+// into the harness cursor / prev-results machinery.
+type Chromeless interface {
+	Chromeless() bool
+}
+
 // Harness is the root tea.Model that frames the active step.
 type Harness struct {
 	steps        []Step
@@ -373,6 +383,12 @@ func (h *Harness) View() string {
 	}
 	if h.cursor >= len(h.steps) {
 		return ""
+	}
+
+	// Chromeless short-circuit: a step that opts in owns the entire frame and
+	// draws its own header / footer. The harness yields Step.View() verbatim.
+	if c, ok := h.steps[h.cursor].(Chromeless); ok && c.Chromeless() {
+		return h.steps[h.cursor].View()
 	}
 
 	header := h.renderHeader()

--- a/internal/tui/harness/harness_test.go
+++ b/internal/tui/harness/harness_test.go
@@ -610,6 +610,70 @@ func TestEscBackReevaluatesConditional(t *testing.T) {
 	}
 }
 
+// fakeChromelessStep satisfies Step plus Chromeless so the harness short-
+// circuits its View() composition and yields the step's raw frame.
+type fakeChromelessStep struct {
+	fakeStep
+	chromeless bool
+}
+
+func (f *fakeChromelessStep) Chromeless() bool { return f.chromeless }
+
+// Override Update so the harness receives a value that still satisfies
+// Chromeless on the next tick (dropping to *fakeStep would shed the capability).
+func (f *fakeChromelessStep) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	f.received = append(f.received, msg)
+	if w, ok := msg.(tea.WindowSizeMsg); ok {
+		f.width = w.Width
+		f.height = w.Height
+	}
+	return f, nil
+}
+
+// TestChromelessStepBypassesHarnessChrome verifies that when a step opts into
+// the Chromeless capability, Harness.View returns the step's View() verbatim
+// without prepending the default header/footer. Regression guard for the
+// `internal/tui/initflow` cinematic stages that own the whole frame.
+func TestChromelessStepBypassesHarnessChrome(t *testing.T) {
+	const frame = "CINEMATIC-FRAME-BODY"
+	cs := &fakeChromelessStep{
+		fakeStep:   fakeStep{title: "cinematic"},
+		chromeless: true,
+	}
+	// Override View via the embedded fakeStep field by replacing title — easier:
+	// use a dedicated helper type below. Instead override inline with a wrapper.
+	csFrame := &chromelessFrameStep{fakeChromelessStep: *cs, frame: frame}
+	h := New("BANNER", "TEST", []Step{csFrame})
+	// Seed a window size so the chrome-full path would otherwise have enough
+	// room to render its header/footer — this isolates the Chromeless bypass.
+	_, _ = h.Update(tea.WindowSizeMsg{Width: 120, Height: 32})
+
+	got := h.View()
+	if got != frame {
+		t.Fatalf("expected Chromeless View() verbatim %q, got %q", frame, got)
+	}
+}
+
+// chromelessFrameStep is a fakeChromelessStep that returns a canned View() so
+// the test can assert the harness didn't add chrome around it.
+type chromelessFrameStep struct {
+	fakeChromelessStep
+	frame string
+}
+
+func (f *chromelessFrameStep) View() string { return f.frame }
+
+// Update must also return the outer type so the harness retains the custom
+// View() across ticks.
+func (f *chromelessFrameStep) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	f.received = append(f.received, msg)
+	if w, ok := msg.(tea.WindowSizeMsg); ok {
+		f.width = w.Width
+		f.height = w.Height
+	}
+	return f, nil
+}
+
 // cmdContainsSentinel walks a tea.Cmd (expanding tea.BatchMsg one level) and
 // returns true if any produced message is a resetSentinelMsg.
 func cmdContainsSentinel(cmd tea.Cmd) bool {

--- a/internal/tui/initflow/chrome.go
+++ b/internal/tui/initflow/chrome.go
@@ -1,0 +1,157 @@
+package initflow
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/tui"
+)
+
+// KeyHint is a single entry in the footer key row: one glyph/token plus a
+// short descriptor. Kept as a small value type so callers can build
+// []KeyHint slices inline from each stage's View().
+type KeyHint struct {
+	Key  string // e.g. "↵", "␣", "?", "esc"
+	Desc string // e.g. "continue", "toggle", "details"
+}
+
+// RenderHeader renders the two-column top banner shown above every stage.
+//
+//	Left:  [盆] BONSAI · INITIALIZE · v<version>
+//	Right: PLANTING INTO
+//	       ~/.../<project>/<station>
+//
+// version "dev" / "" hides the version segment. projectDir is the absolute
+// path to the project root; stationSubdir is the subdir under it (e.g.
+// "station/"). safe gates the single wide-char glyph so ASCII-only terminals
+// get a safe substitute.
+func RenderHeader(version, projectDir, stationSubdir string, width int, safe bool) string {
+	if width <= 0 {
+		width = 80
+	}
+
+	primary := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+
+	// ── Left block ───────────────────────────────────────────────────
+	mark := "盆"
+	if !safe {
+		mark = "o"
+	}
+	leftParts := []string{
+		muted.Render("[") + primary.Render(mark) + muted.Render("]"),
+		primary.Render("BONSAI"),
+		muted.Render("·"),
+		muted.Render("INITIALIZE"),
+	}
+	if version != "" && version != "dev" {
+		leftParts = append(leftParts,
+			muted.Render("·"),
+			muted.Render("v"+version),
+		)
+	}
+	left := strings.Join(leftParts, " ")
+
+	// ── Right block ──────────────────────────────────────────────────
+	// "PLANTING INTO" headline above "~/path/<project>/<station>"
+	projectDisplay := collapseHome(projectDir)
+	projectName := filepath.Base(projectDir)
+	parent := filepath.Dir(projectDisplay)
+	// Render parent muted, project name bark, station leaf.
+	station := stationSubdir
+	if station != "" && !strings.HasSuffix(station, "/") {
+		station += "/"
+	}
+	if parent == "." || parent == "" {
+		parent = ""
+	} else if !strings.HasSuffix(parent, "/") {
+		parent += "/"
+	}
+	pathRow := muted.Render(parent) + bark.Render(projectName) + muted.Render("/") + leaf.Render(station)
+	rightRow1 := muted.Render("PLANTING INTO")
+
+	// ── Compose two-row layout with left-padded right block ─────────
+	// Row 1: left + spaces + rightRow1
+	// Row 2: spaces (matching left width) + pathRow
+	leftW := lipgloss.Width(left)
+	right1W := lipgloss.Width(rightRow1)
+	right2W := lipgloss.Width(pathRow)
+	// Pick the wider right side to use as the target anchor so both rows
+	// right-align consistently.
+	rightW := right1W
+	if right2W > rightW {
+		rightW = right2W
+	}
+	gap := width - leftW - rightW - 2 // -2 for 1-col padding each side
+	if gap < 2 {
+		gap = 2
+	}
+	// Right-pad row 1 / row 2 so their right columns align.
+	row1 := left + strings.Repeat(" ", gap) + strings.Repeat(" ", rightW-right1W) + rightRow1
+	row2Left := strings.Repeat(" ", leftW+gap)
+	row2 := row2Left + strings.Repeat(" ", rightW-right2W) + pathRow
+
+	// Pad both rows to width so AltScreen doesn't see ragged edges.
+	row1 = padRight(row1, width)
+	row2 = padRight(row2, width)
+	return row1 + "\n" + row2
+}
+
+// RenderFooter draws the bottom hairline row: brand on the left, the passed
+// key hints on the right, separated by a muted dot.
+//
+//	一 BONSAI 一               ↵ continue · esc back · ctrl-c quit
+func RenderFooter(hints []KeyHint, width int) string {
+	if width <= 0 {
+		width = 80
+	}
+
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	primary := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+
+	left := muted.Render("一 ") + primary.Render("BONSAI") + muted.Render(" 一")
+	// Render each hint as "<KEY> desc" with the key in muted-emphasis.
+	parts := make([]string, 0, len(hints))
+	for _, h := range hints {
+		key := muted.Render(h.Key)
+		desc := muted.Render(h.Desc)
+		parts = append(parts, key+" "+desc)
+	}
+	sep := muted.Render("  " + tui.GlyphDot + "  ")
+	right := strings.Join(parts, sep)
+
+	leftW := lipgloss.Width(left)
+	rightW := lipgloss.Width(right)
+	gap := width - leftW - rightW - 2
+	if gap < 2 {
+		gap = 2
+	}
+	row := " " + left + strings.Repeat(" ", gap) + right + " "
+	return padRight(row, width)
+}
+
+// padRight right-pads s with spaces so its visible width reaches w.
+func padRight(s string, w int) string {
+	cur := lipgloss.Width(s)
+	if cur >= w {
+		return s
+	}
+	return s + strings.Repeat(" ", w-cur)
+}
+
+// collapseHome replaces a leading $HOME prefix with "~" for display. Fails
+// safely by returning the original path if the lookup errors.
+func collapseHome(abs string) string {
+	home, err := homeDir()
+	if err != nil || home == "" {
+		return abs
+	}
+	if strings.HasPrefix(abs, home) {
+		return "~" + abs[len(home):]
+	}
+	return abs
+}

--- a/internal/tui/initflow/enso.go
+++ b/internal/tui/initflow/enso.go
@@ -1,0 +1,261 @@
+package initflow
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/tui"
+)
+
+// Enso progress glyphs — referenced from Plan 22 decision Q5.
+const (
+	ensoDone    = "●"
+	ensoPending = "○"
+	railChar    = "─"
+)
+
+// RenderEnsoRail draws the 4-stage progress rail used above every stage's
+// body. Rendered as three rows:
+//
+//	row 1: ● ─── ● ─── ◉ ─── ○        (dots + connector segments)
+//	row 2: VESSEL  SOIL  BRANCHES  OBSERVE   (stage labels)
+//	row 3:                えだ                 (kana, current stage only)
+//
+// When safe=false (WideCharSafe() reported false or BONSAI_ASCII_ONLY=1 is
+// set), the dots collapse to bracketed ASCII: [x] for done, [ ] for
+// pending, [N] for current. No kana row is emitted.
+//
+// stageIdx is the 0-based current stage. width is the terminal column count
+// the rail should occupy. Layout tries to centre the rail inside width; the
+// dot/bracket glyphs sit at fixed anchors with equal-length connector runs
+// between them. Labels are centred under each anchor.
+func RenderEnsoRail(stageIdx int, width int, safe bool) string {
+	if width <= 0 {
+		width = 80
+	}
+
+	// Clamp index to the valid range so callers don't have to guard.
+	if stageIdx < 0 {
+		stageIdx = 0
+	}
+	if stageIdx > len(StageLabels)-1 {
+		stageIdx = len(StageLabels) - 1
+	}
+
+	// Glyph + styled rendering for each anchor and connector.
+	numStages := len(StageLabels)
+	anchors := make([]string, numStages)
+	anchorWidths := make([]int, numStages)
+	for i := range StageLabels {
+		glyph, w := anchorGlyph(i, stageIdx, safe)
+		anchors[i] = glyph
+		anchorWidths[i] = w
+	}
+
+	// Total anchor-glyph columns, then distribute remaining width across the
+	// 3 connector gaps between them. Leave a little side padding for breathing
+	// room. Minimum connector length of 3.
+	const minConn = 3
+	const sidePad = 2
+	sumAnchor := 0
+	for _, w := range anchorWidths {
+		sumAnchor += w
+	}
+	connectors := numStages - 1
+	inner := width - sidePad*2
+	connLen := (inner - sumAnchor) / connectors
+	if connLen < minConn {
+		connLen = minConn
+	}
+
+	// Build row 1: dot ─── dot ─── dot ─── dot
+	var row1 strings.Builder
+	row1.WriteString(strings.Repeat(" ", sidePad))
+	for i := 0; i < numStages; i++ {
+		row1.WriteString(anchors[i])
+		if i < numStages-1 {
+			row1.WriteString(railSegment(i, stageIdx, connLen))
+		}
+	}
+
+	// Compute column positions of each anchor so row 2 / row 3 labels can
+	// centre underneath them.
+	colPositions := make([]int, numStages)
+	col := sidePad
+	for i := 0; i < numStages; i++ {
+		colPositions[i] = col + anchorWidths[i]/2
+		col += anchorWidths[i]
+		if i < numStages-1 {
+			col += connLen
+		}
+	}
+
+	// Row 2: stage English labels, centred on each anchor.
+	row2 := placeLabels(colPositions, stageLabelTexts(safe, stageIdx), width, stageIdx, false)
+
+	// Row 3: kana for the current stage only, when safe.
+	var row3 string
+	if safe {
+		labels := make([]string, numStages)
+		if stageIdx >= 0 && stageIdx < numStages {
+			labels[stageIdx] = StageLabels[stageIdx].Kana
+		}
+		row3 = placeLabels(colPositions, labels, width, stageIdx, true)
+	}
+
+	out := row1.String() + "\n" + row2
+	if row3 != "" {
+		out += "\n" + row3
+	}
+	return out
+}
+
+// anchorGlyph returns the styled glyph (and the visible-width-count) for the
+// i-th stage anchor. The current stage gets a bracketed label ([N] or [Kanji]);
+// completed stages get ● (or [x]); pending stages get ○ (or [ ]).
+func anchorGlyph(i, current int, safe bool) (string, int) {
+	leafStyle := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	leafDim := lipgloss.NewStyle().Foreground(tui.ColorLeafDim)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+
+	if safe {
+		switch {
+		case i < current:
+			return leafDim.Render(ensoDone), 1
+		case i == current:
+			// Render kanji in a small boxed form: [K] — 3 visible cells.
+			// Keep it single-row to avoid fragile multi-row alignment.
+			kanji := StageLabels[i].Kanji
+			content := leafStyle.Render(kanji)
+			return muted.Render("[") + content + muted.Render("]"), 4 // kanji=2 + brackets=2
+		default:
+			return muted.Render(ensoPending), 1
+		}
+	}
+
+	// ASCII fallback: [x] done, [N] current (one-indexed), [ ] pending.
+	switch {
+	case i < current:
+		return muted.Render("[") + leafDim.Render("x") + muted.Render("]"), 3
+	case i == current:
+		return muted.Render("[") + leafStyle.Render(itoa(i+1)) + muted.Render("]"), 3
+	default:
+		return muted.Render("[ ]"), 3
+	}
+}
+
+// railSegment renders the "─────" between anchors i and i+1.
+// Segments before the current stage are tinted LeafDim; segments at or
+// beyond the current stage are muted Rule2.
+func railSegment(i, current, length int) string {
+	if length < 1 {
+		length = 1
+	}
+	seg := strings.Repeat(railChar, length)
+	if i < current {
+		return lipgloss.NewStyle().Foreground(tui.ColorLeafDim).Render(seg)
+	}
+	return lipgloss.NewStyle().Foreground(tui.ColorRule2).Render(seg)
+}
+
+// placeLabels renders a row where each non-empty label in `labels` is
+// horizontally centred on the corresponding column in `colPositions`.
+// Labels are padded with spaces to fill the row up to `width`.
+//
+// If kana is true, the current-stage label is rendered muted. Otherwise
+// the current-stage label is rendered leaf-bold while other labels are
+// muted.
+func placeLabels(colPositions []int, labels []string, width, current int, kana bool) string {
+	leafStyle := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+
+	// Build a character-indexed buffer; we overlay each label centred on
+	// its anchor column. Use runes to keep multibyte labels addressable.
+	buf := make([]rune, width)
+	for i := range buf {
+		buf[i] = ' '
+	}
+	for i, text := range labels {
+		if text == "" {
+			continue
+		}
+		runes := []rune(text)
+		// centre the label on colPositions[i]; half of the width to the left.
+		// Use runeWidth-unaware arithmetic here because the labels are
+		// English ASCII ("VESSEL" etc.) OR kana rendered on safe terminals
+		// where kana occupies 2 cells per char — which we compensate for by
+		// treating rune count as char count; perfect centring is not
+		// critical for a three-row rail.
+		start := colPositions[i] - len(runes)/2
+		if start < 0 {
+			start = 0
+		}
+		for j, r := range runes {
+			if start+j >= len(buf) {
+				break
+			}
+			buf[start+j] = r
+		}
+	}
+
+	// Rebuild the row, applying per-label styling by splitting on the
+	// original anchor positions. Simplest: render the whole buffer muted,
+	// then overlay the current label in leaf-bold by substituting at the
+	// right range.
+	out := string(buf)
+	// Trim trailing whitespace to keep the row tidy for small widths.
+	out = strings.TrimRight(out, " ")
+	if kana {
+		return muted.Render(out)
+	}
+	// For the English-label row, apply leaf-bold to the current stage only.
+	if current >= 0 && current < len(labels) && labels[current] != "" {
+		target := labels[current]
+		idx := strings.Index(out, target)
+		if idx >= 0 {
+			prefix := out[:idx]
+			suffix := out[idx+len(target):]
+			return muted.Render(prefix) + leafStyle.Render(target) + muted.Render(suffix)
+		}
+	}
+	return muted.Render(out)
+}
+
+// stageLabelTexts returns the English-label slice for the rail's row 2.
+// Safe vs ASCII has no effect on this row — the English labels always
+// render (the ASCII fallback is on the glyph row above).
+func stageLabelTexts(safe bool, current int) []string {
+	_ = safe // reserved for future styling toggles; labels are uniform today
+	out := make([]string, len(StageLabels))
+	for i, l := range StageLabels {
+		out[i] = l.English
+	}
+	_ = current
+	return out
+}
+
+// itoa is a tiny stdlib-free int-to-string used only for the ASCII fallback
+// rail where the current stage is rendered as "[N]". Avoids pulling strconv
+// into this file just for one callsite.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [12]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/tui/initflow/fallback.go
+++ b/internal/tui/initflow/fallback.go
@@ -1,0 +1,93 @@
+// Package initflow implements the cinematic 4-stage `bonsai init` flow.
+//
+// The package is intentionally self-contained — its primitives (chrome,
+// enso rail, stage base) are only used by the redesigned init path behind
+// the BONSAI_REDESIGN env flag while the legacy flow remains default.
+//
+// fallback.go owns wide-character detection + the stage-label mapping so
+// stage primitives can render kanji/kana on safe terminals and ASCII-only
+// labels on constrained ones.
+package initflow
+
+import (
+	"os"
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// WideCharSafe reports whether the current terminal can reliably render
+// 2-wide CJK characters for the enso-rail kanji. The check is deliberately
+// conservative — on terminals where we cannot prove wide-char support we
+// fall back to the bracketed ASCII rail.
+//
+// Order of checks:
+//  1. BONSAI_ASCII_ONLY=1 — explicit opt-out always wins.
+//  2. runewidth reports East-Asian locale — trust the library.
+//  3. Windows Terminal (WT_SESSION) — modern conhost handles CJK correctly.
+//  4. Allow-listed unix terminals by $TERM prefix.
+//  5. UTF-8 locale ($LC_ALL/$LANG) as a loose signal otherwise.
+//
+// The fall-through returns false only when no positive signal is found —
+// better to render ASCII on a rich terminal than misaligned kanji on a
+// broken one.
+func WideCharSafe() bool {
+	if os.Getenv("BONSAI_ASCII_ONLY") == "1" {
+		return false
+	}
+	if runewidth.EastAsianWidth {
+		return true
+	}
+	if os.Getenv("WT_SESSION") != "" {
+		return true
+	}
+	term := os.Getenv("TERM")
+	goodTerms := []string{"xterm", "screen", "tmux", "alacritty", "kitty", "wezterm", "ghostty"}
+	for _, good := range goodTerms {
+		if strings.HasPrefix(term, good) {
+			return true
+		}
+	}
+	lang := os.Getenv("LC_ALL")
+	if lang == "" {
+		lang = os.Getenv("LANG")
+	}
+	return strings.Contains(strings.ToLower(lang), "utf")
+}
+
+// StageLabel is the triple-label (kanji + kana + English) attached to each
+// of the four init-flow stages. Render picks between the kanji/kana form
+// (when the terminal is wide-char safe) and ASCII-only fallback.
+//
+// Stage labels (design-locked):
+//
+//	器 うつわ Vessel
+//	土 つち  Soil
+//	枝 えだ  Branches
+//	観 みる  Observe
+type StageLabel struct {
+	Kanji   string
+	Kana    string
+	English string
+}
+
+// Render returns (primary, secondary) display strings for this stage label.
+// On wide-safe terminals primary is "<kanji> <English>" and secondary is
+// the kana reading. On ASCII-only terminals primary is English-only and
+// secondary is empty.
+func (l StageLabel) Render(safe bool) (primary, secondary string) {
+	if safe {
+		return l.Kanji + " " + l.English, l.Kana
+	}
+	return l.English, ""
+}
+
+// StageLabels holds the four canonical init-flow stage labels in order.
+// Both the enso rail renderer and stage constructors pull from this table
+// so the text appears in exactly one place.
+var StageLabels = [4]StageLabel{
+	{Kanji: "器", Kana: "うつわ", English: "VESSEL"},
+	{Kanji: "土", Kana: "つち", English: "SOIL"},
+	{Kanji: "枝", Kana: "えだ", English: "BRANCHES"},
+	{Kanji: "観", Kana: "みる", English: "OBSERVE"},
+}

--- a/internal/tui/initflow/fallback_test.go
+++ b/internal/tui/initflow/fallback_test.go
@@ -1,0 +1,65 @@
+package initflow
+
+import (
+	"testing"
+)
+
+// TestWideCharSafe_OptOut verifies BONSAI_ASCII_ONLY=1 forces WideCharSafe
+// to report false regardless of the rest of the environment.
+func TestWideCharSafe_OptOut(t *testing.T) {
+	t.Setenv("BONSAI_ASCII_ONLY", "1")
+	if WideCharSafe() {
+		t.Fatalf("BONSAI_ASCII_ONLY=1 must force WideCharSafe=false")
+	}
+}
+
+// TestStageLabel_RenderASCIIFallback verifies that with safe=false StageLabel
+// renders an English-only primary and an empty secondary — no kanji / kana
+// leaks into the output path on constrained terminals.
+func TestStageLabel_RenderASCIIFallback(t *testing.T) {
+	t.Setenv("BONSAI_ASCII_ONLY", "1")
+	// WideCharSafe should now report false; Render mirrors that contract.
+	safe := WideCharSafe()
+	if safe {
+		t.Fatalf("WideCharSafe should be false under BONSAI_ASCII_ONLY=1")
+	}
+
+	label := StageLabels[2] // Branches
+	primary, secondary := label.Render(safe)
+
+	if primary != "BRANCHES" {
+		t.Fatalf("ascii primary = %q, want %q", primary, "BRANCHES")
+	}
+	if secondary != "" {
+		t.Fatalf("ascii secondary = %q, want empty string", secondary)
+	}
+	// Confirm no kanji/kana slipped through.
+	if containsAny(primary, "枝えだ") {
+		t.Fatalf("ascii primary must not contain kanji/kana: %q", primary)
+	}
+}
+
+// TestStageLabel_RenderSafe verifies the happy path: safe=true yields
+// "<kanji> <English>" + kana secondary.
+func TestStageLabel_RenderSafe(t *testing.T) {
+	label := StageLabels[0] // Vessel
+	primary, secondary := label.Render(true)
+	if primary != "器 VESSEL" {
+		t.Fatalf("safe primary = %q, want %q", primary, "器 VESSEL")
+	}
+	if secondary != "うつわ" {
+		t.Fatalf("safe secondary = %q, want %q", secondary, "うつわ")
+	}
+}
+
+// containsAny reports whether s contains any rune from chars.
+func containsAny(s, chars string) bool {
+	for _, c := range chars {
+		for _, r := range s {
+			if r == c {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/tui/initflow/stage.go
+++ b/internal/tui/initflow/stage.go
@@ -1,0 +1,189 @@
+package initflow
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Stage is the shared base type for every init-flow stage (Vessel, Soil,
+// Branches, Observe). It composes the persistent chrome (header + enso
+// progress rail + footer) around a per-stage body, and satisfies both
+// harness.Step and harness.Chromeless so the harness yields the entire frame.
+//
+// Subclasses embed Stage by value and call renderFrame(body, keys) from
+// their View() to compose the final frame. Stage provides no-op defaults
+// for Done / Result / Update / Init that subclasses override.
+//
+// The fields are carried on Stage (not the subclass) so each stage ctor can
+// stamp them uniformly from runInitRedesign's context bundle.
+type Stage struct {
+	// Rendering context.
+	title    string     // breadcrumb title — unused today but kept for Step contract
+	idx      int        // 0..3 — stage index in the rail
+	label    StageLabel // kanji/kana/English triple
+	width    int        // last seen terminal width
+	height   int        // last seen terminal height
+	ensoSafe bool       // WideCharSafe() snapshot captured at ctor time
+
+	// Project context — identical across all four stages, stamped by
+	// runInitRedesign at entry so each stage renders the same header.
+	projectDir   string    // absolute path to project root
+	stationDir   string    // "station/" by default — can be updated post-Vessel
+	version      string    // cmd.Version; blank/"dev" hides the version chip
+	agentDisplay string    // agentDef.DisplayName — rendered by Observe's AGENT row
+	startedAt    time.Time // captured at runInitRedesign entry for Planted's ELAPSED
+
+	// State.
+	done bool // set by subclass when Enter advances
+}
+
+// NewStage constructs the shared Stage bundle used by every subclass. idx is
+// the 0-based rail position; label is typically StageLabels[idx]. Remaining
+// fields are the project context captured by runInitRedesign.
+func NewStage(
+	idx int,
+	label StageLabel,
+	title string,
+	version string,
+	projectDir string,
+	stationDir string,
+	agentDisplay string,
+	startedAt time.Time,
+) Stage {
+	return Stage{
+		idx:          idx,
+		label:        label,
+		title:        title,
+		version:      version,
+		projectDir:   projectDir,
+		stationDir:   stationDir,
+		agentDisplay: agentDisplay,
+		startedAt:    startedAt,
+		ensoSafe:     WideCharSafe(),
+	}
+}
+
+// Chromeless opts every stage out of the harness's default header/footer.
+// The harness yields Stage.View() verbatim and Stage composes its own frame
+// via renderFrame().
+func (s *Stage) Chromeless() bool { return true }
+
+// Title implements harness.Step. Used only if the harness ever had to
+// surface a breadcrumb — which it does not in the cinematic flow.
+func (s *Stage) Title() string { return s.title }
+
+// Done implements harness.Step. Flipped by subclasses when Enter advances.
+func (s *Stage) Done() bool { return s.done }
+
+// Result implements harness.Step. Overridden by each subclass (Vessel returns
+// a map, Soil returns []string, etc.). The base returns nil.
+func (s *Stage) Result() any { return nil }
+
+// Init implements tea.Model. No-op default; subclasses override when they
+// need to kick a textinput cursor or spinner.
+func (s *Stage) Init() tea.Cmd { return nil }
+
+// Update implements tea.Model. The Phase-2 stub stages handle Enter to
+// advance and Esc is consumed by the harness itself (pops the cursor).
+// Subclasses will override this in Phase 3+ to drive their own key handling.
+func (s *Stage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.width = m.Width
+		s.height = m.Height
+	case tea.KeyMsg:
+		switch m.String() {
+		case "enter":
+			s.done = true
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+// View implements tea.Model. Base returns an empty frame — subclasses
+// override to call renderFrame with the appropriate body and key hints.
+func (s *Stage) View() string { return "" }
+
+// Reset implements the harness.resetter contract. When the user Esc-backs
+// onto a stage, the harness flips Done=false so the cursor doesn't
+// immediately re-advance. Subclasses that hold extra state (textinput
+// cursors, list indices) override this to preserve their values.
+func (s *Stage) Reset() tea.Cmd {
+	s.done = false
+	return nil
+}
+
+// renderFrame composes header + enso rail + body + footer into the final
+// AltScreen frame. body is the per-stage payload (rendered inside a padded
+// content area); keys are the footer hints.
+//
+// The frame height is filled out to s.height (minus 1 for a terminal cursor
+// row) so the AltScreen doesn't leave earlier frames visible at the bottom.
+func (s *Stage) renderFrame(body string, keys []KeyHint) string {
+	width := s.width
+	if width <= 0 {
+		width = 80
+	}
+	height := s.height
+	if height <= 0 {
+		height = 24
+	}
+
+	header := RenderHeader(s.version, s.projectDir, s.stationDir, width, s.ensoSafe)
+	rail := RenderEnsoRail(s.idx, width, s.ensoSafe)
+	footer := RenderFooter(keys, width)
+
+	// Count rendered rows so we can pad the middle to fill the AltScreen.
+	count := func(s string) int { return strings.Count(s, "\n") + 1 }
+	headerRows := count(header)
+	railRows := count(rail)
+	footerRows := count(footer)
+	bodyRows := count(body)
+
+	// Compose: header, blank, rail, blank, body, <pad>, footer.
+	padRows := height - headerRows - railRows - bodyRows - footerRows - 4 // 4 blank separators
+	if padRows < 1 {
+		padRows = 1
+	}
+	pad := strings.Repeat("\n", padRows)
+
+	return header + "\n\n" + rail + "\n\n" + body + "\n" + pad + footer
+}
+
+// DefaultKeys is the base footer key hint set used by the Phase-2 stubs.
+// Phase 3+ subclasses supply their own slice that includes stage-specific
+// hints (e.g. "␣ toggle").
+func DefaultKeys(canGoBack bool) []KeyHint {
+	if canGoBack {
+		return []KeyHint{
+			{Key: "↵", Desc: "continue"},
+			{Key: "esc", Desc: "back"},
+			{Key: "ctrl-c", Desc: "quit"},
+		}
+	}
+	return []KeyHint{
+		{Key: "↵", Desc: "continue"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+// StageContext is a small record used by runInitRedesign to stamp each
+// stage with the shared project context at construction time. Keeps the
+// call-site symmetric and obvious when Phase 3 starts introducing real
+// constructors.
+type StageContext struct {
+	Version      string
+	ProjectDir   string
+	StationDir   string
+	AgentDisplay string
+	StartedAt    time.Time
+}
+
+// homeDir returns $HOME via os.UserHomeDir. Kept wrapped so chrome.go can
+// call it without importing os itself (keeping imports small on files that
+// grow).
+func homeDir() (string, error) { return os.UserHomeDir() }

--- a/internal/tui/initflow/stub.go
+++ b/internal/tui/initflow/stub.go
@@ -1,0 +1,77 @@
+package initflow
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// StubStage is a Phase-2 placeholder that renders the persistent chrome
+// (header + enso rail + footer) around a stub body, and advances on Enter.
+// Each of the four stages in runInitRedesign constructs one StubStage so
+// the flow can be verified end-to-end before Phase 3+ replaces them with
+// real inputs.
+//
+// StubStage composes Stage and delegates Chromeless/Title/Done/Result to
+// the embedded base. It overrides View to paint the placeholder body and
+// Update to advance on Enter (Esc is consumed by the harness).
+type StubStage struct {
+	Stage
+}
+
+// NewStubStage constructs a Phase-2 placeholder stage at rail position idx.
+// All context fields flow through Stage; behaviour is fixed (Enter advances,
+// no body interaction).
+func NewStubStage(
+	idx int,
+	version string,
+	projectDir string,
+	stationDir string,
+	agentDisplay string,
+	startedAt StageContext,
+) *StubStage {
+	label := StageLabels[idx]
+	s := NewStage(
+		idx,
+		label,
+		label.English,
+		version,
+		projectDir,
+		stationDir,
+		agentDisplay,
+		startedAt.StartedAt,
+	)
+	return &StubStage{Stage: s}
+}
+
+// Init kicks off a no-op tea.Cmd. No focus/cursor to manage at this stage.
+func (s *StubStage) Init() tea.Cmd { return nil }
+
+// Update advances on Enter. Esc / Ctrl-C are consumed by the harness.
+func (s *StubStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if k, ok := msg.(tea.KeyMsg); ok {
+		switch k.String() {
+		case "enter":
+			s.done = true
+			return s, nil
+		}
+	}
+	if w, ok := msg.(tea.WindowSizeMsg); ok {
+		s.width = w.Width
+		s.height = w.Height
+	}
+	return s, nil
+}
+
+// View draws the shared chrome around a placeholder body. The string body
+// is deliberately minimal — Phase 3+ replaces this with real stage content.
+func (s *StubStage) View() string {
+	body := "  (stage body goes here)"
+	canGoBack := s.idx > 0
+	return s.renderFrame(body, DefaultKeys(canGoBack))
+}
+
+// Reset ensures popping back onto a stub stage clears its completed flag
+// so the next Enter re-advances (matches harness.resetter expectations).
+func (s *StubStage) Reset() tea.Cmd {
+	s.done = false
+	return nil
+}


### PR DESCRIPTION
## Summary
Phase 2 of Plan 22 (`bonsai init` cinematic redesign) — adds `internal/tui/initflow/` package with chrome/enso/stage/fallback primitives, a `Chromeless` optional capability on the harness, and an env-flag branch in `cmd/init.go` routing to a stub `runInitRedesign`. Legacy `bonsai init` flow unchanged; new path runs only under `BONSAI_REDESIGN=1` and renders empty stage scaffolds.

## Changes
- `internal/tui/harness/harness.go` — `Chromeless` optional interface + short-circuit in `View()`.
- `internal/tui/harness/harness_test.go` — coverage for chromeless render path.
- `internal/tui/initflow/fallback.go` — `WideCharSafe()` + `StageLabel`.
- `internal/tui/initflow/fallback_test.go` — tests.
- `internal/tui/initflow/enso.go` — `RenderEnsoRail`.
- `internal/tui/initflow/chrome.go` — `RenderHeader`, `RenderFooter`, `KeyHint`.
- `internal/tui/initflow/stage.go` — `Stage` base + `renderFrame`.
- `internal/tui/initflow/stub.go` — `StubStage` used by Phase 2's four placeholder stages.
- `cmd/init.go` — env-flag branch.
- `cmd/init_redesign.go` — stub `runInitRedesign` with 4 placeholder stages.
- `go.mod` — promotes `mattn/go-runewidth` from indirect to direct (now imported by `initflow/fallback.go`).

## Plan
station/Playbook/Plans/Active/22-init-redesign.md — Phase 2.

## Verification
- [x] `make build`
- [x] `go test ./...`
- [x] `gofmt -s -l .` clean
- [x] `go vet ./...` clean
- [x] `bonsai init` (no env) runs legacy flow unchanged.
- [x] `BONSAI_REDESIGN=1 bonsai init` renders 4-stage chrome; Enter cycles; Esc pops; Ctrl-C aborts cleanly.
- [x] `BONSAI_ASCII_ONLY=1 BONSAI_REDESIGN=1 bonsai init` uses ASCII rail.
- [x] Ctrl-C with no env flag / with redesign env leaves no `.bonsai.yaml` in tmpdir.

## Snapshot (120 × 32)

Redesign — stage 2 (Branches), wide-char safe:

```
[盆] BONSAI · INITIALIZE · v0.2.0                                                                        PLANTING INTO
                                                                                  /Users/dev/code/voyager-api/station/

  ●────────────────────────────────────●────────────────────────────────────[枝]────────────────────────────────────○
VESSEL                               SOIL                                 BRANCHES                               OBSERVE
                                                                             えだ

  (stage body goes here)



 一 BONSAI 一                                                                   ↵ continue  ·  esc back  ·  ctrl-c quit
```

Redesign — stage 2 (Branches), ASCII fallback (`BONSAI_ASCII_ONLY=1`):

```
[o] BONSAI · INITIALIZE · v0.2.0                                                                         PLANTING INTO
                                                                                  /Users/dev/code/voyager-api/station/

  [x]──────────────────────────────────[x]──────────────────────────────────[3]──────────────────────────────────[ ]
VESSEL                                SOIL                               BRANCHES                              OBSERVE

  (stage body goes here)



 一 BONSAI 一                                                                   ↵ continue  ·  esc back  ·  ctrl-c quit
```

Live tmux smoke test — first stage of redesign (VESSEL), wide-char:

```
[盆] BONSAI · INITIALIZE                                                                                 PLANTING INTO
                                                                                              /tmp/t-redesign/station/

  [器]────────────────────────────────────○────────────────────────────────────○────────────────────────────────────○
 VESSEL                                 SOIL                               BRANCHES                              OBSERVE
   うつわ

  (stage body goes here)



 一 BONSAI 一                                                                                ↵ continue  ·  ctrl-c quit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)