### PR TITLE
Plan 22 Phase 4 — Branches tabbed picker

### DIFF
--- a/cmd/init_redesign.go
+++ b/cmd/init_redesign.go
@@ -75,7 +75,7 @@ func runInitRedesign(cmd *cobra.Command, args []string) error {
 	steps := []harness.Step{
 		initflow.NewVesselStage(ctx),
 		initflow.NewSoilStage(ctx, soilOptions),
-		initflow.NewStubStage(2, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
+		initflow.NewBranchesStage(ctx, cat, agentDef),
 		initflow.NewStubStage(3, ctx.Version, ctx.ProjectDir, ctx.StationDir, ctx.AgentDisplay, ctx),
 	}
 

--- a/internal/tui/initflow/branches.go
+++ b/internal/tui/initflow/branches.go
@@ -1,0 +1,582 @@
+package initflow
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui"
+)
+
+// Branches category keys (also the map keys used for per-category state).
+const (
+	branchCatSkills    = "skills"
+	branchCatWorkflows = "workflows"
+	branchCatProtocols = "protocols"
+	branchCatSensors   = "sensors"
+	branchCatRoutines  = "routines"
+)
+
+// branchCat is a single tab in the BranchesStage — one of the five ability
+// categories. Kanji is the wide-char accent label (ASCII terminals render
+// just the display name).
+type branchCat struct {
+	key         string       // "skills" etc.
+	displayName string       // "skills" lowercased label in header row
+	kanji       string       // 技 / 流 / 律 / 感 / 習
+	items       []branchItem // catalog-ordered item list
+}
+
+// branchItem is a single selectable row inside a category tab. Affects /
+// crossLinks fields are retained for future catalog expansion but are always
+// empty today (the current catalog types don't carry them — the inline expand
+// panel renders ABOUT + FILE only, per the locked decisions).
+type branchItem struct {
+	name        string
+	displayName string
+	description string
+	required    bool
+	isDefault   bool
+	affects     string // reserved for future catalog metadata (always "")
+	crossLinks  string // reserved for future catalog metadata (always "")
+	filePath    string // catalog ContentPath — shown in the inline-expand FILE row
+}
+
+// BranchesStage is the tabbed category picker covering the five ability
+// types (Skills / Workflows / Protocols / Sensors / Routines). Per-category
+// multi-select with inline-expand details on the focused row.
+//
+// State:
+//   - categories: the five tabs with their items (built in the ctor from the
+//     full catalog + agentDef).
+//   - catIdx: currently-visible tab.
+//   - expanded: global toggle for the inline-expand panel on the focused row.
+//   - itemIdx: per-tab focus row index so switching tabs preserves each tab's
+//     focus position.
+//   - selected: per-tab set of machine-names that are picked.
+type BranchesStage struct {
+	Stage
+
+	categories []branchCat
+	catIdx     int
+	expanded   bool
+	itemIdx    map[int]int
+	selected   map[int]map[string]bool
+}
+
+// BranchesResult is the advance-payload returned from Result() when the user
+// hits Enter. Slices preserve the catalog iteration order (alphabetical per
+// catalog.loadItems). Required items are always present.
+type BranchesResult struct {
+	Skills    []string
+	Workflows []string
+	Protocols []string
+	Sensors   []string
+	Routines  []string
+}
+
+// NewBranchesStage constructs the real Branches stage at rail position 2.
+// The ctor walks the five categories of the catalog (filtered to the
+// tech-lead agent), seeds required items as pre-selected + immutable, and
+// marks each default-list entry as pre-selected with an isDefault flag so
+// the renderer can surface the DEFAULT tag.
+func NewBranchesStage(ctx StageContext, cat *catalog.Catalog, agentDef *catalog.AgentDef) *BranchesStage {
+	label := StageLabels[2]
+	base := NewStage(
+		2,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+
+	const agentType = "tech-lead"
+
+	// Build the five category tabs. Each mapper pulls from its own catalog
+	// accessor because the per-type shapes don't share a common interface
+	// (CatalogItem vs SensorItem vs RoutineItem) — but the fields we need
+	// are identical: Name, DisplayName, Description, Required, ContentPath.
+	stringSet := func(xs []string) map[string]bool {
+		out := make(map[string]bool, len(xs))
+		for _, s := range xs {
+			out[s] = true
+		}
+		return out
+	}
+
+	skillsDefaults := stringSet(agentDef.DefaultSkills)
+	workflowsDefaults := stringSet(agentDef.DefaultWorkflows)
+	protocolsDefaults := stringSet(agentDef.DefaultProtocols)
+	sensorsDefaults := stringSet(agentDef.DefaultSensors)
+	routinesDefaults := stringSet(agentDef.DefaultRoutines)
+
+	skills := make([]branchItem, 0)
+	for _, it := range cat.SkillsFor(agentType) {
+		skills = append(skills, branchItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   skillsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+
+	workflows := make([]branchItem, 0)
+	for _, it := range cat.WorkflowsFor(agentType) {
+		workflows = append(workflows, branchItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   workflowsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+
+	protocols := make([]branchItem, 0)
+	for _, it := range cat.ProtocolsFor(agentType) {
+		protocols = append(protocols, branchItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   protocolsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+
+	sensors := make([]branchItem, 0)
+	for _, it := range cat.SensorsFor(agentType) {
+		sensors = append(sensors, branchItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   sensorsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+
+	routines := make([]branchItem, 0)
+	for _, it := range cat.RoutinesFor(agentType) {
+		routines = append(routines, branchItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   routinesDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+
+	categories := []branchCat{
+		{key: branchCatSkills, displayName: "skills", kanji: "技", items: skills},
+		{key: branchCatWorkflows, displayName: "workflows", kanji: "流", items: workflows},
+		{key: branchCatProtocols, displayName: "protocols", kanji: "律", items: protocols},
+		{key: branchCatSensors, displayName: "sensors", kanji: "感", items: sensors},
+		{key: branchCatRoutines, displayName: "routines", kanji: "習", items: routines},
+	}
+
+	// Seed selected maps from required + default lists. Required items are
+	// always-selected; default items start selected but can be toggled off.
+	selected := make(map[int]map[string]bool, len(categories))
+	itemIdx := make(map[int]int, len(categories))
+	for i, c := range categories {
+		picks := make(map[string]bool)
+		for _, it := range c.items {
+			if it.required || it.isDefault {
+				picks[it.name] = true
+			}
+		}
+		selected[i] = picks
+		itemIdx[i] = 0
+	}
+
+	return &BranchesStage{
+		Stage:      base,
+		categories: categories,
+		catIdx:     0,
+		expanded:   false,
+		itemIdx:    itemIdx,
+		selected:   selected,
+	}
+}
+
+// Init implements tea.Model — no cursor/cmd to fire on entry.
+func (s *BranchesStage) Init() tea.Cmd { return nil }
+
+// Update handles tab switching, item focus movement, item toggling, the
+// global inline-expand toggle, and Enter-to-advance.
+func (s *BranchesStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.width = m.Width
+		s.height = m.Height
+	case tea.KeyMsg:
+		switch m.String() {
+		case "left", "h":
+			if len(s.categories) == 0 {
+				return s, nil
+			}
+			s.catIdx = (s.catIdx - 1 + len(s.categories)) % len(s.categories)
+		case "right", "l":
+			if len(s.categories) == 0 {
+				return s, nil
+			}
+			s.catIdx = (s.catIdx + 1) % len(s.categories)
+		case "up", "k":
+			cat := s.currentCat()
+			if cat == nil || len(cat.items) == 0 {
+				return s, nil
+			}
+			cur := s.itemIdx[s.catIdx]
+			cur--
+			if cur < 0 {
+				cur = 0 // clamp, no wrap (per plan spec)
+			}
+			s.itemIdx[s.catIdx] = cur
+		case "down", "j":
+			cat := s.currentCat()
+			if cat == nil || len(cat.items) == 0 {
+				return s, nil
+			}
+			cur := s.itemIdx[s.catIdx]
+			cur++
+			if cur >= len(cat.items) {
+				cur = len(cat.items) - 1 // clamp, no wrap
+			}
+			s.itemIdx[s.catIdx] = cur
+		case " ":
+			cat := s.currentCat()
+			if cat == nil || len(cat.items) == 0 {
+				return s, nil
+			}
+			row := s.itemIdx[s.catIdx]
+			if row < 0 || row >= len(cat.items) {
+				return s, nil
+			}
+			it := cat.items[row]
+			if it.required {
+				return s, nil // required items cannot be toggled
+			}
+			picks := s.selected[s.catIdx]
+			if picks[it.name] {
+				delete(picks, it.name)
+			} else {
+				picks[it.name] = true
+			}
+		case "?":
+			s.expanded = !s.expanded
+		case "enter":
+			s.done = true
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+// currentCat returns a pointer to the active branchCat or nil if the index is
+// out of bounds (defensive — should never happen in practice).
+func (s *BranchesStage) currentCat() *branchCat {
+	if s.catIdx < 0 || s.catIdx >= len(s.categories) {
+		return nil
+	}
+	return &s.categories[s.catIdx]
+}
+
+// View composes the Branches stage body inside the shared frame.
+func (s *BranchesStage) View() string {
+	return s.renderFrame(s.renderBody(), s.keyHints())
+}
+
+// keyHints builds the footer key row for this stage.
+func (s *BranchesStage) keyHints() []KeyHint {
+	return []KeyHint{
+		{Key: "←→", Desc: "tab"},
+		{Key: "↑↓", Desc: "move"},
+		{Key: "␣", Desc: "toggle"},
+		{Key: "?", Desc: "details"},
+		{Key: "↵", Desc: "next"},
+		{Key: "esc", Desc: "back"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+// renderBody renders the stage intro + the tab row + the item list +
+// the counter summary. Body is centred via centerBlock to match the Vessel
+// / Soil visual rhythm.
+func (s *BranchesStage) renderBody() string {
+	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+
+	// Title row — mirrors Vessel / Soil pattern.
+	var title string
+	if s.ensoSafe {
+		title = bark.Render(s.label.Kanji) + " " + white.Render(s.label.English)
+	} else {
+		title = white.Render(s.label.English)
+	}
+
+	intro := strings.Join([]string{
+		title,
+		white.Render("Shape the branches of the Tech Lead."),
+		dim.Render("Five categories of abilities — required pinned, defaults pre-picked."),
+	}, "\n")
+
+	divider := leaf.Render(strings.Repeat("─", 3)) + " " +
+		bark.Render("CATEGORIES") + " " +
+		dim.Render(strings.Repeat("─", 55))
+
+	tabRow := s.renderTabs()
+	list := s.renderList()
+	counter := s.renderCounter()
+
+	body := []string{
+		intro,
+		"",
+		"",
+		divider,
+		"",
+		tabRow,
+		"",
+		list,
+		"",
+		dim.Render(counter),
+	}
+	return centerBlock(strings.Join(body, "\n"), s.width)
+}
+
+// renderTabs renders the 5-column tab header: kanji + display name on row 1,
+// "N / Total" subtitle on row 2. The current tab is highlighted with a Leaf
+// colour + ◆ accent glyph; others are muted. On ASCII-only terminals the
+// kanji is dropped in favour of the display name alone (mirrors the
+// vessel.go / soil.go ensoSafe fallback pattern).
+func (s *BranchesStage) renderTabs() string {
+	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+
+	const colW = 16
+
+	top := make([]string, 0, len(s.categories))
+	sub := make([]string, 0, len(s.categories))
+	for i, c := range s.categories {
+		var label string
+		if s.ensoSafe {
+			label = c.kanji + " " + c.displayName
+		} else {
+			label = c.displayName
+		}
+		if i == s.catIdx {
+			label = label + " ◆"
+			top = append(top, leaf.Render(padRight(label, colW)))
+		} else {
+			top = append(top, muted.Render(padRight(label, colW)))
+		}
+
+		// Subtitle: "N / Total" — selected count vs total items for this tab.
+		picks := s.selected[i]
+		sel := 0
+		for _, it := range c.items {
+			if picks[it.name] {
+				sel++
+			}
+		}
+		line := fmt.Sprintf("%d / %d", sel, len(c.items))
+		if i == s.catIdx {
+			sub = append(sub, bark.Render(padRight(line, colW)))
+		} else {
+			sub = append(sub, dim.Render(padRight(line, colW)))
+		}
+	}
+
+	return strings.Join(top, " ") + "\n" + strings.Join(sub, " ")
+}
+
+// renderList renders the item rows for the current tab. When expanded is
+// true and the focused row is visible, the focused row gets an inline
+// expansion block (ABOUT / FILE). Non-focused rows always render compact.
+func (s *BranchesStage) renderList() string {
+	cat := s.currentCat()
+	if cat == nil {
+		return ""
+	}
+	if len(cat.items) == 0 {
+		dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+		return dim.Render("  (no items in this category)")
+	}
+
+	rows := make([]string, 0, len(cat.items))
+	for i := range cat.items {
+		rows = append(rows, s.renderRow(i))
+		if s.expanded && i == s.itemIdx[s.catIdx] {
+			if block := s.renderExpand(cat.items[i]); block != "" {
+				rows = append(rows, block)
+			}
+		}
+	}
+	return strings.Join(rows, "\n")
+}
+
+// renderRow renders a single ability row at index idx within the current
+// tab. Focused rows get a Leaf "│ " left border; selected rows use ◆ (Leaf),
+// unselected use ◇ (dim). Required items show a muted "(required)" tag;
+// default items show the "DEFAULT" tag right-aligned.
+func (s *BranchesStage) renderRow(idx int) string {
+	cat := s.currentCat()
+	if cat == nil || idx < 0 || idx >= len(cat.items) {
+		return ""
+	}
+	it := cat.items[idx]
+	focused := idx == s.itemIdx[s.catIdx]
+	selected := s.selected[s.catIdx][it.name]
+
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	label := lipgloss.NewStyle().Foreground(tui.ColorSubtle)
+
+	// Glyph: ◆ when selected (Leaf), ◇ when not (dim).
+	glyph := "◇"
+	glyphStyle := dim
+	if selected {
+		glyph = "◆"
+		glyphStyle = leaf
+	}
+
+	// Left border — Leaf "│ " for focused row, two spaces otherwise
+	// (mirrors soil.go:210-215 AdaptiveColor-friendly pattern).
+	border := "  "
+	if focused {
+		border = lipgloss.NewStyle().Foreground(tui.ColorPrimary).Render("│ ")
+	}
+
+	// Name column — bold when focused, regular otherwise.
+	name := it.displayName
+	if name == "" {
+		name = it.name
+	}
+	const nameColW = 22
+	nameCol := label.Render(padRight(name, nameColW))
+	if focused {
+		nameCol = bark.Render(padRight(name, nameColW))
+	}
+
+	// Description column — muted, truncated so the row doesn't wrap.
+	desc := it.description
+	const descColW = 44
+	if len(desc) > descColW {
+		desc = desc[:descColW-1] + "…"
+	}
+	descCol := dim.Render(padRight(desc, descColW))
+
+	// Trailing tags: "(required)" or "DEFAULT" + an expand/collapse caret.
+	tag := ""
+	if it.required {
+		tag = muted.Render("(required)")
+	} else if it.isDefault {
+		tag = muted.Render("DEFAULT")
+	}
+
+	caret := "·"
+	if s.expanded && focused {
+		caret = "▾"
+	}
+	caretStr := dim.Render(caret)
+
+	return border + glyphStyle.Render(glyph) + " " + nameCol + " " + descCol + " " + padRight(tag, 10) + " " + caretStr
+}
+
+// renderExpand renders the inline-expand block beneath the focused row. The
+// current catalog shape only carries Description + ContentPath — so we render
+// ABOUT and FILE, and skip AFFECTS / CROSS (reserved for a future catalog
+// metadata expansion — see locked decisions in Plan 22 §Phase 4).
+func (s *BranchesStage) renderExpand(it branchItem) string {
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+	label := lipgloss.NewStyle().Foreground(tui.ColorSubtle)
+
+	const labelW = 10
+	const indent = "    "
+
+	lines := make([]string, 0, 4)
+	if it.description != "" {
+		lines = append(lines, indent+bark.Render(padRight("ABOUT", labelW))+label.Render(it.description))
+	}
+	// AFFECTS / CROSS retained on the struct for future catalog metadata,
+	// but the current item types don't carry them — never rendered today.
+	if it.affects != "" {
+		lines = append(lines, indent+bark.Render(padRight("AFFECTS", labelW))+label.Render(it.affects))
+	}
+	if it.crossLinks != "" {
+		lines = append(lines, indent+bark.Render(padRight("CROSS", labelW))+label.Render(it.crossLinks))
+	}
+	if it.filePath != "" {
+		lines = append(lines, indent+bark.Render(padRight("FILE", labelW))+dim.Render(it.filePath))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderCounter renders the summary line at the bottom of the stage body.
+// Format: "N abilities selected · across 5 categories".
+func (s *BranchesStage) renderCounter() string {
+	total := 0
+	for i := range s.categories {
+		total += len(s.selected[i])
+	}
+	return fmt.Sprintf("%d abilities selected · across %d categories", total, len(s.categories))
+}
+
+// Result returns a BranchesResult with per-category slices of selected
+// machine-names, preserving catalog order. Required items are always in the
+// result (they're pre-selected + immutable).
+func (s *BranchesStage) Result() any {
+	pick := func(idx int) []string {
+		picks := s.selected[idx]
+		cat := s.categories[idx]
+		out := make([]string, 0, len(picks))
+		for _, it := range cat.items {
+			if picks[it.name] {
+				out = append(out, it.name)
+			}
+		}
+		return out
+	}
+
+	res := BranchesResult{}
+	for i, c := range s.categories {
+		slice := pick(i)
+		switch c.key {
+		case branchCatSkills:
+			res.Skills = slice
+		case branchCatWorkflows:
+			res.Workflows = slice
+		case branchCatProtocols:
+			res.Protocols = slice
+		case branchCatSensors:
+			res.Sensors = slice
+		case branchCatRoutines:
+			res.Routines = slice
+		}
+	}
+	return res
+}
+
+// Reset clears the completion flag so re-entry behaves correctly. The
+// per-tab selections, focus cursor, expand toggle, and current tab index
+// are all preserved so Esc-and-return restores the user's state verbatim.
+func (s *BranchesStage) Reset() tea.Cmd {
+	s.done = false
+	return nil
+}

--- a/internal/tui/initflow/branches_test.go
+++ b/internal/tui/initflow/branches_test.go
@@ -1,0 +1,380 @@
+package initflow
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+)
+
+// newTestBranches constructs a BranchesStage from a minimal in-memory
+// catalog + AgentDef fixture. Keeps the test independent of the on-disk
+// catalog loader — we want to assert behaviour over a known item shape.
+func newTestBranches() *BranchesStage {
+	skillReq := catalog.AgentCompat{Names: []string{"tech-lead"}}
+	none := catalog.AgentCompat{}
+	all := catalog.AgentCompat{All: true}
+
+	cat := &catalog.Catalog{
+		Skills: []catalog.CatalogItem{
+			{Name: "alpha-skill", DisplayName: "Alpha Skill", Description: "first skill", Agents: all, Required: skillReq, ContentPath: "skills/alpha/alpha.md"},
+			{Name: "beta-skill", DisplayName: "Beta Skill", Description: "second skill", Agents: all, Required: none, ContentPath: "skills/beta/beta.md"},
+			{Name: "gamma-skill", DisplayName: "Gamma Skill", Description: "third skill", Agents: all, Required: none, ContentPath: "skills/gamma/gamma.md"},
+		},
+		Workflows: []catalog.CatalogItem{
+			{Name: "wf-one", DisplayName: "WF One", Description: "workflow one", Agents: all, Required: none, ContentPath: "workflows/one/one.md"},
+			{Name: "wf-two", DisplayName: "WF Two", Description: "workflow two", Agents: all, Required: none, ContentPath: "workflows/two/two.md"},
+		},
+		Protocols: []catalog.CatalogItem{
+			{Name: "proto-req", DisplayName: "Proto Req", Description: "required protocol", Agents: all, Required: all, ContentPath: "protocols/req/req.md"},
+		},
+		Sensors: []catalog.SensorItem{
+			{Name: "sensor-one", DisplayName: "Sensor One", Description: "first sensor", Agents: all, Required: none, Event: "SessionStart", ContentPath: "sensors/one/one.sh"},
+			{Name: "sensor-two", DisplayName: "Sensor Two", Description: "second sensor", Agents: all, Required: none, Event: "SessionStart", ContentPath: "sensors/two/two.sh"},
+		},
+		Routines: []catalog.RoutineItem{
+			{Name: "routine-a", DisplayName: "Routine A", Description: "first routine", Agents: all, Required: none, Frequency: "7 days", ContentPath: "routines/a/a.md"},
+		},
+	}
+
+	agentDef := &catalog.AgentDef{
+		Name:             "tech-lead",
+		DisplayName:      "Tech Lead",
+		DefaultSkills:    []string{"beta-skill"},
+		DefaultWorkflows: []string{"wf-one"},
+		DefaultProtocols: nil,
+		DefaultSensors:   []string{"sensor-two"},
+		DefaultRoutines:  nil,
+	}
+
+	return NewBranchesStage(StageContext{
+		Version:      "test",
+		ProjectDir:   "/tmp/branches-test",
+		StationDir:   "station/",
+		AgentDisplay: "Tech Lead",
+		StartedAt:    time.Now(),
+	}, cat, agentDef)
+}
+
+func branchesPressKey(s *BranchesStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if bs, ok := m.(*BranchesStage); ok {
+		*s = *bs
+	}
+}
+
+func branchesPressRune(s *BranchesStage, r rune) {
+	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	if bs, ok := m.(*BranchesStage); ok {
+		*s = *bs
+	}
+}
+
+// TestBranches_DefaultsApplied verifies that required items and default items
+// are both selected on first render. Required = "proto-req"; defaults =
+// beta-skill, wf-one, sensor-two.
+func TestBranches_DefaultsApplied(t *testing.T) {
+	s := newTestBranches()
+
+	// skills (idx 0): beta-skill default → selected.
+	if !s.selected[0]["beta-skill"] {
+		t.Fatalf("beta-skill default not pre-selected")
+	}
+	if s.selected[0]["alpha-skill"] {
+		// alpha-skill is required per fixture → MUST be selected too.
+	} else {
+		t.Fatalf("alpha-skill required not pre-selected")
+	}
+	// gamma-skill has neither flag → NOT selected.
+	if s.selected[0]["gamma-skill"] {
+		t.Fatalf("gamma-skill (no default/required) was pre-selected")
+	}
+	// workflows (idx 1): wf-one default.
+	if !s.selected[1]["wf-one"] {
+		t.Fatalf("wf-one default not pre-selected")
+	}
+	// protocols (idx 2): proto-req required (agents: all).
+	if !s.selected[2]["proto-req"] {
+		t.Fatalf("proto-req required not pre-selected")
+	}
+	// sensors (idx 3): sensor-two default.
+	if !s.selected[3]["sensor-two"] {
+		t.Fatalf("sensor-two default not pre-selected")
+	}
+	// routines (idx 4): nothing default / required.
+	if len(s.selected[4]) != 0 {
+		t.Fatalf("routines tab expected empty pre-selection, got %v", s.selected[4])
+	}
+}
+
+// TestBranches_TabCyclingRight verifies Right cycles through the 5 tabs and
+// wraps back to 0.
+func TestBranches_TabCyclingRight(t *testing.T) {
+	s := newTestBranches()
+	if s.catIdx != 0 {
+		t.Fatalf("initial catIdx = %d, want 0", s.catIdx)
+	}
+	for want := 1; want < len(s.categories); want++ {
+		branchesPressKey(s, tea.KeyRight)
+		if s.catIdx != want {
+			t.Fatalf("after %d Right press, catIdx = %d, want %d", want, s.catIdx, want)
+		}
+	}
+	// One more Right → wrap to 0.
+	branchesPressKey(s, tea.KeyRight)
+	if s.catIdx != 0 {
+		t.Fatalf("after wrap Right, catIdx = %d, want 0", s.catIdx)
+	}
+}
+
+// TestBranches_TabCyclingLeft verifies Left wraps from 0 to the last tab.
+func TestBranches_TabCyclingLeft(t *testing.T) {
+	s := newTestBranches()
+	branchesPressKey(s, tea.KeyLeft)
+	if s.catIdx != len(s.categories)-1 {
+		t.Fatalf("after Left from 0, catIdx = %d, want %d", s.catIdx, len(s.categories)-1)
+	}
+}
+
+// TestBranches_ItemFocusClamps verifies Down clamps at the last item (no
+// wrap) and Up clamps at 0.
+func TestBranches_ItemFocusClamps(t *testing.T) {
+	s := newTestBranches()
+	// skills tab has 3 items (indexes 0,1,2).
+	total := len(s.categories[0].items)
+	if total != 3 {
+		t.Fatalf("fixture regression: skills tab expected 3 items, got %d", total)
+	}
+	// Press Down past the end — should clamp at total-1.
+	for i := 0; i < total+5; i++ {
+		branchesPressKey(s, tea.KeyDown)
+	}
+	if s.itemIdx[0] != total-1 {
+		t.Fatalf("after many Down, itemIdx = %d, want %d (clamp)", s.itemIdx[0], total-1)
+	}
+	// Press Up past the start — should clamp at 0.
+	for i := 0; i < total+5; i++ {
+		branchesPressKey(s, tea.KeyUp)
+	}
+	if s.itemIdx[0] != 0 {
+		t.Fatalf("after many Up, itemIdx = %d, want 0 (clamp)", s.itemIdx[0])
+	}
+}
+
+// TestBranches_ToggleNonRequired verifies Space on a non-required item flips
+// its selected state in both directions.
+func TestBranches_ToggleNonRequired(t *testing.T) {
+	s := newTestBranches()
+	// skills tab: move focus to gamma-skill (idx 2, neither default nor required).
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressKey(s, tea.KeyDown)
+	if s.itemIdx[0] != 2 {
+		t.Fatalf("focus not at 2, got %d", s.itemIdx[0])
+	}
+	if s.selected[0]["gamma-skill"] {
+		t.Fatalf("fixture regression: gamma-skill should start unselected")
+	}
+	branchesPressRune(s, ' ')
+	if !s.selected[0]["gamma-skill"] {
+		t.Fatalf("Space did not select gamma-skill")
+	}
+	branchesPressRune(s, ' ')
+	if s.selected[0]["gamma-skill"] {
+		t.Fatalf("Space did not deselect gamma-skill")
+	}
+}
+
+// TestBranches_ToggleRequiredNoOp verifies Space on a required item leaves it
+// selected (cannot be toggled off).
+func TestBranches_ToggleRequiredNoOp(t *testing.T) {
+	s := newTestBranches()
+	// skills tab, item 0 = alpha-skill (required in fixture).
+	if !s.categories[0].items[0].required {
+		t.Fatalf("fixture regression: alpha-skill expected to be required")
+	}
+	branchesPressRune(s, ' ')
+	if !s.selected[0]["alpha-skill"] {
+		t.Fatalf("Space on required item deselected it")
+	}
+}
+
+// TestBranches_ExpandToggle verifies `?` flips the expanded flag.
+func TestBranches_ExpandToggle(t *testing.T) {
+	s := newTestBranches()
+	if s.expanded {
+		t.Fatalf("initial expanded = true, want false")
+	}
+	branchesPressRune(s, '?')
+	if !s.expanded {
+		t.Fatalf("? did not set expanded=true")
+	}
+	branchesPressRune(s, '?')
+	if s.expanded {
+		t.Fatalf("? did not toggle expanded back to false")
+	}
+}
+
+// TestBranches_ResultShape verifies Result() returns a BranchesResult with
+// per-category slices in catalog order, and required items are always
+// present even if never explicitly toggled.
+func TestBranches_ResultShape(t *testing.T) {
+	s := newTestBranches()
+	// Skills defaults: alpha (required), beta (default) — gamma unpicked.
+	// Toggle gamma ON to verify it joins the result.
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressRune(s, ' ')
+
+	// Switch to workflows tab, toggle wf-two ON.
+	branchesPressKey(s, tea.KeyRight)
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressRune(s, ' ')
+
+	res, ok := s.Result().(BranchesResult)
+	if !ok {
+		t.Fatalf("Result() not a BranchesResult: %T", s.Result())
+	}
+	wantSkills := []string{"alpha-skill", "beta-skill", "gamma-skill"}
+	if !reflect.DeepEqual(res.Skills, wantSkills) {
+		t.Fatalf("Skills = %v, want %v", res.Skills, wantSkills)
+	}
+	wantWF := []string{"wf-one", "wf-two"}
+	if !reflect.DeepEqual(res.Workflows, wantWF) {
+		t.Fatalf("Workflows = %v, want %v", res.Workflows, wantWF)
+	}
+	wantProto := []string{"proto-req"}
+	if !reflect.DeepEqual(res.Protocols, wantProto) {
+		t.Fatalf("Protocols = %v, want %v", res.Protocols, wantProto)
+	}
+	wantSensors := []string{"sensor-two"}
+	if !reflect.DeepEqual(res.Sensors, wantSensors) {
+		t.Fatalf("Sensors = %v, want %v", res.Sensors, wantSensors)
+	}
+	if len(res.Routines) != 0 {
+		t.Fatalf("Routines = %v, want empty", res.Routines)
+	}
+}
+
+// TestBranches_ResultCatalogOrder verifies Result() slices preserve the
+// catalog's iteration order, not the user's toggle order.
+func TestBranches_ResultCatalogOrder(t *testing.T) {
+	s := newTestBranches()
+	// Toggle gamma first (idx 2), then re-select by pressing Space on beta
+	// (default). This proves order is by catalog iteration, not toggle order.
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressRune(s, ' ') // gamma ON
+	branchesPressKey(s, tea.KeyUp)
+	branchesPressRune(s, ' ') // beta OFF
+	branchesPressRune(s, ' ') // beta ON
+
+	res := s.Result().(BranchesResult)
+	want := []string{"alpha-skill", "beta-skill", "gamma-skill"}
+	if !reflect.DeepEqual(res.Skills, want) {
+		t.Fatalf("Skills order = %v, want %v (must follow catalog order)", res.Skills, want)
+	}
+}
+
+// TestBranches_EnterCompletes verifies ↵ flips the done flag.
+func TestBranches_EnterCompletes(t *testing.T) {
+	s := newTestBranches()
+	branchesPressKey(s, tea.KeyEnter)
+	if !s.done {
+		t.Fatalf("done=false after Enter; expected stage advance")
+	}
+}
+
+// TestBranches_ResetPreservesState verifies Reset clears done but keeps
+// catIdx, per-tab selected, per-tab itemIdx, and expanded all intact — so
+// Esc-and-return restores the stage verbatim.
+func TestBranches_ResetPreservesState(t *testing.T) {
+	s := newTestBranches()
+	// Build up some non-default state: jump to sensors tab, toggle sensor-one,
+	// move focus down, turn on expand.
+	branchesPressKey(s, tea.KeyRight)
+	branchesPressKey(s, tea.KeyRight)
+	branchesPressKey(s, tea.KeyRight) // now on sensors (idx 3)
+	if s.catIdx != 3 {
+		t.Fatalf("catIdx = %d, want 3", s.catIdx)
+	}
+	branchesPressRune(s, ' ') // toggle focused item (sensor-one — idx 0 — now ON)
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressRune(s, '?') // expand
+
+	// Snapshot state pre-reset.
+	savedCat := s.catIdx
+	savedExpand := s.expanded
+	savedItemIdx := make(map[int]int, len(s.itemIdx))
+	for k, v := range s.itemIdx {
+		savedItemIdx[k] = v
+	}
+	savedSelected := make(map[int]map[string]bool, len(s.selected))
+	for k, v := range s.selected {
+		cp := make(map[string]bool, len(v))
+		for kk, vv := range v {
+			cp[kk] = vv
+		}
+		savedSelected[k] = cp
+	}
+
+	// Enter to flip done, then Reset.
+	branchesPressKey(s, tea.KeyEnter)
+	if !s.done {
+		t.Fatalf("done=false after Enter")
+	}
+	s.Reset()
+
+	if s.done {
+		t.Fatalf("Reset did not clear done")
+	}
+	if s.catIdx != savedCat {
+		t.Fatalf("Reset changed catIdx: %d -> %d", savedCat, s.catIdx)
+	}
+	if s.expanded != savedExpand {
+		t.Fatalf("Reset changed expanded: %v -> %v", savedExpand, s.expanded)
+	}
+	if !reflect.DeepEqual(s.itemIdx, savedItemIdx) {
+		t.Fatalf("Reset changed itemIdx: %v -> %v", savedItemIdx, s.itemIdx)
+	}
+	if !reflect.DeepEqual(s.selected, savedSelected) {
+		t.Fatalf("Reset changed selected: %v -> %v", savedSelected, s.selected)
+	}
+}
+
+// TestBranches_SelectionPersistsAcrossTabs verifies toggles in one tab don't
+// affect other tabs, and switching back restores the tab's selection.
+func TestBranches_SelectionPersistsAcrossTabs(t *testing.T) {
+	s := newTestBranches()
+	// Toggle gamma-skill ON in skills tab.
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressKey(s, tea.KeyDown)
+	branchesPressRune(s, ' ')
+	if !s.selected[0]["gamma-skill"] {
+		t.Fatalf("gamma-skill not selected after Space")
+	}
+
+	// Switch to sensors tab, toggle sensor-one.
+	branchesPressKey(s, tea.KeyRight)
+	branchesPressKey(s, tea.KeyRight)
+	branchesPressKey(s, tea.KeyRight)
+	branchesPressRune(s, ' ')
+
+	// Skills selection is untouched.
+	if !s.selected[0]["gamma-skill"] {
+		t.Fatalf("gamma-skill lost after tab-switch")
+	}
+	if !s.selected[0]["alpha-skill"] {
+		t.Fatalf("alpha-skill (required) lost after tab-switch")
+	}
+
+	// Come back to skills, focus should still be at gamma.
+	branchesPressKey(s, tea.KeyLeft)
+	branchesPressKey(s, tea.KeyLeft)
+	branchesPressKey(s, tea.KeyLeft)
+	if s.itemIdx[0] != 2 {
+		t.Fatalf("skills focus not restored: itemIdx[0] = %d, want 2", s.itemIdx[0])
+	}
+}


### PR DESCRIPTION
## Summary
Plan 22 Phase 4 — real `BranchesStage` replacing the idx=2 stub. Tabbed picker across Skills/Workflows/Protocols/Sensors/Routines with inline-expand (`?`), per-category multi-select, defaults pre-seeded from agentDef, required items pinned. Behind `BONSAI_REDESIGN=1` until Phase 5.

## Changes
- `internal/tui/initflow/branches.go` — new BranchesStage + BranchesResult
- `internal/tui/initflow/branches_test.go` — tab cycling, toggle, expand, Result, defaults, Reset preservation
- `cmd/init_redesign.go` — wire NewBranchesStage at rail idx=2

## Plan
station/Playbook/Plans/Active/22-init-redesign.md §Phase 4

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `go vet ./...` — clean
- [x] `BONSAI_REDESIGN=1 ./bonsai init` — 5-tab picker renders, `?` toggles expand, ␣ toggles non-required, ↵ on final stage advances to Observe stub