### PR TITLE
feat(init): Plan 22 Phase 3 — Vessel + Soil stages

### DIFF
--- a/cmd/init_redesign.go
+++ b/cmd/init_redesign.go
@@ -15,11 +15,11 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
 
-// runInitRedesign is the Phase-2 stub entry point for Plan 22's cinematic
+// runInitRedesign is the Phase-3 entry point for Plan 22's cinematic
 // `bonsai init` flow. It renders the persistent chrome (header + enso rail
-// + footer) around four placeholder stages that advance on Enter and pop
-// on Esc. No files are written — the generate + planted pipeline lands in
-// Phases 3–5.
+// + footer) around four stages — Vessel and Soil are real input stages;
+// Branches and Observe remain stubs until Phases 4–5. No files are written
+// yet; the generate + planted pipeline lands in Phase 5.
 //
 // Routing: runInit at cmd/init.go:121 branches here when BONSAI_REDESIGN=1.
 // Without the env flag, the legacy flow runs unchanged.
@@ -56,7 +56,9 @@ func runInitRedesign(cmd *cobra.Command, args []string) error {
 	}
 
 	// Shared context stamped on every stage. Station defaults to "station/"
-	// until Phase 3's VesselStage captures a user-entered value.
+	// until VesselStage captures a user-entered value; Phase 5's Planted
+	// stage will read the post-Vessel value out of prev[0] when rendering
+	// the generated file tree.
 	ctx := initflow.StageContext{
 		Version:      Version,
 		ProjectDir:   cwd,
@@ -65,9 +67,14 @@ func runInitRedesign(cmd *cobra.Command, args []string) error {
 		StartedAt:    startedAt,
 	}
 
+	// Phase 3 wires real Vessel + Soil stages; Branches + Observe remain
+	// stubs until Phases 4–5 land. Legacy generate / conflict tail is still
+	// skipped — runInitRedesign does NOT write files yet.
+	soilOptions := scaffoldingToSoilOptions(cat)
+
 	steps := []harness.Step{
-		initflow.NewStubStage(0, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
-		initflow.NewStubStage(1, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
+		initflow.NewVesselStage(ctx),
+		initflow.NewSoilStage(ctx, soilOptions),
 		initflow.NewStubStage(2, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
 		initflow.NewStubStage(3, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
 	}
@@ -80,7 +87,7 @@ func runInitRedesign(cmd *cobra.Command, args []string) error {
 	_, err := harness.Run(bannerLine, "Initializing new project (redesign)", steps)
 	if err != nil {
 		if errors.Is(err, harness.ErrAborted) {
-			// Ctrl-C — no config / files written in Phase 2 either way.
+			// Ctrl-C — no config / files written in Phase 3 either way.
 			return nil
 		}
 		var bpe *harness.BuilderPanicError
@@ -93,8 +100,30 @@ func runInitRedesign(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Phase 2 does not write files, save config, or run a conflict picker —
-	// those wire up in Phases 3–5. Returning cleanly after the flow exits
-	// AltScreen is the expected behaviour for this phase.
+	// Phase 3 does not write files, save config, or run a conflict picker —
+	// the generate + planted pipeline wires up in Phases 4–5. Returning
+	// cleanly after the flow exits AltScreen is the expected behaviour.
 	return nil
+}
+
+// scaffoldingToSoilOptions maps catalog scaffolding entries into the
+// initflow.ScaffoldingOption shape consumed by SoilStage. Parallels the
+// legacy `scaffoldingOptions` helper (which returns tui.ItemOption for the
+// MultiSelectStep) but keeps the redesign path decoupled from the tui
+// package's option type.
+func scaffoldingToSoilOptions(cat *catalog.Catalog) []initflow.ScaffoldingOption {
+	out := make([]initflow.ScaffoldingOption, 0, len(cat.Scaffolding))
+	for _, item := range cat.Scaffolding {
+		desc := item.Description
+		if !item.Required && item.Affects != "" {
+			desc += " · if removed: " + item.Affects
+		}
+		out = append(out, initflow.ScaffoldingOption{
+			Name:        item.Name,
+			DisplayName: item.DisplayName,
+			Description: desc,
+			Required:    item.Required,
+		})
+	}
+	return out
 }

--- a/internal/tui/initflow/chrome.go
+++ b/internal/tui/initflow/chrome.go
@@ -21,13 +21,15 @@ type KeyHint struct {
 //
 //	Left:  [盆] BONSAI · INITIALIZE · v<version>
 //	Right: PLANTING INTO
-//	       ~/.../<project>/<station>
+//	       ~/.../<project>/
 //
 // version "dev" / "" hides the version segment. projectDir is the absolute
-// path to the project root; stationSubdir is the subdir under it (e.g.
-// "station/"). safe gates the single wide-char glyph so ASCII-only terminals
-// get a safe substitute.
-func RenderHeader(version, projectDir, stationSubdir string, width int, safe bool) string {
+// path to the project root — the only path segment rendered in the right
+// block; earlier iterations also rendered a "station/" suffix, but the
+// station subdir doesn't exist yet at any point before the Generate stage,
+// so showing it was misleading. safe gates the single wide-char glyph so
+// ASCII-only terminals get a safe substitute.
+func RenderHeader(version, projectDir string, width int, safe bool) string {
 	if width <= 0 {
 		width = 80
 	}
@@ -35,7 +37,6 @@ func RenderHeader(version, projectDir, stationSubdir string, width int, safe boo
 	primary := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
 	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
 	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary)
-	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
 
 	// ── Left block ───────────────────────────────────────────────────
 	mark := "盆"
@@ -57,21 +58,17 @@ func RenderHeader(version, projectDir, stationSubdir string, width int, safe boo
 	left := strings.Join(leftParts, " ")
 
 	// ── Right block ──────────────────────────────────────────────────
-	// "PLANTING INTO" headline above "~/path/<project>/<station>"
+	// "PLANTING INTO" headline above "~/path/<project>/".
 	projectDisplay := collapseHome(projectDir)
 	projectName := filepath.Base(projectDir)
 	parent := filepath.Dir(projectDisplay)
-	// Render parent muted, project name bark, station leaf.
-	station := stationSubdir
-	if station != "" && !strings.HasSuffix(station, "/") {
-		station += "/"
-	}
+	// Render parent muted, project name bark, trailing slash muted.
 	if parent == "." || parent == "" {
 		parent = ""
 	} else if !strings.HasSuffix(parent, "/") {
 		parent += "/"
 	}
-	pathRow := muted.Render(parent) + bark.Render(projectName) + muted.Render("/") + leaf.Render(station)
+	pathRow := muted.Render(parent) + bark.Render(projectName) + muted.Render("/")
 	rightRow1 := muted.Render("PLANTING INTO")
 
 	// ── Compose two-row layout with left-padded right block ─────────

--- a/internal/tui/initflow/chrome_test.go
+++ b/internal/tui/initflow/chrome_test.go
@@ -1,0 +1,65 @@
+package initflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderHeader_CollapsesHome verifies that a project path rooted under
+// $HOME is rendered with the tilde-collapsed prefix (~/...) rather than the
+// full absolute path.
+func TestRenderHeader_CollapsesHome(t *testing.T) {
+	t.Setenv("HOME", "/home/alice")
+
+	out := RenderHeader("0.1.2", "/home/alice/voyager-api", 120, true)
+
+	if !strings.Contains(out, "~/voyager-api") {
+		t.Fatalf("expected tilde-collapsed project path in header, got:\n%s", out)
+	}
+	// The project name itself must appear.
+	if !strings.Contains(out, "voyager-api") {
+		t.Fatalf("expected project name to appear in header, got:\n%s", out)
+	}
+}
+
+// TestRenderHeader_AbsolutePathOutsideHome verifies that a project path that
+// is not under $HOME is rendered verbatim (no spurious ~ substitution).
+func TestRenderHeader_AbsolutePathOutsideHome(t *testing.T) {
+	t.Setenv("HOME", "/home/bob")
+
+	out := RenderHeader("0.1.2", "/tmp/p", 120, true)
+
+	if !strings.Contains(out, "/tmp/p") {
+		t.Fatalf("expected absolute project path in header, got:\n%s", out)
+	}
+	if strings.Contains(out, "~/") {
+		t.Fatalf("expected no tilde substitution for path outside HOME, got:\n%s", out)
+	}
+}
+
+// TestRenderHeader_NoStationSegment is the regression guard for the Phase-3
+// bug fix — the station subdir doesn't exist until Phase 5 generate runs, so
+// the header must not claim "station/" in its path row. Covers both safe and
+// ASCII-fallback rendering modes.
+func TestRenderHeader_NoStationSegment(t *testing.T) {
+	t.Setenv("HOME", "/home/alice")
+
+	for _, safe := range []bool{true, false} {
+		out := RenderHeader("0.1.2", "/home/alice/voyager-api", 120, safe)
+		if strings.Contains(out, "station") {
+			t.Fatalf("safe=%v: header must not contain \"station\" substring, got:\n%s", safe, out)
+		}
+	}
+}
+
+// TestRenderHeader_TrailingSlash verifies the project row renders a trailing
+// slash after the project name so the path reads as a directory.
+func TestRenderHeader_TrailingSlash(t *testing.T) {
+	t.Setenv("HOME", "/home/alice")
+
+	out := RenderHeader("0.1.2", "/home/alice/voyager-api", 120, true)
+
+	if !strings.Contains(out, "voyager-api/") {
+		t.Fatalf("expected trailing slash after project name, got:\n%s", out)
+	}
+}

--- a/internal/tui/initflow/soil.go
+++ b/internal/tui/initflow/soil.go
@@ -1,0 +1,261 @@
+package initflow
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/tui"
+)
+
+// ScaffoldingOption is the per-row shape consumed by SoilStage. It is
+// deliberately minimal — the stage only needs a machine name (returned via
+// Result), a display name + description (rendered in the row), and a
+// Required flag (pinned, non-toggleable). Callers map their catalog types
+// into this shape so the stage package stays independent of catalog.
+type ScaffoldingOption struct {
+	Name        string // machine identifier — returned verbatim in Result
+	DisplayName string // human-readable label shown in each row
+	Description string // one-line caption rendered muted after the label
+	Required    bool   // pinned selection — cannot be toggled off
+}
+
+// SoilStage presents the scaffolding options as a hand-rolled multi-select
+// list. Rationale (plan §Design decisions resolved, 2026-04-21):
+// scaffolding catalog is ~4–8 items; bubbles/list ships its own styling
+// that's hard to match the design's exact row layout. Hand-rolled list is
+// ~120 lines of exact control over glyphs, focus highlight, and badges.
+type SoilStage struct {
+	Stage
+
+	options  []ScaffoldingOption
+	selected []bool // parallel to options; true = selected
+	focus    int    // index of the currently-highlighted row
+}
+
+// NewSoilStage constructs the Soil stage at rail position 1. Required
+// options are pre-selected and cannot be toggled off.
+func NewSoilStage(ctx StageContext, options []ScaffoldingOption) *SoilStage {
+	label := StageLabels[1]
+	base := NewStage(
+		1,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+
+	selected := make([]bool, len(options))
+	for i, opt := range options {
+		if opt.Required {
+			selected[i] = true
+		}
+	}
+
+	return &SoilStage{
+		Stage:    base,
+		options:  options,
+		selected: selected,
+		focus:    0,
+	}
+}
+
+// Init implements tea.Model — no cursor/cmd to fire on entry.
+func (s *SoilStage) Init() tea.Cmd { return nil }
+
+// Update handles arrow-key focus, space-to-toggle, enter-to-advance.
+func (s *SoilStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.width = m.Width
+		s.height = m.Height
+	case tea.KeyMsg:
+		switch m.String() {
+		case "up", "k":
+			if len(s.options) == 0 {
+				return s, nil
+			}
+			s.focus--
+			if s.focus < 0 {
+				s.focus = len(s.options) - 1 // wrap to bottom
+			}
+		case "down", "j":
+			if len(s.options) == 0 {
+				return s, nil
+			}
+			s.focus++
+			if s.focus >= len(s.options) {
+				s.focus = 0 // wrap to top
+			}
+		case " ":
+			if s.focus < 0 || s.focus >= len(s.options) {
+				return s, nil
+			}
+			// Required options ignore toggles — they stay selected.
+			if s.options[s.focus].Required {
+				return s, nil
+			}
+			s.selected[s.focus] = !s.selected[s.focus]
+		case "enter":
+			s.done = true
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+// View composes the Soil stage body inside the shared frame.
+func (s *SoilStage) View() string {
+	return s.renderFrame(s.renderBody(), s.keyHints())
+}
+
+// keyHints builds the footer key row for this stage.
+func (s *SoilStage) keyHints() []KeyHint {
+	return []KeyHint{
+		{Key: "↑↓", Desc: "move"},
+		{Key: "␣", Desc: "toggle"},
+		{Key: "↵", Desc: "next"},
+		{Key: "esc", Desc: "back"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+// renderBody renders the stage intro + the list of scaffolding rows.
+func (s *SoilStage) renderBody() string {
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+
+	primary, secondary := s.label.Render(s.ensoSafe)
+	title := leaf.Render(primary)
+	if secondary != "" {
+		title += muted.Render("  " + secondary)
+	}
+	title += muted.Render("  ·  SOIL")
+
+	intro := strings.Join([]string{
+		title,
+		bark.Render("Choose what the project carries."),
+		muted.Render("Shared files every agent can see. Required items are always on."),
+	}, "\n")
+
+	divider := muted.Render(strings.Repeat("─", 3)) + " " +
+		bark.Render("SCAFFOLDING") + " " +
+		muted.Render(strings.Repeat("─", 3)+" 足場 "+strings.Repeat("─", 20))
+
+	// Render each option row.
+	rows := make([]string, 0, len(s.options))
+	for i := range s.options {
+		rows = append(rows, s.renderRow(i))
+	}
+
+	// Counter — "X of N selected · R required, always on".
+	total := len(s.options)
+	selCount := 0
+	reqCount := 0
+	for i, opt := range s.options {
+		if s.selected[i] {
+			selCount++
+		}
+		if opt.Required {
+			reqCount++
+		}
+	}
+	counter := fmt.Sprintf("%d of %d selected · %d required, always on", selCount, total, reqCount)
+
+	body := []string{
+		"  " + intro,
+		"",
+		"  " + divider,
+		"",
+	}
+	for _, r := range rows {
+		body = append(body, "  "+r)
+	}
+	body = append(body, "", "  "+muted.Render(counter))
+	return strings.Join(body, "\n")
+}
+
+// renderRow renders a single scaffolding option at index idx. Focused rows
+// get a Leaf left-border + leaf-tint background; selected rows use the ◆
+// glyph in Leaf, unselected use ◇ in a dimmer muted color. The REQUIRED
+// badge (Bark) is right-aligned.
+func (s *SoilStage) renderRow(idx int) string {
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+	label := lipgloss.NewStyle().Foreground(tui.ColorSubtle)
+
+	opt := s.options[idx]
+	selected := s.selected[idx]
+
+	// Glyph: ◆ when selected (Leaf), ◇ when not (dim).
+	glyph := "◇"
+	glyphStyle := dim
+	if selected {
+		glyph = "◆"
+		glyphStyle = leaf
+	}
+
+	// Left-border: Leaf "│ " for the focused row, two spaces otherwise.
+	// The focus tint background is approximated via the Leaf-dim foreground
+	// on the border glyph — LipGloss AdaptiveColor degrades predictably on
+	// 256-color terminals without forcing an ANSI background (keeps the row
+	// readable on both dark and light themes).
+	border := "  "
+	if idx == s.focus {
+		border = lipgloss.NewStyle().Foreground(tui.ColorPrimary).Render("│ ")
+	}
+
+	// Name column — bold when focused, regular otherwise. Keep it padded so
+	// descriptions align across rows.
+	name := opt.DisplayName
+	if name == "" {
+		name = opt.Name
+	}
+	nameCol := label.Render(padRight(name, 20))
+	if idx == s.focus {
+		nameCol = bark.Render(padRight(name, 20))
+	}
+
+	// Description column — muted, truncated at ~50 cols to keep the row
+	// from wrapping in narrow terminals.
+	desc := opt.Description
+	if len(desc) > 50 {
+		desc = desc[:49] + "…"
+	}
+	descCol := muted.Render(desc)
+
+	// Required badge — right-aligned after the description, in Bark.
+	badge := ""
+	if opt.Required {
+		badge = "  " + bark.Render("REQUIRED")
+	}
+
+	return border + glyphStyle.Render(glyph) + " " + nameCol + " " + descCol + badge
+}
+
+// Result returns the machine names of every selected option, preserving the
+// input order. Required items are always present in the result.
+func (s *SoilStage) Result() any {
+	out := make([]string, 0, len(s.options))
+	for i, opt := range s.options {
+		if s.selected[i] {
+			out = append(out, opt.Name)
+		}
+	}
+	return out
+}
+
+// Reset clears the completion flag so re-entry behaves correctly, preserving
+// the user's selections + focus cursor position.
+func (s *SoilStage) Reset() tea.Cmd {
+	s.done = false
+	return nil
+}

--- a/internal/tui/initflow/soil_test.go
+++ b/internal/tui/initflow/soil_test.go
@@ -1,0 +1,179 @@
+package initflow
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// testSoilOptions returns a deterministic fixture mirroring the typical
+// bonsai scaffolding catalog — two required items followed by three
+// optional ones.
+func testSoilOptions() []ScaffoldingOption {
+	return []ScaffoldingOption{
+		{Name: "claude-md", DisplayName: "CLAUDE.md", Description: "root agent directive", Required: true},
+		{Name: "agents-index", DisplayName: "agents-index", Description: "directory of every agent", Required: true},
+		{Name: "session-log", DisplayName: "session-log", Description: "rolling log of what each session did"},
+		{Name: "readme-stub", DisplayName: "readme-stub", Description: "a starter README"},
+		{Name: "editor-config", DisplayName: "editor-config", Description: "editorconfig file"},
+	}
+}
+
+func newTestSoil() *SoilStage {
+	return NewSoilStage(StageContext{
+		Version:      "test",
+		ProjectDir:   "/tmp/soil-test",
+		StationDir:   "station/",
+		AgentDisplay: "Tech Lead",
+		StartedAt:    time.Now(),
+	}, testSoilOptions())
+}
+
+func soilPress(s *SoilStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if ss, ok := m.(*SoilStage); ok {
+		*s = *ss
+	}
+}
+
+func soilSpace(s *SoilStage) {
+	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(" ")})
+	if ss, ok := m.(*SoilStage); ok {
+		*s = *ss
+	}
+}
+
+// TestSoil_RequiredPreSelected verifies every Required option starts in the
+// selected state on construction.
+func TestSoil_RequiredPreSelected(t *testing.T) {
+	s := newTestSoil()
+	for i, opt := range s.options {
+		if opt.Required && !s.selected[i] {
+			t.Fatalf("required option %q at index %d not pre-selected", opt.Name, i)
+		}
+	}
+}
+
+// TestSoil_RequiredCannotToggle verifies Space on a Required row does not
+// flip its selected flag.
+func TestSoil_RequiredCannotToggle(t *testing.T) {
+	s := newTestSoil()
+	// focus=0 is a Required option per fixture.
+	if !s.options[0].Required {
+		t.Fatalf("fixture regression: index 0 expected to be Required")
+	}
+	before := s.selected[0]
+	soilSpace(s)
+	if s.selected[0] != before {
+		t.Fatalf("Required option flipped selected state via Space: %v -> %v",
+			before, s.selected[0])
+	}
+}
+
+// TestSoil_OptionalToggle verifies Space on an optional row flips its
+// selected flag both directions.
+func TestSoil_OptionalToggle(t *testing.T) {
+	s := newTestSoil()
+	// Move focus to index 2 (first optional).
+	soilPress(s, tea.KeyDown)
+	soilPress(s, tea.KeyDown)
+	if s.focus != 2 {
+		t.Fatalf("focus = %d, want 2", s.focus)
+	}
+	if s.options[2].Required {
+		t.Fatalf("fixture regression: index 2 expected to be optional")
+	}
+
+	if s.selected[2] {
+		t.Fatalf("fixture regression: optional index 2 should start unselected")
+	}
+
+	soilSpace(s)
+	if !s.selected[2] {
+		t.Fatalf("Space on optional didn't select it")
+	}
+	soilSpace(s)
+	if s.selected[2] {
+		t.Fatalf("Space on optional didn't deselect it")
+	}
+}
+
+// TestSoil_FocusAdvance verifies arrow-key focus movement and wrap-around.
+func TestSoil_FocusAdvance(t *testing.T) {
+	s := newTestSoil()
+	total := len(s.options)
+	if s.focus != 0 {
+		t.Fatalf("initial focus = %d, want 0", s.focus)
+	}
+	soilPress(s, tea.KeyDown)
+	if s.focus != 1 {
+		t.Fatalf("after Down focus = %d, want 1", s.focus)
+	}
+	// Cycle to the end + one more → wrap to 0.
+	for i := 1; i < total; i++ {
+		soilPress(s, tea.KeyDown)
+	}
+	if s.focus != 0 {
+		t.Fatalf("wrap focus = %d, want 0", s.focus)
+	}
+	// Up from 0 → last index.
+	soilPress(s, tea.KeyUp)
+	if s.focus != total-1 {
+		t.Fatalf("reverse wrap focus = %d, want %d", s.focus, total-1)
+	}
+}
+
+// TestSoil_ResultOrder verifies Result() returns selected item names in the
+// original option order, regardless of toggle order.
+func TestSoil_ResultOrder(t *testing.T) {
+	s := newTestSoil()
+	// Fixture: index 0,1 Required → pre-selected. Toggle index 4 first, then
+	// index 2 — Result should still order 0,1,2,4 per original option order.
+	s.focus = 4
+	soilSpace(s)
+	s.focus = 2
+	soilSpace(s)
+
+	got := s.Result().([]string)
+	want := []string{"claude-md", "agents-index", "session-log", "editor-config"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Result order = %v, want %v", got, want)
+	}
+}
+
+// TestSoil_EnterCompletes verifies ↵ flips the done flag so the harness
+// can advance to the next stage.
+func TestSoil_EnterCompletes(t *testing.T) {
+	s := newTestSoil()
+	soilPress(s, tea.KeyEnter)
+	if !s.done {
+		t.Fatalf("done=false after Enter; expected stage advance")
+	}
+}
+
+// TestSoil_ResetPreservesSelections verifies Reset clears done but keeps the
+// selected slice + focus cursor intact so Esc-and-return doesn't erase the
+// user's work.
+func TestSoil_ResetPreservesSelections(t *testing.T) {
+	s := newTestSoil()
+	s.focus = 3
+	soilSpace(s)
+	picked := make([]bool, len(s.selected))
+	copy(picked, s.selected)
+	prevFocus := s.focus
+
+	soilPress(s, tea.KeyEnter) // done=true
+	s.Reset()
+
+	if s.done {
+		t.Fatalf("Reset did not clear done flag")
+	}
+	if !reflect.DeepEqual(s.selected, picked) {
+		t.Fatalf("Reset modified selections: %v -> %v", picked, s.selected)
+	}
+	if s.focus != prevFocus {
+		t.Fatalf("Reset moved focus: %d -> %d", prevFocus, s.focus)
+	}
+}

--- a/internal/tui/initflow/stage.go
+++ b/internal/tui/initflow/stage.go
@@ -133,7 +133,7 @@ func (s *Stage) renderFrame(body string, keys []KeyHint) string {
 		height = 24
 	}
 
-	header := RenderHeader(s.version, s.projectDir, s.stationDir, width, s.ensoSafe)
+	header := RenderHeader(s.version, s.projectDir, width, s.ensoSafe)
 	rail := RenderEnsoRail(s.idx, width, s.ensoSafe)
 	footer := RenderFooter(keys, width)
 

--- a/internal/tui/initflow/vessel.go
+++ b/internal/tui/initflow/vessel.go
@@ -1,0 +1,278 @@
+package initflow
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/tui"
+)
+
+// VesselStage collects the three project-identity fields (NAME, DESCRIPTION,
+// STATION) on a single page using three composed bubbles/textinput models.
+// Replaces the first three legacy harness steps with a unified stage so the
+// cinematic flow can own the full frame.
+//
+// Result() returns map[string]string{"name", "description", "station"} so
+// runInitRedesign indexes per-stage rather than per-field — keeps prev[]
+// indexing stable across the 4-stage design.
+type VesselStage struct {
+	Stage
+
+	inputs [3]textinput.Model
+	focus  int // 0..2 — which input is focused
+
+	// showErrors is flipped on when the user attempts to submit with an
+	// invalid NAME or STATION — inline error labels render under those
+	// fields until the input is valid.
+	showErrors bool
+}
+
+const (
+	vesselIdxName = iota
+	vesselIdxDescription
+	vesselIdxStation
+)
+
+// defaultStationDir is the placeholder + fallback value for the STATION
+// input — matches legacy runInit behaviour where empty resolved to
+// "station/".
+const defaultStationDir = "station/"
+
+// NewVesselStage constructs the real Vessel stage, replacing the Phase-2 stub
+// at rail position 0. Inputs default to empty; the station input shows
+// "station/" as a placeholder (but does not pre-fill — empty submit falls
+// back to the default).
+func NewVesselStage(ctx StageContext) *VesselStage {
+	label := StageLabels[0]
+	base := NewStage(
+		0,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+
+	inputs := [3]textinput.Model{}
+	for i := range inputs {
+		ti := textinput.New()
+		ti.Prompt = "❯ "
+		ti.PromptStyle = lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+		ti.TextStyle = lipgloss.NewStyle().Foreground(tui.ColorSecondary)
+		ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(tui.ColorMuted)
+		ti.CharLimit = 256
+		ti.Width = 48
+		inputs[i] = ti
+	}
+
+	inputs[vesselIdxName].Placeholder = "my-project"
+	inputs[vesselIdxDescription].Placeholder = "one line · shown in agent prompts"
+	inputs[vesselIdxStation].Placeholder = defaultStationDir
+
+	inputs[vesselIdxName].Focus()
+
+	return &VesselStage{
+		Stage:  base,
+		inputs: inputs,
+		focus:  vesselIdxName,
+	}
+}
+
+// Init kicks the textinput cursor blink on the initially-focused input.
+func (s *VesselStage) Init() tea.Cmd { return textinput.Blink }
+
+// focusAt shifts focus to the input at idx (mod 3, positive). Called from
+// Tab/Shift-Tab/↑/↓ key handling so exactly one input is focused at a time.
+func (s *VesselStage) focusAt(idx int) tea.Cmd {
+	idx = ((idx % len(s.inputs)) + len(s.inputs)) % len(s.inputs)
+	for i := range s.inputs {
+		if i == idx {
+			s.inputs[i].Focus()
+		} else {
+			s.inputs[i].Blur()
+		}
+	}
+	s.focus = idx
+	return textinput.Blink
+}
+
+// validate returns true when every required field has a non-empty, valid
+// value. Used on ↵ to gate stage advancement. Rules mirror the existing
+// cmd.stationDirValidator (empty or "/" rejected for STATION) — Vessel
+// enforces inline so the user corrects without leaving the stage. Empty
+// STATION is treated as "use the default station/" rather than an error.
+func (s *VesselStage) validate() bool {
+	if strings.TrimSpace(s.inputs[vesselIdxName].Value()) == "" {
+		return false
+	}
+	station := strings.TrimSpace(s.inputs[vesselIdxStation].Value())
+	if station == "" {
+		return true
+	}
+	return station != "/"
+}
+
+// Update handles key input for focus cycling + Enter-to-advance.
+func (s *VesselStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.width = m.Width
+		s.height = m.Height
+	case tea.KeyMsg:
+		switch m.String() {
+		case "tab", "down":
+			return s, s.focusAt(s.focus + 1)
+		case "up":
+			return s, s.focusAt(s.focus - 1)
+		case "shift+tab":
+			// Shift+Tab on the first field: propagate to the harness so it
+			// pops back one stage. Otherwise, move focus up.
+			if s.focus == 0 {
+				return s, nil // harness handles the pop
+			}
+			return s, s.focusAt(s.focus - 1)
+		case "enter":
+			// On the last input, attempt submit. On earlier inputs, advance
+			// focus — matches the "one ↵ at the last field" idiom.
+			if s.focus < len(s.inputs)-1 {
+				return s, s.focusAt(s.focus + 1)
+			}
+			if !s.validate() {
+				s.showErrors = true
+				// Jump focus to the first invalid input so the user's next
+				// keystroke edits the offender.
+				if strings.TrimSpace(s.inputs[vesselIdxName].Value()) == "" {
+					return s, s.focusAt(vesselIdxName)
+				}
+				return s, s.focusAt(vesselIdxStation)
+			}
+			s.done = true
+			return s, nil
+		}
+	}
+
+	// Forward all other input to the focused textinput.
+	var cmd tea.Cmd
+	s.inputs[s.focus], cmd = s.inputs[s.focus].Update(msg)
+	return s, cmd
+}
+
+// View composes the Vessel stage body inside the shared frame.
+func (s *VesselStage) View() string {
+	return s.renderFrame(s.renderBody(), s.keyHints())
+}
+
+// keyHints returns the footer key row for this stage.
+func (s *VesselStage) keyHints() []KeyHint {
+	return []KeyHint{
+		{Key: "↵", Desc: "next"},
+		{Key: "tab", Desc: "cycle"},
+		{Key: "esc", Desc: "back"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+// renderBody renders the stage intro + the three labelled inputs.
+func (s *VesselStage) renderBody() string {
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	errStyle := lipgloss.NewStyle().Foreground(tui.ColorLeafDim)
+
+	primary, secondary := s.label.Render(s.ensoSafe)
+	title := leaf.Render(primary)
+	if secondary != "" {
+		title += muted.Render("  " + secondary)
+	}
+	title += muted.Render("  ·  VESSEL")
+
+	intro := strings.Join([]string{
+		title,
+		bark.Render("Shape the vessel."),
+		muted.Render("Every Bonsai begins with a small decision — what will this one carry?"),
+	}, "\n")
+
+	divider := muted.Render(strings.Repeat("─", 3)) + " " +
+		bark.Render("FIELDS") + " " +
+		muted.Render(strings.Repeat("─", 3)+" 入力 "+strings.Repeat("─", 20))
+
+	// Per-field rows: LABEL (Bark bold) + input + optional help caption + error.
+	row := func(label, help string, input *textinput.Model, errMsg string) string {
+		labelCol := bark.Render(padRight(label, 14))
+		inputCol := input.View()
+		line := labelCol + inputCol
+		helpLine := muted.Render(padRight(" ", 14) + help)
+		out := line + "\n" + helpLine
+		if errMsg != "" {
+			errLine := errStyle.Render(padRight(" ", 14) + errMsg)
+			out += "\n" + errLine
+		}
+		return out
+	}
+
+	nameErr := ""
+	if s.showErrors && strings.TrimSpace(s.inputs[vesselIdxName].Value()) == "" {
+		nameErr = "required"
+	}
+	stationErrMsg := ""
+	if s.showErrors {
+		v := strings.TrimSpace(s.inputs[vesselIdxStation].Value())
+		if v == "/" {
+			stationErrMsg = "must be a subdirectory like: station/"
+		}
+	}
+
+	nameRow := row("NAME", "required · used as .bonsai.yaml project_name",
+		&s.inputs[vesselIdxName], nameErr)
+	descRow := row("DESCRIPTION", "optional · one line · shown in agent prompts",
+		&s.inputs[vesselIdxDescription], "")
+	stationRow := row("STATION", "where agent files live · default "+defaultStationDir,
+		&s.inputs[vesselIdxStation], stationErrMsg)
+
+	return strings.Join([]string{
+		"  " + intro,
+		"",
+		"  " + divider,
+		"",
+		"  " + strings.ReplaceAll(nameRow, "\n", "\n  "),
+		"",
+		"  " + strings.ReplaceAll(descRow, "\n", "\n  "),
+		"",
+		"  " + strings.ReplaceAll(stationRow, "\n", "\n  "),
+	}, "\n")
+}
+
+// Result returns the three collected fields as a single map keyed by
+// "name" / "description" / "station". Description is returned verbatim
+// (may be empty — it is optional). Station falls back to "station/" when
+// empty, and is normalised to a trailing slash so downstream callers get a
+// path-shaped value. The shape matches cmd.normaliseDocsPath so the caller
+// can treat the result as already-normalised.
+func (s *VesselStage) Result() any {
+	name := strings.TrimSpace(s.inputs[vesselIdxName].Value())
+	description := strings.TrimSpace(s.inputs[vesselIdxDescription].Value())
+	station := strings.TrimSpace(s.inputs[vesselIdxStation].Value())
+	if station == "" {
+		station = defaultStationDir
+	}
+	if !strings.HasSuffix(station, "/") {
+		station += "/"
+	}
+	return map[string]string{
+		"name":        name,
+		"description": description,
+		"station":     station,
+	}
+}
+
+// Reset clears the completion flag so re-entry behaves correctly but keeps
+// the entered values so the user's work is preserved when popping back.
+func (s *VesselStage) Reset() tea.Cmd {
+	s.done = false
+	return s.focusAt(s.focus)
+}

--- a/internal/tui/initflow/vessel_test.go
+++ b/internal/tui/initflow/vessel_test.go
@@ -1,0 +1,185 @@
+package initflow
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// newTestVessel constructs a VesselStage with a minimal StageContext suitable
+// for unit tests. The project path + version are not read by Vessel during
+// its interaction — only the stage index + label matter — so they're stamped
+// with benign defaults.
+func newTestVessel() *VesselStage {
+	return NewVesselStage(StageContext{
+		Version:      "test",
+		ProjectDir:   "/tmp/vessel-test",
+		StationDir:   "station/",
+		AgentDisplay: "Tech Lead",
+		StartedAt:    time.Now(),
+	})
+}
+
+// pressTea helper routes a specific tea.KeyType through Update.
+func pressTea(s *VesselStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if vs, ok := m.(*VesselStage); ok {
+		*s = *vs
+	}
+}
+
+// TestVessel_FocusCycling_Tab verifies Tab advances focus through the three
+// inputs in order.
+func TestVessel_FocusCycling_Tab(t *testing.T) {
+	v := newTestVessel()
+
+	if v.focus != vesselIdxName {
+		t.Fatalf("initial focus = %d, want %d", v.focus, vesselIdxName)
+	}
+	pressTea(v, tea.KeyTab)
+	if v.focus != vesselIdxDescription {
+		t.Fatalf("after Tab focus = %d, want %d", v.focus, vesselIdxDescription)
+	}
+	pressTea(v, tea.KeyTab)
+	if v.focus != vesselIdxStation {
+		t.Fatalf("after Tab×2 focus = %d, want %d", v.focus, vesselIdxStation)
+	}
+	pressTea(v, tea.KeyTab)
+	if v.focus != vesselIdxName {
+		t.Fatalf("after Tab×3 focus = %d (should wrap to %d)", v.focus, vesselIdxName)
+	}
+}
+
+// TestVessel_FocusCycling_ShiftTab verifies Shift-Tab from the middle field
+// moves focus up, and on the first field is a no-op (propagates to harness).
+func TestVessel_FocusCycling_ShiftTab(t *testing.T) {
+	v := newTestVessel()
+
+	// Shift-Tab on field 0 should be a no-op — focus stays put.
+	pressTea(v, tea.KeyShiftTab)
+	if v.focus != vesselIdxName {
+		t.Fatalf("Shift-Tab on first field moved focus to %d (expected no-op)", v.focus)
+	}
+	// Move to description, then Shift-Tab back to name.
+	pressTea(v, tea.KeyTab)
+	pressTea(v, tea.KeyShiftTab)
+	if v.focus != vesselIdxName {
+		t.Fatalf("Shift-Tab from Description focus = %d, want %d", v.focus, vesselIdxName)
+	}
+}
+
+// TestVessel_EnterAdvancesFocus verifies ↵ on a non-last field moves focus
+// forward rather than completing the stage.
+func TestVessel_EnterAdvancesFocus(t *testing.T) {
+	v := newTestVessel()
+	v.inputs[vesselIdxName].SetValue("proj")
+
+	pressTea(v, tea.KeyEnter)
+	if v.focus != vesselIdxDescription {
+		t.Fatalf("Enter on NAME advanced focus to %d, want %d", v.focus, vesselIdxDescription)
+	}
+	if v.done {
+		t.Fatalf("Enter on NAME completed the stage — should only cycle focus")
+	}
+}
+
+// TestVessel_RequiredEmptyBlocksSubmit verifies submit is blocked when NAME
+// is empty and the error flag is surfaced.
+func TestVessel_RequiredEmptyBlocksSubmit(t *testing.T) {
+	v := newTestVessel()
+	// Jump directly to station focus and press Enter — NAME is still empty.
+	v.focusAt(vesselIdxStation)
+	pressTea(v, tea.KeyEnter)
+
+	if v.done {
+		t.Fatalf("submit succeeded despite empty required NAME field")
+	}
+	if !v.showErrors {
+		t.Fatalf("showErrors flag not set after failed submit")
+	}
+}
+
+// TestVessel_StationSlashRejected verifies STATION value "/" is rejected
+// and the stage does not complete.
+func TestVessel_StationSlashRejected(t *testing.T) {
+	v := newTestVessel()
+	v.inputs[vesselIdxName].SetValue("proj")
+	v.inputs[vesselIdxStation].SetValue("/")
+	v.focusAt(vesselIdxStation)
+
+	pressTea(v, tea.KeyEnter)
+
+	if v.done {
+		t.Fatalf("submit succeeded despite STATION = \"/\"")
+	}
+}
+
+// TestVessel_ResultShape verifies Result() returns the expected
+// map[string]string with keys "name", "description", "station".
+func TestVessel_ResultShape(t *testing.T) {
+	v := newTestVessel()
+	v.inputs[vesselIdxName].SetValue("voyager-api")
+	v.inputs[vesselIdxDescription].SetValue("Internal voyager service")
+	v.inputs[vesselIdxStation].SetValue("workspace")
+
+	res := v.Result()
+	m, ok := res.(map[string]string)
+	if !ok {
+		t.Fatalf("Result() type = %T, want map[string]string", res)
+	}
+	if m["name"] != "voyager-api" {
+		t.Fatalf("name = %q, want %q", m["name"], "voyager-api")
+	}
+	if m["description"] != "Internal voyager service" {
+		t.Fatalf("description = %q, want %q", m["description"], "Internal voyager service")
+	}
+	// Station gets a trailing slash appended.
+	if m["station"] != "workspace/" {
+		t.Fatalf("station = %q, want %q", m["station"], "workspace/")
+	}
+}
+
+// TestVessel_ResultEmptyDescription verifies an empty DESCRIPTION input
+// surfaces as an empty string in the result (not a missing key).
+func TestVessel_ResultEmptyDescription(t *testing.T) {
+	v := newTestVessel()
+	v.inputs[vesselIdxName].SetValue("proj")
+	// Description left empty.
+
+	res := v.Result().(map[string]string)
+	desc, present := res["description"]
+	if !present {
+		t.Fatalf("description key missing from Result")
+	}
+	if desc != "" {
+		t.Fatalf("description = %q, want empty string", desc)
+	}
+}
+
+// TestVessel_ResultStationDefault verifies an empty STATION input falls back
+// to the default "station/" value.
+func TestVessel_ResultStationDefault(t *testing.T) {
+	v := newTestVessel()
+	v.inputs[vesselIdxName].SetValue("proj")
+	// Station left empty.
+
+	res := v.Result().(map[string]string)
+	if res["station"] != defaultStationDir {
+		t.Fatalf("station default = %q, want %q", res["station"], defaultStationDir)
+	}
+}
+
+// TestVessel_SubmitOnLastField verifies ↵ on STATION with a valid NAME
+// completes the stage (done=true).
+func TestVessel_SubmitOnLastField(t *testing.T) {
+	v := newTestVessel()
+	v.inputs[vesselIdxName].SetValue("proj")
+	v.focusAt(vesselIdxStation)
+
+	pressTea(v, tea.KeyEnter)
+
+	if !v.done {
+		t.Fatalf("done=false after valid submit; expected stage advance")
+	}
+}


### PR DESCRIPTION
## Summary
Plan 22 Phase 3 — VesselStage (3 textinputs) + SoilStage (hand-rolled multi-select) replace stubs in `internal/tui/initflow/`. Strips misleading `station/` segment from `RenderHeader` (station dir doesn't exist pre-generate).

## Changes
- `internal/tui/initflow/vessel.go` — new VesselStage (3× textinput, focus cycling, validation)
- `internal/tui/initflow/vessel_test.go` — new tests
- `internal/tui/initflow/soil.go` — new SoilStage (hand-rolled list, ◆/◇ glyphs, REQUIRED pinning)
- `internal/tui/initflow/soil_test.go` — new tests
- `internal/tui/initflow/chrome.go` — drop `stationSubdir` param from `RenderHeader`
- `internal/tui/initflow/chrome_test.go` — new tests for header render
- `internal/tui/initflow/stage.go` — update `renderFrame` to new `RenderHeader` signature
- `cmd/init_redesign.go` — wire `NewVesselStage` + `NewSoilStage` in place of stubs

## Plan
`station/Playbook/Plans/Active/22-init-redesign.md` (Phase 3)

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `BONSAI_REDESIGN=1 ./bonsai init` — Vessel + Soil flow works, header shows project path only
- [x] `BONSAI_ASCII_ONLY=1 BONSAI_REDESIGN=1 ./bonsai init` — ASCII fallback works
- [x] Legacy `./bonsai init` (no env var) — unchanged