### PR TITLE
feat(add): Plan 23 Phase 1 — addflow package + new-agent cinematic path

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -100,6 +101,12 @@ func normaliseWorkspace(s string) string {
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
+	// Plan 23 Phase 1 — cinematic add flow gated on BONSAI_ADD_REDESIGN=1.
+	// Phase 3 flips the default and deletes this branch + the legacy body.
+	if os.Getenv("BONSAI_ADD_REDESIGN") == "1" {
+		return runAddRedesign(cmd, args)
+	}
+
 	cwd := mustCwd()
 	configPath := filepath.Join(cwd, configFile)
 	cfg, err := requireConfig(configPath)

--- a/cmd/add_redesign.go
+++ b/cmd/add_redesign.go
@@ -1,0 +1,311 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/addflow"
+	"github.com/LastStep/Bonsai/internal/tui/harness"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// runAddRedesign is the cinematic `bonsai add` entry point, gated by the
+// BONSAI_ADD_REDESIGN=1 env flag during Plan 23 Phase 1+2. Phase 3 flips
+// the default and deletes the legacy runAdd body.
+//
+// Step list:
+//
+//	[0] Select             agent picker
+//	[1] LazyGroup          splices one of:
+//	      new-agent         [Ground(Lazy), Graft(NewAgent), Observe]
+//	      all-installed     [YieldAllInstalled]                 (terminal)
+//	      tech-lead-req     [YieldTechLeadRequired]             (terminal)
+//	      add-items         (Phase 2 — nil for now, legacy handles it)
+//	[2] Conditional(Lazy(Grow))  gated on observeConfirmed
+//	[3] LazyGroup          conflicts placeholder (Phase 2 no-op)
+//	[4] Conditional(Lazy(Yield)) gated on growSucceeded
+func runAddRedesign(cmd *cobra.Command, args []string) error {
+	startedAt := time.Now()
+
+	cwd := mustCwd()
+	configPath := filepath.Join(cwd, configFile)
+	cfg, err := requireConfig(configPath)
+	if err != nil {
+		return err
+	}
+	cat := loadCatalog()
+
+	existingWorkspaces := make(map[string]bool)
+	for _, a := range cfg.Agents {
+		key := strings.TrimRight(filepath.Clean(a.Workspace), "/") + "/"
+		existingWorkspaces[key] = true
+	}
+
+	// Shared context stamped onto every stage. AgentDisplay is resolved lazily
+	// inside the splicer once the user picks an agent — the initial value
+	// here is empty so the header right-block reads "PLANTING INTO" over the
+	// project path (same convention as initflow).
+	ctx := initflow.StageContext{
+		Version:      Version,
+		ProjectDir:   cwd,
+		StationDir:   "station/",
+		AgentDisplay: "",
+		StartedAt:    startedAt,
+	}
+
+	lock, _ := config.LoadLockFile(cwd)
+	var wr generate.WriteResult
+	var installed *config.InstalledAgent
+	var outcome addflow.Outcome
+
+	// Predicates --------------------------------------------------------
+	observeConfirmed := func(prev []any) bool {
+		// prev layout after splice:
+		//   new-agent happy path:  [0]=agent, [1]=ws, [2]=graft, [3]=observe-bool
+		//   all-installed / tech-lead-req terminal splices: last slot is nil (Yield.Result)
+		//   add-items (Phase 2 TBD)
+		if len(prev) == 0 {
+			return false
+		}
+		b, ok := prev[len(prev)-1].(bool)
+		return ok && b
+	}
+	growSucceeded := func(prev []any) bool {
+		if !observeConfirmed(prev) {
+			return false
+		}
+		// grow slot is cursor-1 vs the predicate-eval point. Walk prev from the
+		// tail looking for an error — Grow publishes nil on success.
+		for i := len(prev) - 1; i >= 0; i-- {
+			if e, isErr := prev[i].(error); isErr && e != nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Step list ---------------------------------------------------------
+	steps := []harness.Step{
+		addflow.NewSelectStage(ctx, addflow.BuildAgentOptions(cat, installedSet(cfg))),
+		harness.NewLazyGroup("Agent flow", func(prev []any) []harness.Step {
+			agentType := asString(prev[0])
+			agentDef := cat.GetAgent(agentType)
+			if agentDef == nil {
+				// Unknown agent — render the tech-lead-required variant with
+				// the unknown name so the user has a durable next-step.
+				return []harness.Step{addflow.NewYieldTechLeadRequired(ctx, agentType)}
+			}
+
+			// Add-items branch — Phase 1 stub. Plan 23 Phase 2 wires the
+			// filtered Graft + Observe path; for Phase 1 we short-circuit to
+			// an all-installed Yield so the user has a terminal card rather
+			// than a blank screen. Legacy runAdd (gated off by the absence
+			// of BONSAI_ADD_REDESIGN) still handles the real add-items path.
+			if installedAgent, exists := cfg.Agents[agentType]; exists {
+				if availableAddItems(cat, installedAgent).Total() == 0 {
+					return []harness.Step{addflow.NewYieldAllInstalled(ctx, agentDef)}
+				}
+				// Phase 1: defer to Phase 2 for the real add-items flow.
+				return []harness.Step{addflow.NewYieldAllInstalled(ctx, agentDef)}
+			}
+
+			// Tech-lead guard — non-tech-lead pick with no tech-lead installed.
+			if agentType != "tech-lead" {
+				if _, hasTechLead := cfg.Agents["tech-lead"]; !hasTechLead {
+					return []harness.Step{addflow.NewYieldTechLeadRequired(ctx, agentType)}
+				}
+			}
+
+			// New-agent branch.
+			agentCtx := ctx
+			agentCtx.AgentDisplay = agentDef.DisplayName
+			if agentCtx.AgentDisplay == "" {
+				agentCtx.AgentDisplay = catalog.DisplayNameFrom(agentDef.Name)
+			}
+			ground := addflow.NewGroundStage(agentCtx, addflow.GroundContext{
+				AgentType:          agentType,
+				DocsPath:           cfg.DocsPath,
+				ExistingWorkspaces: existingWorkspaces,
+			})
+			graft := addflow.NewNewAgentGraft(agentCtx, addflow.GraftContext{
+				Cat:       cat,
+				AgentType: agentType,
+				AgentDef:  agentDef,
+			})
+			observe := addflow.NewObserveStage(agentCtx, cat)
+			return []harness.Step{ground, graft, observe}
+		}),
+		harness.NewConditional(
+			harness.NewLazy("Grow", func(prev []any) harness.Step {
+				action := buildAddGrowAction(prev, cwd, configPath, cfg, cat, existingWorkspaces, lock, &wr, &installed, &outcome)
+				return addflow.NewGrowStage(ctx, action)
+			}),
+			observeConfirmed,
+		),
+		harness.NewLazyGroup("Resolve conflicts", func(prev []any) []harness.Step {
+			if !growSucceeded(prev) {
+				return nil
+			}
+			if !wr.HasConflicts() {
+				return nil
+			}
+			return buildConflictSteps(&wr)
+		}),
+		harness.NewConditional(
+			harness.NewLazy("Yield", func(_ []any) harness.Step {
+				total := outcome.TotalSelected
+				if total == 0 && installed != nil {
+					total = len(installed.Skills) + len(installed.Workflows) +
+						len(installed.Protocols) + len(installed.Sensors) + len(installed.Routines)
+				}
+				return addflow.NewYieldSuccess(ctx, installed, cat, outcome.NewAgent, total)
+			}),
+			growSucceeded,
+		),
+	}
+
+	bannerLine := "BONSAI"
+	if Version != "" && Version != "dev" {
+		bannerLine = fmt.Sprintf("BONSAI v%s", Version)
+	}
+
+	results, err := harness.Run(bannerLine, "Adding", steps)
+	if err != nil {
+		if errors.Is(err, harness.ErrAborted) {
+			return nil
+		}
+		var bpe *harness.BuilderPanicError
+		if errors.As(err, &bpe) {
+			tui.FatalPanel("Harness builder panic",
+				fmt.Sprintf("Step %q: %v", bpe.Step, bpe.Value),
+				"This is a bug — please report it.")
+			return nil
+		}
+		return err
+	}
+
+	// Post-harness cleanup when Grow ran successfully: apply conflict picks
+	// and save the lock. When the user cancelled at Observe or the splice
+	// terminated at a Yield variant there is nothing to persist.
+	if !observeConfirmed(results) {
+		return nil
+	}
+	if outcome.SpinnerErr != nil {
+		tui.Warning("Generation error: " + outcome.SpinnerErr.Error())
+		return nil
+	}
+
+	// Conflict picker, when present, sits just before the trailing Yield slot.
+	confIdx := -1
+	if wr.HasConflicts() {
+		confIdx = len(results) - 2
+	}
+	applyConflictPicks(results, confIdx, &wr, lock, cwd)
+
+	if err := lock.Save(cwd); err != nil {
+		tui.Warning("Could not save lock file: " + err.Error())
+	}
+	return nil
+}
+
+// installedSet builds the "already installed" lookup for BuildAgentOptions.
+func installedSet(cfg *config.ProjectConfig) map[string]bool {
+	out := make(map[string]bool, len(cfg.Agents))
+	for name := range cfg.Agents {
+		out[name] = true
+	}
+	return out
+}
+
+// buildAddGrowAction mirrors runAddSpinner's new-agent body but closes over
+// the cinematic flow's prev indices (agent at [0], workspace at [1], Graft
+// at [2], observe bool at [3]). Duplicated — not reused — so the cinematic
+// path has no back-import into legacy helpers beyond loadCatalog et al.
+func buildAddGrowAction(
+	prev []any,
+	cwd, configPath string,
+	cfg *config.ProjectConfig,
+	cat *catalog.Catalog,
+	existingWorkspaces map[string]bool,
+	lock *config.LockFile,
+	wr *generate.WriteResult,
+	installedOut **config.InstalledAgent,
+	outcome *addflow.Outcome,
+) initflow.GenerateAction {
+	return func() error {
+		outcome.Ran = true
+
+		agentType, _ := prev[0].(string)
+		agentDef := cat.GetAgent(agentType)
+		if agentDef == nil {
+			outcome.SpinnerErr = fmt.Errorf("unknown agent type %q", agentType)
+			return outcome.SpinnerErr
+		}
+		outcome.AgentDef = agentDef
+
+		if _, exists := cfg.Agents[agentType]; exists {
+			// Phase 1: add-items path terminates at the Yield splice before
+			// reaching Grow. Defensive no-op.
+			return nil
+		}
+
+		// New-agent path.
+		workspace, _ := prev[1].(string)
+		if workspace == "" {
+			workspace = addflow.NormaliseWorkspace(agentType + "/")
+		}
+		if agentType == "tech-lead" {
+			workspace = cfg.DocsPath
+			if workspace == "" {
+				workspace = "station/"
+			}
+		}
+		if existingWorkspaces[workspace] {
+			outcome.SpinnerErr = fmt.Errorf("workspace %q is already in use by another agent", workspace)
+			return outcome.SpinnerErr
+		}
+
+		graft, _ := prev[2].(addflow.GraftResult)
+
+		installed := &config.InstalledAgent{
+			AgentType: agentType,
+			Workspace: workspace,
+			Skills:    append([]string(nil), graft.Skills...),
+			Workflows: append([]string(nil), graft.Workflows...),
+			Protocols: append([]string(nil), graft.Protocols...),
+			Sensors:   append([]string(nil), graft.Sensors...),
+			Routines:  append([]string(nil), graft.Routines...),
+		}
+		generate.EnsureRoutineCheckSensor(installed)
+		cfg.Agents[agentType] = installed
+		if err := cfg.Save(configPath); err != nil {
+			outcome.SpinnerErr = err
+			return err
+		}
+
+		var errs []error
+		errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+		if joined := errors.Join(errs...); joined != nil {
+			outcome.SpinnerErr = joined
+			return joined
+		}
+
+		outcome.Workspace = workspace
+		outcome.NewAgent = true
+		outcome.TotalSelected = graft.Total()
+		*installedOut = installed
+		return nil
+	}
+}

--- a/cmd/add_redesign.go
+++ b/cmd/add_redesign.go
@@ -105,17 +105,16 @@ func runAddRedesign(cmd *cobra.Command, args []string) error {
 				return []harness.Step{addflow.NewYieldTechLeadRequired(ctx, agentType)}
 			}
 
-			// Add-items branch — Phase 1 stub. Plan 23 Phase 2 wires the
-			// filtered Graft + Observe path; for Phase 1 we short-circuit to
-			// an all-installed Yield so the user has a terminal card rather
-			// than a blank screen. Legacy runAdd (gated off by the absence
-			// of BONSAI_ADD_REDESIGN) still handles the real add-items path.
+			// Add-items branch — Phase 1 terminal splices only. Plan 23
+			// Phase 2 wires the real filtered Graft + Observe path; until
+			// then this splicer either terminates at the "already full"
+			// card or directs the user to the legacy flow via the
+			// AddItemsDeferred variant. Never falls through silently.
 			if installedAgent, exists := cfg.Agents[agentType]; exists {
 				if availableAddItems(cat, installedAgent).Total() == 0 {
 					return []harness.Step{addflow.NewYieldAllInstalled(ctx, agentDef)}
 				}
-				// Phase 1: defer to Phase 2 for the real add-items flow.
-				return []harness.Step{addflow.NewYieldAllInstalled(ctx, agentDef)}
+				return []harness.Step{addflow.NewYieldAddItemsDeferred(ctx, agentDef)}
 			}
 
 			// Tech-lead guard — non-tech-lead pick with no tech-lead installed.

--- a/internal/tui/addflow/addflow.go
+++ b/internal/tui/addflow/addflow.go
@@ -1,0 +1,105 @@
+// Package addflow implements the cinematic 6-stage `bonsai add` flow.
+//
+// The package mirrors internal/tui/initflow's shape — chromeless stages that
+// compose a shared persistent chrome (header + enso rail + footer) around a
+// per-stage body — but with a 6-segment rail specific to the add journey:
+//
+//	選 SELECT  地 GROUND  接 GRAFT  観 OBSERVE  育 GROW  結 YIELD
+//
+// Every chrome primitive (RenderHeader, RenderEnsoRail, RenderFooter,
+// RenderMinSizeFloor, ClampColumns, Viewport, PanelContentWidth, design
+// tokens) is imported from initflow — addflow does not reimplement any of
+// them. The rail length adapts because initflow.RenderEnsoRail accepts an
+// explicit label slice (Plan 23 Phase 1 refactor).
+//
+// Plan 23 reference: station/Playbook/Plans/Active/23-uiux-phase2-add.md.
+package addflow
+
+import (
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// Stage indices in the add-flow rail. Kept as named constants so ctors and
+// splicers reference them by name rather than literal integers.
+const (
+	StageIdxSelect  = 0
+	StageIdxGround  = 1
+	StageIdxGraft   = 2
+	StageIdxObserve = 3
+	StageIdxGrow    = 4
+	StageIdxYield   = 5
+)
+
+// StageLabels holds the six canonical add-flow stage labels in order.
+// Matches Plan 23 decision Q2 — bonsai-raising metaphor extended to the add
+// journey.
+//
+//	選 えらぶ  Select   — pick the agent
+//	地 じ      Ground   — workspace (skipped for tech-lead)
+//	接 つぐ    Graft    — abilities (skills/workflows/protocols/sensors/routines)
+//	観 みる    Observe  — one last look before the write
+//	育 そだつ  Grow     — the write animation
+//	結 むすぶ  Yield    — completion card
+var StageLabels = []initflow.StageLabel{
+	{Kanji: "選", Kana: "えらぶ", English: "SELECT"},
+	{Kanji: "地", Kana: "じ", English: "GROUND"},
+	{Kanji: "接", Kana: "つぐ", English: "GRAFT"},
+	{Kanji: "観", Kana: "みる", English: "OBSERVE"},
+	{Kanji: "育", Kana: "そだつ", English: "GROW"},
+	{Kanji: "結", Kana: "むすぶ", English: "YIELD"},
+}
+
+// AgentOption is the per-row shape consumed by SelectStage. Deliberately
+// minimal — the stage needs a machine name, a display label, a description,
+// and a flag indicating whether the agent type is already installed (renders
+// as an "(installed)" suffix).
+type AgentOption struct {
+	Name        string // machine identifier returned verbatim in Result
+	DisplayName string // human-readable label shown in the row
+	Description string // one-line caption rendered muted after the name
+	Installed   bool   // true when cfg.Agents[name] exists
+}
+
+// GraftResult is the advance-payload returned from GraftStage.Result() on
+// Enter. Slices preserve catalog iteration order (alphabetical per
+// catalog.loadItems). Required items are always present. Mirrors
+// initflow.BranchesResult shape so the action closure can read either path
+// with a type switch.
+type GraftResult struct {
+	Skills    []string
+	Workflows []string
+	Protocols []string
+	Sensors   []string
+	Routines  []string
+}
+
+// Total returns the sum of selection counts across the five categories. Used
+// by Observe for the CTA's "Graft ~N items" line.
+func (r GraftResult) Total() int {
+	return len(r.Skills) + len(r.Workflows) + len(r.Protocols) +
+		len(r.Sensors) + len(r.Routines)
+}
+
+// Outcome is the cross-stage scratchpad populated by the Grow action and
+// consumed by Yield + the post-harness cleanup in cmd/add_redesign.go. Kept
+// in addflow (not cmd/) so test helpers can stamp synthetic outcomes without
+// back-importing cmd.
+//
+// Field semantics:
+//
+//   - Ran            — true once the Grow action body executed (even on error).
+//   - AgentDef       — resolved catalog AgentDef (nil on unknown-agent error).
+//   - Workspace      — normalised workspace path actually written.
+//   - NewAgent       — true for the new-agent branch, false for add-items.
+//   - TotalSelected  — GraftResult.Total() captured at write time.
+//   - SpinnerErr     — non-nil when the write pipeline failed; routed to a
+//     tui.Warning by the caller and short-circuits the Yield render.
+type Outcome struct {
+	AgentDef      *catalog.AgentDef
+	Workspace     string
+	NewAgent      bool
+	TotalSelected int
+	SpinnerErr    error
+	Ran           bool
+}

--- a/internal/tui/addflow/graft.go
+++ b/internal/tui/addflow/graft.go
@@ -114,9 +114,9 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 	}
 
 	var (
-		installedSkills, installedWorkflows   map[string]bool
-		installedProtocols, installedSensors  map[string]bool
-		installedRoutines                     map[string]bool
+		installedSkills, installedWorkflows  map[string]bool
+		installedProtocols, installedSensors map[string]bool
+		installedRoutines                    map[string]bool
 	)
 	if filter && gctx.Installed != nil {
 		installedSkills = stringSet(gctx.Installed.Skills)

--- a/internal/tui/addflow/graft.go
+++ b/internal/tui/addflow/graft.go
@@ -1,0 +1,762 @@
+package addflow
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// Graft category keys — same five ability types as initflow.BranchesStage.
+const (
+	graftCatSkills    = "skills"
+	graftCatWorkflows = "workflows"
+	graftCatProtocols = "protocols"
+	graftCatSensors   = "sensors"
+	graftCatRoutines  = "routines"
+)
+
+// graftCat is a single tab in the GraftStage — mirrors branchCat from
+// initflow but kept package-local so Phase 1 doesn't couple to unexported
+// initflow types.
+type graftCat struct {
+	key         string
+	displayName string
+	introLine1  string
+	introLine2  string
+	items       []graftItem
+}
+
+type graftItem struct {
+	name        string
+	displayName string
+	description string
+	required    bool
+	isDefault   bool
+	filePath    string
+}
+
+// GraftStage is the tabbed ability picker at rail position 2 (接 GRAFT).
+// Keystroke model matches initflow.BranchesStage: ← → tab, ↑ ↓ focus, ␣
+// toggle, ? details, ↵ advance. Required items are pre-selected and
+// immutable; defaults are pre-selected but toggleable.
+//
+// Result: GraftResult with per-category slices of selected machine names.
+type GraftStage struct {
+	initflow.Stage
+
+	categories []graftCat
+	catIdx     int
+	expanded   bool
+	itemIdx    map[int]int
+	selected   map[int]map[string]bool
+
+	viewport initflow.Viewport
+}
+
+// GraftContext bundles everything a Graft ctor needs. Kept separate from
+// StageContext so the add-items branch can pass an Installed pointer
+// without polluting the shared context type.
+type GraftContext struct {
+	Cat       *catalog.Catalog
+	AgentType string
+	AgentDef  *catalog.AgentDef
+	// Installed is nil on the new-agent branch; populated on add-items.
+	Installed *config.InstalledAgent
+}
+
+// NewNewAgentGraft constructs a Graft stage for the new-agent branch — all
+// five tabs, defaults seeded from agentDef.
+func NewNewAgentGraft(ctx initflow.StageContext, gctx GraftContext) *GraftStage {
+	return newGraft(ctx, gctx, false)
+}
+
+// NewAddItemsGraft constructs a Graft stage for the add-items branch —
+// filters each category to uninstalled items, drops empty tabs. Phase 1
+// stub returns a stage with no tabs (add-items branch falls back to legacy
+// runAdd until Phase 2).
+func NewAddItemsGraft(ctx initflow.StageContext, gctx GraftContext) *GraftStage {
+	return newGraft(ctx, gctx, true)
+}
+
+// newGraft is the shared constructor. filter=true excludes already-installed
+// items per category and drops empty tabs.
+func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftStage {
+	label := StageLabels[StageIdxGraft]
+	base := initflow.NewStage(
+		StageIdxGraft,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+	base.SetRailLabels(StageLabels)
+
+	agentDef := gctx.AgentDef
+	agentType := gctx.AgentType
+	cat := gctx.Cat
+
+	stringSet := func(xs []string) map[string]bool {
+		out := make(map[string]bool, len(xs))
+		for _, s := range xs {
+			out[s] = true
+		}
+		return out
+	}
+
+	var (
+		installedSkills, installedWorkflows   map[string]bool
+		installedProtocols, installedSensors  map[string]bool
+		installedRoutines                     map[string]bool
+	)
+	if filter && gctx.Installed != nil {
+		installedSkills = stringSet(gctx.Installed.Skills)
+		installedWorkflows = stringSet(gctx.Installed.Workflows)
+		installedProtocols = stringSet(gctx.Installed.Protocols)
+		installedSensors = stringSet(gctx.Installed.Sensors)
+		installedRoutines = stringSet(gctx.Installed.Routines)
+	}
+
+	skillsDefaults := stringSet(agentDef.DefaultSkills)
+	workflowsDefaults := stringSet(agentDef.DefaultWorkflows)
+	protocolsDefaults := stringSet(agentDef.DefaultProtocols)
+	sensorsDefaults := stringSet(agentDef.DefaultSensors)
+	routinesDefaults := stringSet(agentDef.DefaultRoutines)
+
+	skills := make([]graftItem, 0)
+	for _, it := range cat.SkillsFor(agentType) {
+		if filter && installedSkills[it.Name] {
+			continue
+		}
+		skills = append(skills, graftItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   !filter && skillsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+	workflows := make([]graftItem, 0)
+	for _, it := range cat.WorkflowsFor(agentType) {
+		if filter && installedWorkflows[it.Name] {
+			continue
+		}
+		workflows = append(workflows, graftItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   !filter && workflowsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+	protocols := make([]graftItem, 0)
+	for _, it := range cat.ProtocolsFor(agentType) {
+		if filter && installedProtocols[it.Name] {
+			continue
+		}
+		protocols = append(protocols, graftItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   !filter && protocolsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+	sensors := make([]graftItem, 0)
+	for _, it := range cat.SensorsFor(agentType) {
+		// routine-check is auto-managed — never user-picked.
+		if it.Name == "routine-check" {
+			continue
+		}
+		if filter && installedSensors[it.Name] {
+			continue
+		}
+		sensors = append(sensors, graftItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   !filter && sensorsDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+	routines := make([]graftItem, 0)
+	for _, it := range cat.RoutinesFor(agentType) {
+		if filter && installedRoutines[it.Name] {
+			continue
+		}
+		routines = append(routines, graftItem{
+			name:        it.Name,
+			displayName: it.DisplayName,
+			description: it.Description,
+			required:    it.Required.CompatibleWith(agentType),
+			isDefault:   !filter && routinesDefaults[it.Name],
+			filePath:    it.ContentPath,
+		})
+	}
+
+	all := []graftCat{
+		{
+			key: graftCatSkills, displayName: "SKILLS",
+			introLine1: "Rulebooks for specific domains.",
+			introLine2: "Standards the agent consults when doing focused work.",
+			items:      skills,
+		},
+		{
+			key: graftCatWorkflows, displayName: "WORKFLOWS",
+			introLine1: "Activity-level procedures.",
+			introLine2: "Playbooks for multi-phase tasks from intake to ship.",
+			items:      workflows,
+		},
+		{
+			key: graftCatProtocols, displayName: "PROTOCOLS",
+			introLine1: "Always-on guardrails.",
+			introLine2: "Rules every session follows, regardless of task.",
+			items:      protocols,
+		},
+		{
+			key: graftCatSensors, displayName: "SENSORS",
+			introLine1: "Hook-triggered automations.",
+			introLine2: "Event scripts the harness runs without prompting.",
+			items:      sensors,
+		},
+		{
+			key: graftCatRoutines, displayName: "ROUTINES",
+			introLine1: "Periodic self-maintenance.",
+			introLine2: "Recurring checks on a time-based schedule.",
+			items:      routines,
+		},
+	}
+
+	// Add-items branch: drop empty tabs entirely.
+	categories := make([]graftCat, 0, len(all))
+	for _, c := range all {
+		if filter && len(c.items) == 0 {
+			continue
+		}
+		categories = append(categories, c)
+	}
+
+	selected := make(map[int]map[string]bool, len(categories))
+	itemIdx := make(map[int]int, len(categories))
+	for i, c := range categories {
+		picks := make(map[string]bool)
+		for _, it := range c.items {
+			if it.required || it.isDefault {
+				picks[it.name] = true
+			}
+		}
+		selected[i] = picks
+		itemIdx[i] = 0
+	}
+
+	return &GraftStage{
+		Stage:      base,
+		categories: categories,
+		catIdx:     0,
+		itemIdx:    itemIdx,
+		selected:   selected,
+	}
+}
+
+// Init implements tea.Model — nothing to fire on entry.
+func (s *GraftStage) Init() tea.Cmd { return nil }
+
+// Update handles tab cycling, row focus, toggle, inline-expand, and Enter.
+func (s *GraftStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		switch m.String() {
+		case "left", "h":
+			if len(s.categories) == 0 {
+				return s, nil
+			}
+			s.catIdx = (s.catIdx - 1 + len(s.categories)) % len(s.categories)
+		case "right", "l":
+			if len(s.categories) == 0 {
+				return s, nil
+			}
+			s.catIdx = (s.catIdx + 1) % len(s.categories)
+		case "up", "k":
+			c := s.currentCat()
+			if c == nil || len(c.items) == 0 {
+				return s, nil
+			}
+			cur := s.itemIdx[s.catIdx] - 1
+			if cur < 0 {
+				cur = 0
+			}
+			s.itemIdx[s.catIdx] = cur
+		case "down", "j":
+			c := s.currentCat()
+			if c == nil || len(c.items) == 0 {
+				return s, nil
+			}
+			cur := s.itemIdx[s.catIdx] + 1
+			if cur >= len(c.items) {
+				cur = len(c.items) - 1
+			}
+			s.itemIdx[s.catIdx] = cur
+		case " ":
+			c := s.currentCat()
+			if c == nil || len(c.items) == 0 {
+				return s, nil
+			}
+			row := s.itemIdx[s.catIdx]
+			if row < 0 || row >= len(c.items) {
+				return s, nil
+			}
+			it := c.items[row]
+			if it.required {
+				return s, nil
+			}
+			picks := s.selected[s.catIdx]
+			if picks[it.name] {
+				delete(picks, it.name)
+			} else {
+				picks[it.name] = true
+			}
+		case "?":
+			s.expanded = !s.expanded
+		case "enter":
+			s.MarkDone()
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+func (s *GraftStage) currentCat() *graftCat {
+	if s.catIdx < 0 || s.catIdx >= len(s.categories) {
+		return nil
+	}
+	return &s.categories[s.catIdx]
+}
+
+// View composes the stage body inside the shared frame.
+func (s *GraftStage) View() string {
+	return s.RenderFrame(s.renderBody(), s.keyHints())
+}
+
+func (s *GraftStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "←→", Desc: "tab"},
+		{Key: "↑↓", Desc: "move"},
+		{Key: "␣", Desc: "toggle"},
+		{Key: "?", Desc: "details"},
+		{Key: "↵", Desc: "next"},
+		{Key: "esc", Desc: "back"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+func (s *GraftStage) renderBody() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+
+	var title string
+	if s.EnsoSafe() {
+		title = bark.Render(s.Label().Kanji) + " " + white.Render(s.Label().English)
+	} else {
+		title = white.Render(s.Label().English)
+	}
+
+	intro := strings.Join([]string{
+		title,
+		white.Render("Graft the agent's abilities."),
+		dim.Render("Five categories — required pinned, defaults pre-picked."),
+	}, "\n")
+
+	panelW := initflow.PanelWidth(s.Width())
+	divider := initflow.RenderSectionHeader("CATEGORIES", panelW)
+
+	if len(s.categories) == 0 {
+		empty := dim.Render("  (nothing to graft — all abilities already installed)")
+		body := []string{intro, "", "", divider, "", empty}
+		return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+	}
+
+	tabRow := s.renderTabs()
+	tabIntro := s.renderTabIntro()
+	list := s.renderList()
+	details := s.renderDetails()
+	counter := s.renderCounter()
+
+	listH := s.listHeight()
+	if listH > 0 {
+		rendered := strings.Count(list, "\n") + 1
+		if list == "" {
+			rendered = 0
+		}
+		if rendered < listH {
+			list = list + strings.Repeat("\n", listH-rendered)
+		}
+	}
+
+	body := []string{
+		intro,
+		"",
+		"",
+		divider,
+		"",
+		tabRow,
+		"",
+		tabIntro,
+		"",
+		list,
+		"",
+		"",
+		details,
+		"",
+		dim.Render(counter),
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+func (s *GraftStage) renderTabIntro() string {
+	c := s.currentCat()
+	if c == nil {
+		return ""
+	}
+	dim := initflow.DimStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent)
+	w := s.availableWidth()
+	if w < 10 {
+		w = 10
+	}
+	clamp := func(t string) string {
+		if lipgloss.Width(t) <= w {
+			return t
+		}
+		rr := []rune(t)
+		if len(rr) > w-1 {
+			return string(rr[:w-1]) + "…"
+		}
+		return t
+	}
+	return white.Render(clamp(c.introLine1)) + "\n" + dim.Render(clamp(c.introLine2))
+}
+
+func (s *GraftStage) renderTabs() string {
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	bracket := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	chevron := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+
+	const colW = 18
+
+	cells := make([]string, 0, len(s.categories))
+	for i, c := range s.categories {
+		label := fmt.Sprintf("%s (%d)", c.displayName, len(s.selected[i]))
+		var cell string
+		if i == s.catIdx {
+			cell = bracket.Render("[ ") + leaf.Render(label) + bracket.Render(" ]")
+		} else {
+			cell = "  " + muted.Render(label) + "  "
+		}
+		cells = append(cells, lipgloss.PlaceHorizontal(colW, lipgloss.Center, cell))
+	}
+
+	row := strings.Join(cells, " ")
+	return chevron.Render("‹") + " " + row + " " + chevron.Render("›")
+}
+
+func (s *GraftStage) renderList() string {
+	c := s.currentCat()
+	if c == nil {
+		return ""
+	}
+	if len(c.items) == 0 {
+		dim := initflow.DimStyle()
+		return dim.Render("  (no items in this category)")
+	}
+	rows := make([]string, 0, len(c.items))
+	for i := range c.items {
+		rows = append(rows, s.renderRow(i))
+	}
+	listH := s.listHeight()
+	if listH <= 0 || listH >= len(rows) {
+		return strings.Join(rows, "\n")
+	}
+	s.viewport.SetLines(rows)
+	s.viewport.SetHeight(listH)
+	s.viewport.Follow(s.itemIdx[s.catIdx])
+	return s.viewport.View()
+}
+
+func (s *GraftStage) renderRow(idx int) string {
+	c := s.currentCat()
+	if c == nil || idx < 0 || idx >= len(c.items) {
+		return ""
+	}
+	it := c.items[idx]
+	focused := idx == s.itemIdx[s.catIdx]
+	selected := s.selected[s.catIdx][it.name]
+
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	dim := initflow.DimStyle()
+
+	glyph := "◇"
+	glyphStyle := dim
+	if selected {
+		glyph = "◆"
+		glyphStyle = leaf
+	}
+
+	border := initflow.UnfocusBorder()
+	if focused {
+		border = initflow.FocusBorder()
+	}
+
+	nameColW, descColW, tagColW := initflow.ClampColumns(s.availableWidth())
+	descColW += tagColW - 2
+
+	name := it.displayName
+	if name == "" {
+		name = it.name
+	}
+	nameBudget := nameColW
+	if it.required {
+		nameBudget = nameColW - 2
+	}
+	if lipgloss.Width(name) > nameBudget {
+		rr := []rune(name)
+		if len(rr) > nameBudget-1 && nameBudget > 1 {
+			name = string(rr[:nameBudget-1]) + "…"
+		}
+	}
+
+	var nameStyle lipgloss.Style
+	switch {
+	case selected && focused:
+		nameStyle = leaf.Bold(true)
+	case selected:
+		nameStyle = leaf
+	case focused:
+		nameStyle = initflow.FocusedNameStyle()
+	default:
+		nameStyle = initflow.UnfocusedNameStyle()
+	}
+	nameText := nameStyle.Render(name)
+	if it.required {
+		nameText += " " + initflow.RequiredGlyph()
+	}
+	nameCol := initflow.PadRight(nameText, nameColW)
+
+	var descCol string
+	if descColW > 0 {
+		desc := it.description
+		if lipgloss.Width(desc) > descColW {
+			rr := []rune(desc)
+			if len(rr) > descColW-1 {
+				desc = string(rr[:descColW-1]) + "…"
+			}
+		}
+		descStyle := dim
+		if focused {
+			descStyle = initflow.FocusedDescStyle()
+		}
+		descCol = " " + descStyle.Render(initflow.PadRight(desc, descColW))
+	}
+	return border + glyphStyle.Render(glyph) + " " + nameCol + descCol
+}
+
+func (s *GraftStage) renderDetails() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	value := lipgloss.NewStyle().Foreground(tui.ColorAccent)
+
+	header := initflow.RenderSectionHeader("DETAILS", initflow.PanelWidth(s.Width()))
+	const labelW = 10
+	const indent = "    "
+	const aboutRows = 3
+	contentW := s.Width() - 10
+	if contentW > 70 {
+		contentW = 70
+	}
+	if contentW < 20 {
+		contentW = 20
+	}
+
+	if !s.expanded {
+		hint := indent + dim.Render("press ? to reveal ABOUT + FILE on the focused ability")
+		blank := indent
+		return header + "\n" + hint + "\n" + blank + "\n" + blank + "\n" + blank
+	}
+
+	c := s.currentCat()
+	if c == nil || len(c.items) == 0 {
+		empty := indent + dim.Render("(nothing to show)")
+		blank := indent
+		return header + "\n" + empty + "\n" + blank + "\n" + blank + "\n" + blank
+	}
+	row := s.itemIdx[s.catIdx]
+	if row < 0 || row >= len(c.items) {
+		empty := indent + dim.Render("(nothing to show)")
+		blank := indent
+		return header + "\n" + empty + "\n" + blank + "\n" + blank + "\n" + blank
+	}
+	it := c.items[row]
+
+	about := it.description
+	if about == "" {
+		about = "—"
+	}
+	aboutLines := wrapToWidth(about, contentW)
+	if len(aboutLines) > aboutRows {
+		last := aboutLines[aboutRows-1]
+		rr := []rune(last)
+		if len(rr) > contentW-1 {
+			last = string(rr[:contentW-1]) + "…"
+		} else {
+			last = last + "…"
+		}
+		aboutLines = append(aboutLines[:aboutRows-1], last)
+	}
+	for len(aboutLines) < aboutRows {
+		aboutLines = append(aboutLines, "")
+	}
+
+	file := it.filePath
+	if file == "" {
+		file = "—"
+	}
+	fileRR := []rune(file)
+	if len(fileRR) > contentW {
+		file = "…" + string(fileRR[len(fileRR)-contentW+1:])
+	}
+
+	aboutRow1 := indent + bark.Render(initflow.PadRight("ABOUT", labelW)) + value.Render(aboutLines[0])
+	aboutRow2 := indent + strings.Repeat(" ", labelW) + value.Render(aboutLines[1])
+	aboutRow3 := indent + strings.Repeat(" ", labelW) + value.Render(aboutLines[2])
+	fileRow := indent + bark.Render(initflow.PadRight("FILE", labelW)) + value.Render(file)
+	return header + "\n" + aboutRow1 + "\n" + aboutRow2 + "\n" + aboutRow3 + "\n" + fileRow
+}
+
+func (s *GraftStage) renderCounter() string {
+	total := 0
+	for i := range s.categories {
+		total += len(s.selected[i])
+	}
+	return fmt.Sprintf("%d abilities selected · across %d categories", total, len(s.categories))
+}
+
+// listHeight mirrors BranchesStage.listHeight — same chrome + non-list body
+// row accounting.
+func (s *GraftStage) listHeight() int {
+	if s.Height() <= 0 {
+		return 0
+	}
+	const chromeRows = 10
+	const fixedBodyRows = 21
+	h := s.Height() - chromeRows - fixedBodyRows
+	if h < 3 {
+		h = 3
+	}
+	return h
+}
+
+func (s *GraftStage) availableWidth() int {
+	w := s.Width() - 4
+	if w < 0 {
+		return 0
+	}
+	return w
+}
+
+// Result returns a GraftResult with per-category slices of selected machine
+// names, preserving catalog iteration order. Required items are always
+// present.
+func (s *GraftStage) Result() any {
+	pick := func(idx int) []string {
+		picks := s.selected[idx]
+		c := s.categories[idx]
+		out := make([]string, 0, len(picks))
+		for _, it := range c.items {
+			if picks[it.name] {
+				out = append(out, it.name)
+			}
+		}
+		return out
+	}
+	res := GraftResult{}
+	for i, c := range s.categories {
+		slice := pick(i)
+		switch c.key {
+		case graftCatSkills:
+			res.Skills = slice
+		case graftCatWorkflows:
+			res.Workflows = slice
+		case graftCatProtocols:
+			res.Protocols = slice
+		case graftCatSensors:
+			res.Sensors = slice
+		case graftCatRoutines:
+			res.Routines = slice
+		}
+	}
+	return res
+}
+
+// Reset clears the completion flag. Per-tab selections, cursor positions,
+// and the inline-expand toggle are all preserved across Esc-back.
+func (s *GraftStage) Reset() tea.Cmd {
+	s.ClearDone()
+	return nil
+}
+
+// wrapToWidth word-wraps text so no line exceeds width cells. Hard-wraps
+// oversized single words. Mirrors the helper in initflow/branches.go —
+// duplicated so addflow has no dependency on unexported initflow helpers.
+func wrapToWidth(text string, width int) []string {
+	if width <= 0 {
+		return []string{text}
+	}
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return []string{""}
+	}
+	var lines []string
+	cur := ""
+	for _, w := range words {
+		if cur == "" {
+			if lipgloss.Width(w) > width {
+				rr := []rune(w)
+				for len(rr) > width {
+					lines = append(lines, string(rr[:width]))
+					rr = rr[width:]
+				}
+				cur = string(rr)
+			} else {
+				cur = w
+			}
+			continue
+		}
+		candidate := cur + " " + w
+		if lipgloss.Width(candidate) <= width {
+			cur = candidate
+		} else {
+			lines = append(lines, cur)
+			cur = w
+		}
+	}
+	if cur != "" {
+		lines = append(lines, cur)
+	}
+	return lines
+}

--- a/internal/tui/addflow/graft_test.go
+++ b/internal/tui/addflow/graft_test.go
@@ -1,0 +1,281 @@
+package addflow
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// newTestGraftCatalog builds a fixture catalog covering all five ability
+// categories with a mix of required / default / plain items.
+func newTestGraftCatalog() (*catalog.Catalog, *catalog.AgentDef) {
+	none := catalog.AgentCompat{}
+	all := catalog.AgentCompat{All: true}
+
+	cat := &catalog.Catalog{
+		Skills: []catalog.CatalogItem{
+			{Name: "alpha-skill", DisplayName: "Alpha", Description: "a", Agents: all, Required: none, ContentPath: "skills/alpha/alpha.md"},
+			{Name: "beta-skill", DisplayName: "Beta", Description: "b", Agents: all, Required: none, ContentPath: "skills/beta/beta.md"},
+		},
+		Workflows: []catalog.CatalogItem{
+			{Name: "wf-one", DisplayName: "WF1", Description: "w1", Agents: all, Required: none, ContentPath: "workflows/one/one.md"},
+		},
+		Protocols: []catalog.CatalogItem{
+			{Name: "proto-req", DisplayName: "Proto Req", Description: "p", Agents: all, Required: all, ContentPath: "protocols/req/req.md"},
+		},
+		Sensors: []catalog.SensorItem{
+			{Name: "sensor-a", DisplayName: "Sensor A", Description: "s", Agents: all, Required: none, Event: "SessionStart", ContentPath: "sensors/a/a.sh"},
+			{Name: "routine-check", DisplayName: "Routine Check", Description: "auto", Agents: all, Required: none, Event: "SessionStart", ContentPath: "sensors/rc/rc.sh"},
+		},
+		Routines: []catalog.RoutineItem{
+			{Name: "routine-a", DisplayName: "Routine A", Description: "r", Agents: all, Required: none, Frequency: "7 days", ContentPath: "routines/a/a.md"},
+		},
+	}
+	agentDef := &catalog.AgentDef{
+		Name:          "backend",
+		DisplayName:   "Backend",
+		DefaultSkills: []string{"beta-skill"},
+	}
+	return cat, agentDef
+}
+
+func newTestGraft() *GraftStage {
+	cat, agentDef := newTestGraftCatalog()
+	return NewNewAgentGraft(initflow.StageContext{
+		StartedAt: time.Now(),
+	}, GraftContext{
+		Cat:       cat,
+		AgentType: "backend",
+		AgentDef:  agentDef,
+	})
+}
+
+func graftPressKey(s *GraftStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if gs, ok := m.(*GraftStage); ok {
+		*s = *gs
+	}
+}
+
+func graftPressRune(s *GraftStage, r rune) {
+	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	if gs, ok := m.(*GraftStage); ok {
+		*s = *gs
+	}
+}
+
+// TestGraft_FiltersRoutineCheck verifies the routine-check sensor is dropped
+// from the sensors tab regardless of filter mode.
+func TestGraft_FiltersRoutineCheck(t *testing.T) {
+	s := newTestGraft()
+	for _, c := range s.categories {
+		if c.key != graftCatSensors {
+			continue
+		}
+		for _, it := range c.items {
+			if it.name == "routine-check" {
+				t.Fatal("routine-check should be filtered from sensors tab")
+			}
+		}
+	}
+}
+
+// TestGraft_RequiredPreSelected verifies required items are pre-selected and
+// cannot be toggled off.
+func TestGraft_RequiredPreSelected(t *testing.T) {
+	s := newTestGraft()
+	// proto-req is in category protocols.
+	var protoIdx int = -1
+	for i, c := range s.categories {
+		if c.key == graftCatProtocols {
+			protoIdx = i
+			break
+		}
+	}
+	if protoIdx < 0 {
+		t.Fatal("protocols category missing")
+	}
+	if !s.selected[protoIdx]["proto-req"] {
+		t.Fatal("proto-req should be pre-selected as required")
+	}
+	// Navigate to protocols tab + try to toggle.
+	s.catIdx = protoIdx
+	graftPressRune(s, ' ')
+	if !s.selected[protoIdx]["proto-req"] {
+		t.Fatal("␣ on required item should be no-op")
+	}
+}
+
+// TestGraft_DefaultPreSelectedButToggleable verifies defaults are
+// pre-selected and can be toggled off.
+func TestGraft_DefaultPreSelectedButToggleable(t *testing.T) {
+	s := newTestGraft()
+	// beta-skill is default in category skills.
+	var skillIdx int = -1
+	for i, c := range s.categories {
+		if c.key == graftCatSkills {
+			skillIdx = i
+			break
+		}
+	}
+	if skillIdx < 0 {
+		t.Fatal("skills category missing")
+	}
+	if !s.selected[skillIdx]["beta-skill"] {
+		t.Fatal("beta-skill should be pre-selected as default")
+	}
+	// Focus beta-skill (second row, idx=1) and toggle off.
+	s.catIdx = skillIdx
+	s.itemIdx[skillIdx] = 1
+	graftPressRune(s, ' ')
+	if s.selected[skillIdx]["beta-skill"] {
+		t.Fatal("␣ on default should toggle off")
+	}
+}
+
+// TestGraft_TabCycles verifies ← → cycles tabs with wrap.
+func TestGraft_TabCycles(t *testing.T) {
+	s := newTestGraft()
+	start := s.catIdx
+	graftPressKey(s, tea.KeyRight)
+	if s.catIdx != start+1 {
+		t.Fatalf("right tab = %d, want %d", s.catIdx, start+1)
+	}
+	// Walk to end + wrap.
+	for range s.categories {
+		graftPressKey(s, tea.KeyRight)
+	}
+	if s.catIdx != start+1 {
+		t.Fatalf("after full cycle, catIdx = %d, want %d (wrap)", s.catIdx, start+1)
+	}
+}
+
+// TestGraft_ExpandToggle verifies ? flips the expanded flag.
+func TestGraft_ExpandToggle(t *testing.T) {
+	s := newTestGraft()
+	if s.expanded {
+		t.Fatal("expanded should start false")
+	}
+	graftPressRune(s, '?')
+	if !s.expanded {
+		t.Fatal("? should set expanded=true")
+	}
+	graftPressRune(s, '?')
+	if s.expanded {
+		t.Fatal("?? should toggle back to false")
+	}
+}
+
+// TestGraft_EnterAdvances verifies Enter flips done.
+func TestGraft_EnterAdvances(t *testing.T) {
+	s := newTestGraft()
+	if s.Done() {
+		t.Fatal("should not be done before Enter")
+	}
+	graftPressKey(s, tea.KeyEnter)
+	if !s.Done() {
+		t.Fatal("should be done after Enter")
+	}
+}
+
+// TestGraft_ResultShape verifies Result returns a GraftResult with the
+// expected pre-selected items (required + defaults).
+func TestGraft_ResultShape(t *testing.T) {
+	s := newTestGraft()
+	res, ok := s.Result().(GraftResult)
+	if !ok {
+		t.Fatalf("Result type = %T, want GraftResult", s.Result())
+	}
+	if !reflect.DeepEqual(res.Skills, []string{"beta-skill"}) {
+		t.Fatalf("Skills = %v, want [beta-skill]", res.Skills)
+	}
+	if !reflect.DeepEqual(res.Protocols, []string{"proto-req"}) {
+		t.Fatalf("Protocols = %v, want [proto-req]", res.Protocols)
+	}
+	if len(res.Workflows) != 0 {
+		t.Fatalf("Workflows = %v, want empty", res.Workflows)
+	}
+}
+
+// TestGraft_AddItemsFiltersInstalled verifies add-items mode filters out
+// items already in the installed agent + drops empty tabs.
+func TestGraft_AddItemsFiltersInstalled(t *testing.T) {
+	cat, agentDef := newTestGraftCatalog()
+	installed := &config.InstalledAgent{
+		AgentType: "backend",
+		Workspace: "backend/",
+		Skills:    []string{"alpha-skill", "beta-skill"},
+		Workflows: []string{"wf-one"},
+		Protocols: []string{"proto-req"},
+		Sensors:   []string{"sensor-a"},
+		Routines:  []string{"routine-a"},
+	}
+	s := NewAddItemsGraft(initflow.StageContext{StartedAt: time.Now()}, GraftContext{
+		Cat:       cat,
+		AgentType: "backend",
+		AgentDef:  agentDef,
+		Installed: installed,
+	})
+	// Every tab should be dropped — each category had all items installed.
+	if len(s.categories) != 0 {
+		t.Fatalf("add-items with everything installed: len(categories) = %d, want 0", len(s.categories))
+	}
+}
+
+// TestGraft_AddItemsPartialDropsEmpty verifies add-items mode drops only the
+// tabs that go empty after filtering.
+func TestGraft_AddItemsPartialDropsEmpty(t *testing.T) {
+	cat, agentDef := newTestGraftCatalog()
+	installed := &config.InstalledAgent{
+		AgentType: "backend",
+		Workspace: "backend/",
+		Skills:    []string{"alpha-skill"}, // leaves beta-skill available
+		Workflows: []string{"wf-one"},      // empty after filter
+		Protocols: []string{"proto-req"},   // empty after filter
+		Sensors:   []string{"sensor-a"},    // empty after filter
+		Routines:  []string{"routine-a"},   // empty after filter
+	}
+	s := NewAddItemsGraft(initflow.StageContext{StartedAt: time.Now()}, GraftContext{
+		Cat:       cat,
+		AgentType: "backend",
+		AgentDef:  agentDef,
+		Installed: installed,
+	})
+	if len(s.categories) != 1 {
+		t.Fatalf("len(categories) = %d, want 1 (only skills should remain)", len(s.categories))
+	}
+	if s.categories[0].key != graftCatSkills {
+		t.Fatalf("remaining tab = %q, want skills", s.categories[0].key)
+	}
+	if len(s.categories[0].items) != 1 || s.categories[0].items[0].name != "beta-skill" {
+		t.Fatalf("skills tab items = %v, want [beta-skill]", s.categories[0].items)
+	}
+}
+
+// TestGraft_ResetPreservesState verifies Reset clears done but preserves
+// selections + cursor + expanded.
+func TestGraft_ResetPreservesState(t *testing.T) {
+	s := newTestGraft()
+	// Move around + toggle.
+	graftPressKey(s, tea.KeyRight)
+	graftPressRune(s, '?')
+	graftPressKey(s, tea.KeyEnter)
+	catIdx := s.catIdx
+	expanded := s.expanded
+	s.Reset()
+	if s.Done() {
+		t.Fatal("Reset should clear done")
+	}
+	if s.catIdx != catIdx {
+		t.Fatalf("Reset changed catIdx — got %d, want %d", s.catIdx, catIdx)
+	}
+	if s.expanded != expanded {
+		t.Fatalf("Reset changed expanded — got %v, want %v", s.expanded, expanded)
+	}
+}

--- a/internal/tui/addflow/ground.go
+++ b/internal/tui/addflow/ground.go
@@ -1,0 +1,233 @@
+package addflow
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// GroundStage collects the workspace directory for a new non-tech-lead
+// agent at rail position 1 (地 GROUND). Single textinput with Vessel-style
+// focus underline + unique-workspace validator. For the tech-lead agent
+// type the stage auto-completes with the resolved DocsPath (or "station/")
+// without any keystroke — AutoComplete() drives the harness's skip-past.
+//
+// Result: resolved workspace string (always trailing-slashed + cleaned).
+type GroundStage struct {
+	initflow.Stage
+
+	input              textinput.Model
+	agentType          string
+	defaultWorkspace   string            // pre-filled value / tech-lead override
+	existingWorkspaces map[string]bool   // duplicate guard
+	techLead           bool              // true → AutoComplete skips the stage
+	validateErr        string            // inline error label under the input
+	showError          bool              // only draw errors after first submit attempt
+	_                  lipgloss.Position // reserved — keeps imports stable
+}
+
+// GroundContext is the ctor bundle for GroundStage. Mirrors the shape used
+// by the other addflow ctors so cmd/add_redesign.go can stamp everything in
+// one place.
+type GroundContext struct {
+	AgentType          string
+	DocsPath           string          // cfg.DocsPath for tech-lead fallback
+	ExistingWorkspaces map[string]bool // keys already taken by installed agents
+}
+
+// NewGroundStage constructs the Ground stage. When agentType is "tech-lead"
+// the stage is in auto-complete mode — AutoComplete() returns (workspace,
+// true) and the harness's NewLazy wrapper should skip it.
+func NewGroundStage(ctx initflow.StageContext, gc GroundContext) *GroundStage {
+	label := StageLabels[StageIdxGround]
+	base := initflow.NewStage(
+		StageIdxGround,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+
+	ti := textinput.New()
+	ti.Prompt = "❯ "
+	ti.PromptStyle = lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	ti.TextStyle = lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(tui.ColorRule2)
+	ti.CharLimit = 256
+	ti.Width = 60
+	ti.Placeholder = gc.AgentType + "/"
+	ti.SetValue(gc.AgentType + "/")
+	ti.CursorEnd()
+	ti.Focus()
+
+	techLead := gc.AgentType == "tech-lead"
+	defaultWs := gc.DocsPath
+	if defaultWs == "" {
+		defaultWs = "station/"
+	}
+
+	return &GroundStage{
+		Stage:              base,
+		input:              ti,
+		agentType:          gc.AgentType,
+		defaultWorkspace:   defaultWs,
+		existingWorkspaces: gc.ExistingWorkspaces,
+		techLead:           techLead,
+	}
+}
+
+// Init kicks the textinput cursor blink. For the tech-lead agent the stage
+// is non-interactive — flip Done immediately so the harness forwards past
+// the stage without a keystroke.
+func (s *GroundStage) Init() tea.Cmd {
+	if s.techLead {
+		s.MarkDone()
+		return nil
+	}
+	return textinput.Blink
+}
+
+// AutoComplete reports true when there is nothing for the user to change on
+// this stage (tech-lead path) so the harness's Esc-back walker skips past
+// it. Matches the SpinnerStep / MultiSelectStep(all required) convention.
+func (s *GroundStage) AutoComplete() bool { return s.techLead }
+
+// Update handles typing + Enter-to-validate-and-advance. Esc propagates to
+// the harness (pops back to Select).
+func (s *GroundStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		if m.String() == "enter" {
+			v := strings.TrimSpace(s.input.Value())
+			if v == "" {
+				s.validateErr = "workspace required"
+				s.showError = true
+				return s, nil
+			}
+			norm := NormaliseWorkspace(v)
+			if s.existingWorkspaces[norm] {
+				s.validateErr = fmt.Sprintf("workspace %q is already in use", norm)
+				s.showError = true
+				return s, nil
+			}
+			s.validateErr = ""
+			s.showError = false
+			s.input.SetValue(norm)
+			s.MarkDone()
+			return s, nil
+		}
+	}
+	var cmd tea.Cmd
+	s.input, cmd = s.input.Update(msg)
+	return s, cmd
+}
+
+// View composes the body inside the shared frame.
+func (s *GroundStage) View() string {
+	return s.RenderFrame(s.renderBody(), s.keyHints())
+}
+
+func (s *GroundStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "↵", Desc: "next"},
+		{Key: "esc", Desc: "back"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+func (s *GroundStage) renderBody() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	errStyle := lipgloss.NewStyle().Foreground(tui.ColorDanger)
+
+	var title string
+	if s.EnsoSafe() {
+		title = bark.Render(s.Label().Kanji) + " " + white.Render(s.Label().English)
+	} else {
+		title = white.Render(s.Label().English)
+	}
+
+	intro := strings.Join([]string{
+		title,
+		white.Render("Ground the agent."),
+		dim.Render("Where on disk should this agent live?"),
+	}, "\n")
+
+	divider := initflow.RenderSectionHeader("WORKSPACE", initflow.PanelWidth(s.Width()))
+
+	const labelColW = 20
+	inputW := s.Width() - labelColW - 4
+	if inputW > 60 {
+		inputW = 60
+	}
+	if inputW < 30 {
+		inputW = 30
+	}
+	inputCellW := inputW + 4
+	s.input.Width = inputW
+
+	labelLine := bark.Render(initflow.PadRight("WORKSPACE", labelColW))
+	subtitleLine := dim.Render(initflow.PadRight("e.g. backend/", labelColW))
+	inputLine := lipgloss.PlaceHorizontal(inputCellW, lipgloss.Left, s.input.View())
+	underline := leaf.Render(strings.Repeat("─", inputCellW))
+
+	line1 := labelLine + inputLine
+	line2 := subtitleLine + underline
+
+	row := line1 + "\n" + line2
+	if s.showError && s.validateErr != "" {
+		row += "\n" + initflow.PadRight(" ", labelColW) + errStyle.Render(s.validateErr)
+	}
+
+	block := strings.Join([]string{
+		intro,
+		"",
+		"",
+		divider,
+		"",
+		row,
+	}, "\n")
+	return initflow.CenterBlock(block, s.Width())
+}
+
+// Result returns the resolved workspace string (normalised trailing slash)
+// or the tech-lead default when in auto-complete mode.
+func (s *GroundStage) Result() any {
+	if s.techLead {
+		return s.defaultWorkspace
+	}
+	return NormaliseWorkspace(s.input.Value())
+}
+
+// Reset clears completion so re-entry doesn't auto-advance. Preserves the
+// entered value.
+func (s *GroundStage) Reset() tea.Cmd {
+	s.ClearDone()
+	return nil
+}
+
+// NormaliseWorkspace applies the shared trim + filepath.Clean + trailing-
+// slash rule used by cmd/add.go. Duplicated here (not referenced via cmd/)
+// so addflow has no back-import into cmd. Phase 3 can drop the cmd copy.
+func NormaliseWorkspace(s string) string {
+	v := strings.TrimSpace(s)
+	if v == "" {
+		return ""
+	}
+	v = strings.TrimRight(filepath.Clean(v), "/") + "/"
+	return v
+}

--- a/internal/tui/addflow/ground_test.go
+++ b/internal/tui/addflow/ground_test.go
@@ -1,0 +1,166 @@
+package addflow
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+func newTestGround(agentType string, existing map[string]bool) *GroundStage {
+	return NewGroundStage(initflow.StageContext{
+		Version:      "test",
+		ProjectDir:   "/tmp/ground-test",
+		StationDir:   "station/",
+		AgentDisplay: "",
+		StartedAt:    time.Now(),
+	}, GroundContext{
+		AgentType:          agentType,
+		DocsPath:           "station/",
+		ExistingWorkspaces: existing,
+	})
+}
+
+func groundPressKey(s *GroundStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if gs, ok := m.(*GroundStage); ok {
+		*s = *gs
+	}
+}
+
+func groundType(s *GroundStage, text string) {
+	s.input.SetValue(text)
+}
+
+// TestGround_TechLeadAutoCompletes verifies tech-lead agent flips done at
+// Init and AutoComplete returns true.
+func TestGround_TechLeadAutoCompletes(t *testing.T) {
+	s := newTestGround("tech-lead", nil)
+	s.Init()
+	if !s.Done() {
+		t.Fatal("tech-lead Init should MarkDone")
+	}
+	if !s.AutoComplete() {
+		t.Fatal("tech-lead AutoComplete should return true")
+	}
+	got, ok := s.Result().(string)
+	if !ok || got != "station/" {
+		t.Fatalf("Result = %v, want station/", s.Result())
+	}
+}
+
+// TestGround_TechLeadUsesDocsPath verifies the DocsPath passed via context is
+// returned verbatim when non-empty.
+func TestGround_TechLeadUsesDocsPath(t *testing.T) {
+	s := NewGroundStage(initflow.StageContext{StartedAt: time.Now()}, GroundContext{
+		AgentType: "tech-lead",
+		DocsPath:  "docs/",
+	})
+	got, _ := s.Result().(string)
+	if got != "docs/" {
+		t.Fatalf("Result = %q, want docs/", got)
+	}
+}
+
+// TestGround_NewAgentDoesNotAutoComplete verifies non-tech-lead paths don't
+// auto-advance.
+func TestGround_NewAgentDoesNotAutoComplete(t *testing.T) {
+	s := newTestGround("backend", nil)
+	s.Init()
+	if s.Done() {
+		t.Fatal("backend Init should not MarkDone")
+	}
+	if s.AutoComplete() {
+		t.Fatal("backend AutoComplete should return false")
+	}
+}
+
+// TestGround_EnterValidatesEmpty verifies empty workspace is rejected.
+func TestGround_EnterValidatesEmpty(t *testing.T) {
+	s := newTestGround("backend", nil)
+	s.input.SetValue("")
+	groundPressKey(s, tea.KeyEnter)
+	if s.Done() {
+		t.Fatal("empty value should not advance")
+	}
+	if !strings.Contains(s.validateErr, "required") {
+		t.Fatalf("validateErr = %q, want 'required'", s.validateErr)
+	}
+}
+
+// TestGround_EnterRejectsDuplicate verifies a workspace already in use is
+// flagged.
+func TestGround_EnterRejectsDuplicate(t *testing.T) {
+	existing := map[string]bool{"backend/": true}
+	s := newTestGround("backend", existing)
+	groundType(s, "backend/")
+	groundPressKey(s, tea.KeyEnter)
+	if s.Done() {
+		t.Fatal("duplicate should not advance")
+	}
+	if !strings.Contains(s.validateErr, "already in use") {
+		t.Fatalf("validateErr = %q, want 'already in use'", s.validateErr)
+	}
+}
+
+// TestGround_EnterAdvancesOnValid verifies valid input normalises + advances.
+func TestGround_EnterAdvancesOnValid(t *testing.T) {
+	s := newTestGround("backend", nil)
+	groundType(s, "./services/api")
+	groundPressKey(s, tea.KeyEnter)
+	if !s.Done() {
+		t.Fatal("valid input should advance")
+	}
+	got, _ := s.Result().(string)
+	if got != "services/api/" {
+		t.Fatalf("Result = %q, want services/api/", got)
+	}
+}
+
+// TestGround_ResultNormalises verifies Result normalises whitespace/clean.
+func TestGround_ResultNormalises(t *testing.T) {
+	s := newTestGround("backend", nil)
+	groundType(s, "  custom//  ")
+	got, _ := s.Result().(string)
+	if got != "custom/" {
+		t.Fatalf("Result = %q, want custom/", got)
+	}
+}
+
+// TestNormaliseWorkspace covers the standalone helper.
+func TestNormaliseWorkspace(t *testing.T) {
+	cases := map[string]string{
+		"backend":    "backend/",
+		"backend/":   "backend/",
+		"./backend":  "backend/",
+		"  api  ":    "api/",
+		"":           "",
+		"nested/dir": "nested/dir/",
+	}
+	for in, want := range cases {
+		if got := NormaliseWorkspace(in); got != want {
+			t.Errorf("NormaliseWorkspace(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestGround_ResetPreservesValue verifies Reset clears done but not the
+// entered value.
+func TestGround_ResetPreservesValue(t *testing.T) {
+	s := newTestGround("backend", nil)
+	groundType(s, "services/api/")
+	groundPressKey(s, tea.KeyEnter)
+	if !s.Done() {
+		t.Fatal("should be done")
+	}
+	s.Reset()
+	if s.Done() {
+		t.Fatal("Reset should clear done")
+	}
+	if s.input.Value() != "services/api/" {
+		t.Fatalf("Reset should preserve value — got %q", s.input.Value())
+	}
+}

--- a/internal/tui/addflow/grow.go
+++ b/internal/tui/addflow/grow.go
@@ -1,0 +1,23 @@
+package addflow
+
+import (
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// NewGrowStage constructs the Grow stage (育 GROW) at rail position 4.
+// Thin wrapper around initflow.NewGenerateStage — installs the add-flow
+// rail labels on the embedded Stage and overrides the body title kanji
+// from 生 (init's Generate) to 育 (Grow) so the visual language matches
+// the bonsai-raising metaphor of the add flow.
+//
+// action is the same GenerateAction contract as the init flow — a
+// one-shot func() error that runs the write pipeline and returns nil on
+// success. The underlying min-hold + animation behaviour is unchanged.
+func NewGrowStage(ctx initflow.StageContext, action initflow.GenerateAction) *initflow.GenerateStage {
+	g := initflow.NewGenerateStage(ctx, action)
+	g.SetRailLabels(StageLabels)
+	g.SetRailIndex(StageIdxGrow)
+	g.SetLabel(StageLabels[StageIdxGrow])
+	g.SetBodyTitle(StageLabels[StageIdxGrow].Kanji, "GROWING")
+	return g
+}

--- a/internal/tui/addflow/observe.go
+++ b/internal/tui/addflow/observe.go
@@ -27,9 +27,9 @@ type ObserveStage struct {
 
 	cat *catalog.Catalog
 
-	agent     string       // machine name — prev[0]
-	workspace string       // resolved path — prev[1] (tech-lead auto-fills)
-	graft     GraftResult  // prev[2]
+	agent     string      // machine name — prev[0]
+	workspace string      // resolved path — prev[1] (tech-lead auto-fills)
+	graft     GraftResult // prev[2]
 
 	// agentDef + agentDisplay resolved from cat on each SetPrior.
 	agentDef     *catalog.AgentDef

--- a/internal/tui/addflow/observe.go
+++ b/internal/tui/addflow/observe.go
@@ -1,0 +1,280 @@
+package addflow
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// ObserveStage is the pre-write "one last look" stage at rail position 3
+// (観 OBSERVE). Composes a read-only summary of the Select / Ground / Graft
+// results into a single review panel with a GRAFT / BACK CTA.
+//
+// Result:
+//   - true  → user confirmed GRAFT — harness proceeds to Grow.
+//   - false → user cancelled — flow exits without writes.
+//
+// Prior inputs arrive via SetPrior so the stage can render fresh summaries
+// even after an Esc-back edit pass upstream.
+type ObserveStage struct {
+	initflow.Stage
+
+	cat *catalog.Catalog
+
+	agent     string       // machine name — prev[0]
+	workspace string       // resolved path — prev[1] (tech-lead auto-fills)
+	graft     GraftResult  // prev[2]
+
+	// agentDef + agentDisplay resolved from cat on each SetPrior.
+	agentDef     *catalog.AgentDef
+	agentDisplay string
+
+	confirmed bool
+	btnFocus  int // 0 = BACK, 1 = GRAFT. Default GRAFT (1).
+}
+
+// NewObserveStage constructs the Observe stage.
+func NewObserveStage(ctx initflow.StageContext, cat *catalog.Catalog) *ObserveStage {
+	label := StageLabels[StageIdxObserve]
+	base := initflow.NewStage(
+		StageIdxObserve,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+	base.SetRailLabels(StageLabels)
+	return &ObserveStage{
+		Stage:    base,
+		cat:      cat,
+		btnFocus: 1,
+	}
+}
+
+// SetPrior captures Select / Ground / Graft results. Called on entry and
+// after every Esc-back edit.
+func (s *ObserveStage) SetPrior(prev []any) {
+	if len(prev) >= 1 {
+		if a, ok := prev[0].(string); ok {
+			s.agent = a
+		}
+	}
+	if len(prev) >= 2 {
+		if w, ok := prev[1].(string); ok {
+			s.workspace = w
+		}
+	}
+	if len(prev) >= 3 {
+		if g, ok := prev[2].(GraftResult); ok {
+			s.graft = g
+		}
+	}
+	if s.agent != "" && s.cat != nil {
+		s.agentDef = s.cat.GetAgent(s.agent)
+		if s.agentDef != nil {
+			s.agentDisplay = s.agentDef.DisplayName
+			if s.agentDisplay == "" {
+				s.agentDisplay = catalog.DisplayNameFrom(s.agentDef.Name)
+			}
+		}
+	}
+}
+
+// Init implements tea.Model — no cmd on entry.
+func (s *ObserveStage) Init() tea.Cmd { return nil }
+
+// Update handles button toggle + Enter confirm + y/n shortcuts.
+func (s *ObserveStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		switch m.String() {
+		case "tab", "right", "l", "shift+tab", "left", "h":
+			s.btnFocus = (s.btnFocus + 1) % 2
+		case "y", "Y":
+			s.confirmed = true
+			s.MarkDone()
+			return s, nil
+		case "n", "N":
+			s.confirmed = false
+			s.MarkDone()
+			return s, nil
+		case "enter":
+			s.confirmed = s.btnFocus == 1
+			s.MarkDone()
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+// View composes the body inside the shared frame.
+func (s *ObserveStage) View() string {
+	return s.RenderFrame(s.renderBody(), s.keyHints())
+}
+
+func (s *ObserveStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "↵", Desc: "confirm"},
+		{Key: "tab", Desc: "toggle"},
+		{Key: "y/n", Desc: "graft / cancel"},
+		{Key: "esc", Desc: "back"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+func (s *ObserveStage) renderBody() string {
+	bark := initflow.LabelStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	dim := initflow.DimStyle()
+
+	var title string
+	if s.EnsoSafe() {
+		title = bark.Render(s.Label().Kanji) + " " + white.Render(s.Label().English)
+	} else {
+		title = white.Render(s.Label().English)
+	}
+
+	intro := strings.Join([]string{
+		title,
+		white.Render("One last look before grafting."),
+		dim.Render("Review your picks — ↵ grafts, n cancels."),
+	}, "\n")
+
+	agentBlock := s.renderAgentBlock()
+	abilitiesBlock := s.renderAbilitiesBlock()
+	cta := s.renderCTA()
+
+	body := []string{
+		intro,
+		"",
+		"",
+		agentBlock,
+		"",
+		"",
+		abilitiesBlock,
+		"",
+		"",
+		cta,
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+func (s *ObserveStage) renderAgentBlock() string {
+	bark := initflow.LabelStyle()
+	value := initflow.ValueStyle()
+
+	panelW := initflow.PanelWidth(s.Width())
+	header := initflow.RenderSectionHeader("AGENT", panelW)
+
+	name := s.agentDisplay
+	if name == "" {
+		name = s.agent
+	}
+	if name == "" {
+		name = "—"
+	}
+	workspace := s.workspace
+	if workspace == "" {
+		workspace = "—"
+	}
+	agentType := s.agent
+	if agentType == "" {
+		agentType = "—"
+	}
+
+	const labelW = 14
+	const indent = "  "
+	rows := []string{
+		header,
+		indent + bark.Render(initflow.PadRight("NAME", labelW)) + value.Render(name),
+		indent + bark.Render(initflow.PadRight("WORKSPACE", labelW)) + value.Render(workspace),
+		indent + bark.Render(initflow.PadRight("TYPE", labelW)) + value.Render(agentType),
+	}
+	return strings.Join(rows, "\n")
+}
+
+func (s *ObserveStage) renderAbilitiesBlock() string {
+	bark := initflow.LabelStyle()
+	dim := initflow.DimStyle()
+	value := initflow.ValueStyle()
+
+	panelW := initflow.PanelWidth(s.Width())
+	header := initflow.RenderSectionHeader("ABILITIES", panelW)
+
+	const labelW = 14
+	const indent = "  "
+
+	renderRow := func(label string, items []string) string {
+		row := indent + bark.Render(initflow.PadRight(label, labelW))
+		if len(items) == 0 {
+			return row + dim.Render("(none)")
+		}
+		return row + value.Render(fmt.Sprintf("%d", len(items))) + dim.Render("  "+strings.Join(items, ", "))
+	}
+
+	rows := []string{
+		header,
+		renderRow("SKILLS", s.graft.Skills),
+		renderRow("WORKFLOWS", s.graft.Workflows),
+		renderRow("PROTOCOLS", s.graft.Protocols),
+		renderRow("SENSORS", s.graft.Sensors),
+		renderRow("ROUTINES", s.graft.Routines),
+	}
+	return strings.Join(rows, "\n")
+}
+
+func (s *ObserveStage) renderCTA() string {
+	dim := initflow.DimStyle()
+	bark := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	accent := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+
+	total := s.graft.Total()
+	ws := s.workspace
+	if ws == "" {
+		ws = "—"
+	}
+
+	backLabel := "[ BACK ]"
+	graftLabel := fmt.Sprintf("[ ⏎  GRAFT ~%d items ]", total)
+	if !s.EnsoSafe() {
+		graftLabel = fmt.Sprintf("[ Enter  GRAFT ~%d items ]", total)
+	}
+
+	var backBtn, graftBtn string
+	if s.btnFocus == 0 {
+		backBtn = accent.Render(backLabel)
+		graftBtn = muted.Render(graftLabel)
+	} else {
+		backBtn = muted.Render(backLabel)
+		graftBtn = leaf.Bold(true).Render(graftLabel)
+	}
+
+	line1 := leaf.Render("Graft into ") + bark.Render(ws)
+	line2 := dim.Render("Existing files will be offered for merge · nothing overwritten without your say-so")
+	line3 := backBtn + "   " + graftBtn
+	return strings.Join([]string{line1, line2, "", line3}, "\n")
+}
+
+// Result returns a bool: true = proceed to Grow, false = cancel.
+func (s *ObserveStage) Result() any { return s.confirmed }
+
+// Reset clears completion + confirmation while preserving the captured
+// prior snapshot and button focus.
+func (s *ObserveStage) Reset() tea.Cmd {
+	s.ClearDone()
+	s.confirmed = false
+	return nil
+}

--- a/internal/tui/addflow/observe_test.go
+++ b/internal/tui/addflow/observe_test.go
@@ -1,0 +1,175 @@
+package addflow
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+func newTestObserve() *ObserveStage {
+	cat := &catalog.Catalog{
+		Agents: []catalog.AgentDef{
+			{Name: "backend", DisplayName: "Backend", Description: "b"},
+		},
+	}
+	return NewObserveStage(initflow.StageContext{
+		Version:      "test",
+		ProjectDir:   "/tmp/observe-test",
+		StationDir:   "station/",
+		AgentDisplay: "",
+		StartedAt:    time.Now(),
+	}, cat)
+}
+
+func observePressKey(s *ObserveStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if os, ok := m.(*ObserveStage); ok {
+		*s = *os
+	}
+}
+
+func observePressRune(s *ObserveStage, r rune) {
+	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	if os, ok := m.(*ObserveStage); ok {
+		*s = *os
+	}
+}
+
+// TestObserve_SetPriorCapturesFields verifies SetPrior pulls the three
+// upstream results into the stage.
+func TestObserve_SetPriorCapturesFields(t *testing.T) {
+	s := newTestObserve()
+	graft := GraftResult{
+		Skills:    []string{"s1"},
+		Workflows: []string{"w1"},
+	}
+	s.SetPrior([]any{"backend", "services/api/", graft})
+	if s.agent != "backend" {
+		t.Fatalf("agent = %q, want backend", s.agent)
+	}
+	if s.workspace != "services/api/" {
+		t.Fatalf("workspace = %q, want services/api/", s.workspace)
+	}
+	if len(s.graft.Skills) != 1 || s.graft.Skills[0] != "s1" {
+		t.Fatalf("graft.Skills = %v, want [s1]", s.graft.Skills)
+	}
+	if s.agentDef == nil || s.agentDef.Name != "backend" {
+		t.Fatal("agentDef should be resolved from catalog")
+	}
+	if s.agentDisplay != "Backend" {
+		t.Fatalf("agentDisplay = %q, want Backend", s.agentDisplay)
+	}
+}
+
+// TestObserve_SetPriorMissingAgentTolerant verifies SetPrior tolerates an
+// unknown agent without panicking.
+func TestObserve_SetPriorMissingAgentTolerant(t *testing.T) {
+	s := newTestObserve()
+	s.SetPrior([]any{"unknown-agent", "x/", GraftResult{}})
+	if s.agent != "unknown-agent" {
+		t.Fatalf("agent = %q, want unknown-agent", s.agent)
+	}
+	if s.agentDef != nil {
+		t.Fatal("unknown agent should leave agentDef nil")
+	}
+}
+
+// TestObserve_DefaultFocusGraft verifies btnFocus starts on GRAFT (1).
+func TestObserve_DefaultFocusGraft(t *testing.T) {
+	s := newTestObserve()
+	if s.btnFocus != 1 {
+		t.Fatalf("btnFocus = %d, want 1 (GRAFT default)", s.btnFocus)
+	}
+}
+
+// TestObserve_TabTogglesButtons verifies tab flips button focus.
+func TestObserve_TabTogglesButtons(t *testing.T) {
+	s := newTestObserve()
+	observePressKey(s, tea.KeyTab)
+	if s.btnFocus != 0 {
+		t.Fatalf("after Tab btnFocus = %d, want 0", s.btnFocus)
+	}
+	observePressKey(s, tea.KeyTab)
+	if s.btnFocus != 1 {
+		t.Fatalf("after 2× Tab btnFocus = %d, want 1", s.btnFocus)
+	}
+}
+
+// TestObserve_YConfirmsGraft verifies y shortcut sets confirmed + done.
+func TestObserve_YConfirmsGraft(t *testing.T) {
+	s := newTestObserve()
+	observePressRune(s, 'y')
+	if !s.Done() {
+		t.Fatal("y should MarkDone")
+	}
+	if got, _ := s.Result().(bool); !got {
+		t.Fatal("y should set Result=true")
+	}
+}
+
+// TestObserve_NCancels verifies n shortcut cancels.
+func TestObserve_NCancels(t *testing.T) {
+	s := newTestObserve()
+	observePressRune(s, 'n')
+	if !s.Done() {
+		t.Fatal("n should MarkDone")
+	}
+	if got, _ := s.Result().(bool); got {
+		t.Fatal("n should set Result=false")
+	}
+}
+
+// TestObserve_EnterOnGraftConfirms verifies Enter with GRAFT focus confirms.
+func TestObserve_EnterOnGraftConfirms(t *testing.T) {
+	s := newTestObserve()
+	// btnFocus defaults to 1 (GRAFT).
+	observePressKey(s, tea.KeyEnter)
+	if got, _ := s.Result().(bool); !got {
+		t.Fatal("Enter on GRAFT should confirm")
+	}
+}
+
+// TestObserve_EnterOnBackCancels verifies Enter with BACK focus cancels.
+func TestObserve_EnterOnBackCancels(t *testing.T) {
+	s := newTestObserve()
+	observePressKey(s, tea.KeyTab) // move to BACK
+	observePressKey(s, tea.KeyEnter)
+	if got, _ := s.Result().(bool); got {
+		t.Fatal("Enter on BACK should cancel")
+	}
+}
+
+// TestObserve_ViewRendersWorkspace verifies the workspace path appears in
+// the rendered view.
+func TestObserve_ViewRendersWorkspace(t *testing.T) {
+	s := newTestObserve()
+	s.SetSize(120, 40)
+	s.SetPrior([]any{"backend", "services/api/", GraftResult{Skills: []string{"s1"}}})
+	out := s.View()
+	if !strings.Contains(out, "services/api/") {
+		t.Fatal("view should contain workspace path")
+	}
+}
+
+// TestObserve_ResetClearsConfirmation verifies Reset clears done and
+// confirmation state but preserves prior.
+func TestObserve_ResetClearsConfirmation(t *testing.T) {
+	s := newTestObserve()
+	s.SetPrior([]any{"backend", "ws/", GraftResult{}})
+	observePressRune(s, 'y')
+	s.Reset()
+	if s.Done() {
+		t.Fatal("Reset should clear done")
+	}
+	if got, _ := s.Result().(bool); got {
+		t.Fatal("Reset should clear confirmed")
+	}
+	if s.agent != "backend" {
+		t.Fatal("Reset should preserve prior")
+	}
+}

--- a/internal/tui/addflow/select.go
+++ b/internal/tui/addflow/select.go
@@ -1,0 +1,301 @@
+package addflow
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// SelectStage is the single-choice agent picker at rail position 0. Renders
+// the full agent catalog as a Branches-style list — Leaf "│ " focus border,
+// white-bold focused name, ColorRule2 description on unfocused rows — and
+// appends an "(installed)" suffix after any agent already present in the
+// config.
+//
+// Result: machine name of the chosen agent (string).
+type SelectStage struct {
+	initflow.Stage
+
+	options []AgentOption
+	focus   int
+
+	// Viewport wraps the list when the catalog exceeds available body rows.
+	viewport initflow.Viewport
+}
+
+// NewSelectStage constructs the Select stage. options is typically built via
+// BuildAgentOptions against the loaded catalog + project config.
+func NewSelectStage(ctx initflow.StageContext, options []AgentOption) *SelectStage {
+	label := StageLabels[StageIdxSelect]
+	base := initflow.NewStage(
+		StageIdxSelect,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+	base.SetRailLabels(StageLabels)
+	return &SelectStage{
+		Stage:   base,
+		options: options,
+		focus:   0,
+	}
+}
+
+// BuildAgentOptions maps catalog agents into SelectStage's row shape,
+// flagging each entry as Installed when the config already contains that
+// agent type. Catalog order is preserved verbatim.
+func BuildAgentOptions(cat *catalog.Catalog, installed map[string]bool) []AgentOption {
+	out := make([]AgentOption, 0, len(cat.Agents))
+	for _, a := range cat.Agents {
+		display := a.DisplayName
+		if display == "" {
+			display = catalog.DisplayNameFrom(a.Name)
+		}
+		out = append(out, AgentOption{
+			Name:        a.Name,
+			DisplayName: display,
+			Description: a.Description,
+			Installed:   installed[a.Name],
+		})
+	}
+	return out
+}
+
+// Init implements tea.Model — no cmd to fire on entry.
+func (s *SelectStage) Init() tea.Cmd { return nil }
+
+// Update handles focus movement + Enter-to-advance. Esc is consumed by the
+// harness at the root — stage 0 esc is a no-op (aborts only via Ctrl-C).
+func (s *SelectStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		switch m.String() {
+		case "up", "k":
+			if len(s.options) == 0 {
+				return s, nil
+			}
+			s.focus--
+			if s.focus < 0 {
+				s.focus = 0
+			}
+		case "down", "j":
+			if len(s.options) == 0 {
+				return s, nil
+			}
+			s.focus++
+			if s.focus >= len(s.options) {
+				s.focus = len(s.options) - 1
+			}
+		case "enter":
+			s.MarkDone()
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+// View composes the Select stage body inside the shared frame.
+func (s *SelectStage) View() string {
+	return s.RenderFrame(s.renderBody(), s.keyHints())
+}
+
+func (s *SelectStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "↑↓", Desc: "move"},
+		{Key: "↵", Desc: "pick"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+// renderBody composes intro + CATEGORY divider + list + counter. Single-
+// column layout (no tabs) — mirrors SoilStage's visual rhythm.
+func (s *SelectStage) renderBody() string {
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+
+	var title string
+	if s.EnsoSafe() {
+		title = bark.Render(s.Label().Kanji) + " " + white.Render(s.Label().English)
+	} else {
+		title = white.Render(s.Label().English)
+	}
+
+	intro := strings.Join([]string{
+		title,
+		white.Render("Pick the agent to add."),
+		dim.Render("Each agent ships its own defaults — review and adjust in the next stages."),
+	}, "\n")
+
+	divider := initflow.RenderSectionHeader("AGENTS", initflow.PanelWidth(s.Width()))
+
+	// Render each row.
+	rows := make([]string, 0, len(s.options))
+	for i := range s.options {
+		rows = append(rows, s.renderRow(i))
+	}
+
+	// Viewport wrap when row count exceeds available budget.
+	listH := s.listHeight()
+	listBody := strings.Join(rows, "\n")
+	if listH > 0 && listH < len(rows) {
+		s.viewport.SetLines(rows)
+		s.viewport.SetHeight(listH)
+		s.viewport.Follow(s.focus)
+		listBody = s.viewport.View()
+	}
+
+	installed := 0
+	for _, o := range s.options {
+		if o.Installed {
+			installed++
+		}
+	}
+	counter := fmt.Sprintf("%d agents · %d already installed", len(s.options), installed)
+
+	body := []string{
+		intro,
+		"",
+		"",
+		divider,
+		"",
+		listBody,
+		"",
+		dim.Render(counter),
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+// listHeight returns the visible row budget for the agent list. Body fixed
+// rows: intro (3) + blanks (2) + divider (1) + blank (1) + blank (1) +
+// counter (1) = 9 rows. Chrome (10). Floor at 3.
+func (s *SelectStage) listHeight() int {
+	h := s.Height()
+	if h <= 0 {
+		return 0
+	}
+	const chromeRows = 10
+	const fixedBodyRows = 9
+	v := h - chromeRows - fixedBodyRows
+	if v < 3 {
+		v = 3
+	}
+	return v
+}
+
+// renderRow renders a single agent entry. Matches BranchesStage row layout
+// for cross-flow consistency:
+//
+//	[border 2] [glyph 1] [sp 1] [name + tag] [sp 1] [desc]
+//
+// Focused rows use FocusBorder + FocusedNameStyle + FocusedDescStyle; the
+// "(installed)" suffix renders in bark gold after the name so the badge sits
+// inside the name column.
+func (s *SelectStage) renderRow(idx int) string {
+	opt := s.options[idx]
+	focused := idx == s.focus
+
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+
+	// Single-choice glyph: ▸ on focus, · otherwise. No ◆/◇ — there's no
+	// persistent selection state before Enter commits.
+	glyph := " "
+	glyphStyle := dim
+	if focused {
+		glyph = "▸"
+		glyphStyle = leaf
+	}
+
+	border := initflow.UnfocusBorder()
+	if focused {
+		border = initflow.FocusBorder()
+	}
+
+	nameColW, descColW, tagColW := initflow.ClampColumns(s.Width() - 4)
+	// Recover the tag column for desc (no trailing badge) — same move as
+	// Branches post-2026-04-22 polish.
+	descColW += tagColW - 2
+
+	name := opt.DisplayName
+	if name == "" {
+		name = opt.Name
+	}
+
+	var nameStyle lipgloss.Style
+	switch {
+	case focused:
+		nameStyle = initflow.FocusedNameStyle()
+	default:
+		nameStyle = initflow.UnfocusedNameStyle()
+	}
+
+	// Reserve space for the "(installed)" suffix when present so the name is
+	// truncated before the badge rather than after.
+	suffix := ""
+	if opt.Installed {
+		suffix = " " + bark.Render("(installed)")
+	}
+	suffixW := lipgloss.Width(suffix)
+
+	nameBudget := nameColW - suffixW
+	if nameBudget < 6 {
+		nameBudget = 6
+	}
+	if lipgloss.Width(name) > nameBudget {
+		rr := []rune(name)
+		if len(rr) > nameBudget-1 && nameBudget > 1 {
+			name = string(rr[:nameBudget-1]) + "…"
+		}
+	}
+	nameText := nameStyle.Render(name) + suffix
+	nameCol := initflow.PadRight(nameText, nameColW)
+
+	// Description column.
+	var descCol string
+	if descColW > 0 {
+		desc := opt.Description
+		if lipgloss.Width(desc) > descColW {
+			rr := []rune(desc)
+			if len(rr) > descColW-1 {
+				desc = string(rr[:descColW-1]) + "…"
+			}
+		}
+		descStyle := initflow.UnfocusedDescStyle()
+		if focused {
+			descStyle = initflow.FocusedDescStyle()
+		}
+		descCol = " " + descStyle.Render(initflow.PadRight(desc, descColW))
+	}
+
+	return border + glyphStyle.Render(glyph) + " " + nameCol + descCol
+}
+
+// Result returns the selected agent machine name. Zero value ("") on empty
+// option slice or pre-completion.
+func (s *SelectStage) Result() any {
+	if s.focus < 0 || s.focus >= len(s.options) {
+		return ""
+	}
+	return s.options[s.focus].Name
+}
+
+// Reset clears the completion flag so re-entry renders fresh. Focus index +
+// option slice are preserved so the user's pick is not scrubbed.
+func (s *SelectStage) Reset() tea.Cmd {
+	s.ClearDone()
+	return nil
+}

--- a/internal/tui/addflow/select_test.go
+++ b/internal/tui/addflow/select_test.go
@@ -1,0 +1,168 @@
+package addflow
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// newTestSelect constructs a SelectStage with a three-option fixture. The
+// second option is pre-marked installed so tests can assert the suffix
+// rendering.
+func newTestSelect() *SelectStage {
+	opts := []AgentOption{
+		{Name: "tech-lead", DisplayName: "Tech Lead", Description: "orchestrator", Installed: false},
+		{Name: "backend", DisplayName: "Backend", Description: "server-side", Installed: true},
+		{Name: "frontend", DisplayName: "Frontend", Description: "ui layer", Installed: false},
+	}
+	return NewSelectStage(initflow.StageContext{
+		Version:      "test",
+		ProjectDir:   "/tmp/select-test",
+		StationDir:   "station/",
+		AgentDisplay: "",
+		StartedAt:    time.Now(),
+	}, opts)
+}
+
+func selectPressKey(s *SelectStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if ss, ok := m.(*SelectStage); ok {
+		*s = *ss
+	}
+}
+
+func selectPressRune(s *SelectStage, r rune) {
+	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	if ss, ok := m.(*SelectStage); ok {
+		*s = *ss
+	}
+}
+
+// TestSelect_FocusDownUp verifies ↑↓ clamps at the ends (no wrap).
+func TestSelect_FocusDownUp(t *testing.T) {
+	s := newTestSelect()
+	if s.focus != 0 {
+		t.Fatalf("initial focus = %d, want 0", s.focus)
+	}
+	selectPressKey(s, tea.KeyDown)
+	selectPressKey(s, tea.KeyDown)
+	if s.focus != 2 {
+		t.Fatalf("after 2× down focus = %d, want 2", s.focus)
+	}
+	// Clamp at bottom.
+	selectPressKey(s, tea.KeyDown)
+	if s.focus != 2 {
+		t.Fatalf("after extra down focus = %d, want clamp at 2", s.focus)
+	}
+	selectPressKey(s, tea.KeyUp)
+	selectPressKey(s, tea.KeyUp)
+	selectPressKey(s, tea.KeyUp)
+	if s.focus != 0 {
+		t.Fatalf("after 3× up focus = %d, want clamp at 0", s.focus)
+	}
+}
+
+// TestSelect_EnterMarksDone verifies Enter flips done.
+func TestSelect_EnterMarksDone(t *testing.T) {
+	s := newTestSelect()
+	if s.Done() {
+		t.Fatal("should not be done before Enter")
+	}
+	selectPressKey(s, tea.KeyEnter)
+	if !s.Done() {
+		t.Fatal("should be done after Enter")
+	}
+}
+
+// TestSelect_ResultReturnsMachineName verifies Result returns the focused
+// option's machine Name (not DisplayName).
+func TestSelect_ResultReturnsMachineName(t *testing.T) {
+	s := newTestSelect()
+	selectPressKey(s, tea.KeyDown)
+	got, ok := s.Result().(string)
+	if !ok {
+		t.Fatalf("Result type = %T, want string", s.Result())
+	}
+	if got != "backend" {
+		t.Fatalf("Result = %q, want %q", got, "backend")
+	}
+}
+
+// TestSelect_ResetPreservesFocus verifies Reset clears done but not focus.
+func TestSelect_ResetPreservesFocus(t *testing.T) {
+	s := newTestSelect()
+	selectPressKey(s, tea.KeyDown)
+	selectPressKey(s, tea.KeyEnter)
+	s.Reset()
+	if s.Done() {
+		t.Fatal("Reset should clear done")
+	}
+	if s.focus != 1 {
+		t.Fatalf("Reset should preserve focus — got %d, want 1", s.focus)
+	}
+}
+
+// TestSelect_ViewRendersInstalledBadge verifies the "(installed)" suffix is
+// rendered for options flagged as installed.
+func TestSelect_ViewRendersInstalledBadge(t *testing.T) {
+	s := newTestSelect()
+	s.SetSize(120, 40)
+	selectPressKey(s, tea.KeyUp) // harmless; triggers dims captured
+	out := s.View()
+	if !strings.Contains(out, "(installed)") {
+		t.Fatal("expected (installed) badge in rendered view")
+	}
+}
+
+// TestSelect_JKBindings verifies j/k map to down/up.
+func TestSelect_JKBindings(t *testing.T) {
+	s := newTestSelect()
+	selectPressRune(s, 'j')
+	if s.focus != 1 {
+		t.Fatalf("j → focus = %d, want 1", s.focus)
+	}
+	selectPressRune(s, 'k')
+	if s.focus != 0 {
+		t.Fatalf("k → focus = %d, want 0", s.focus)
+	}
+}
+
+// TestSelect_EmptyOptions verifies no-panic on empty option list.
+func TestSelect_EmptyOptions(t *testing.T) {
+	s := NewSelectStage(initflow.StageContext{StartedAt: time.Now()}, nil)
+	selectPressKey(s, tea.KeyDown)
+	selectPressKey(s, tea.KeyUp)
+	got := s.Result()
+	if str, _ := got.(string); str != "" {
+		t.Fatalf("empty options Result = %q, want empty", str)
+	}
+}
+
+// TestBuildAgentOptions_FlagsInstalled verifies BuildAgentOptions marks the
+// Installed bool on agents present in the installed set.
+func TestBuildAgentOptions_FlagsInstalled(t *testing.T) {
+	cat := &catalog.Catalog{
+		Agents: []catalog.AgentDef{
+			{Name: "tech-lead", DisplayName: "Tech Lead", Description: "a"},
+			{Name: "backend", DisplayName: "Backend", Description: "b"},
+		},
+	}
+	opts := BuildAgentOptions(cat, map[string]bool{"backend": true})
+	if len(opts) != 2 {
+		t.Fatalf("len(opts) = %d, want 2", len(opts))
+	}
+	if opts[0].Installed {
+		t.Fatal("tech-lead should not be installed")
+	}
+	if !opts[1].Installed {
+		t.Fatal("backend should be installed")
+	}
+	if opts[0].DisplayName != "Tech Lead" {
+		t.Fatalf("opts[0].DisplayName = %q, want Tech Lead", opts[0].DisplayName)
+	}
+}

--- a/internal/tui/addflow/yield.go
+++ b/internal/tui/addflow/yield.go
@@ -20,6 +20,7 @@ const (
 	yieldModeSuccess yieldMode = iota
 	yieldModeAllInstalled
 	yieldModeTechLeadRequired
+	yieldModeAddItemsDeferred
 )
 
 // YieldStage is the terminal completion card at rail position 5 (結 YIELD).
@@ -72,6 +73,15 @@ func NewYieldAllInstalled(ctx initflow.StageContext, agentDef *catalog.AgentDef)
 func NewYieldTechLeadRequired(ctx initflow.StageContext, agentType string) *YieldStage {
 	return newYield(ctx, yieldModeTechLeadRequired, func(y *YieldStage) {
 		y.pickedAgentType = agentType
+	})
+}
+
+// NewYieldAddItemsDeferred renders the Phase 1 "add-items not yet wired"
+// card. Plan 23 ships add-items in Phase 2; until then the user must
+// unset BONSAI_ADD_REDESIGN to reach the legacy flow for that path.
+func NewYieldAddItemsDeferred(ctx initflow.StageContext, agentDef *catalog.AgentDef) *YieldStage {
+	return newYield(ctx, yieldModeAddItemsDeferred, func(y *YieldStage) {
+		y.agentDef = agentDef
 	})
 }
 
@@ -132,6 +142,8 @@ func (s *YieldStage) renderBody() string {
 		return s.renderAllInstalled()
 	case yieldModeTechLeadRequired:
 		return s.renderTechLeadRequired()
+	case yieldModeAddItemsDeferred:
+		return s.renderAddItemsDeferred()
 	default:
 		return s.renderSuccess()
 	}
@@ -301,6 +313,49 @@ func (s *YieldStage) renderTechLeadRequired() string {
 		"     " + dim.Render("bootstrap the project scaffold + tech-lead agent"),
 		"  " + bark.Render("2") + "  " + white.Render(fmt.Sprintf("$ bonsai add %s", agentType)),
 		"     " + dim.Render("re-run this flow once the tech-lead is planted"),
+	}
+
+	body := []string{
+		heroTitle,
+		intro,
+		helper,
+		"",
+		"",
+		strings.Join(nextLines, "\n"),
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+func (s *YieldStage) renderAddItemsDeferred() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	warn := lipgloss.NewStyle().Foreground(tui.ColorWarning).Bold(true)
+
+	var heroTitle string
+	if s.EnsoSafe() {
+		heroTitle = warn.Render(s.Label().Kanji + " · ADD-ITEMS COMING IN PHASE 2")
+	} else {
+		heroTitle = warn.Render("ADD-ITEMS COMING IN PHASE 2")
+	}
+	agentName := "this agent"
+	if s.agentDef != nil {
+		agentName = s.agentDef.DisplayName
+		if agentName == "" {
+			agentName = catalog.DisplayNameFrom(s.agentDef.Name)
+		}
+	}
+
+	intro := white.Render(fmt.Sprintf("%s already exists — adding more abilities to it is Phase 2 work.", agentName))
+	helper := dim.Render("Phase 1 of the cinematic flow only wires the new-agent path. Use the legacy flow until Phase 2 lands.")
+
+	nextHeader := initflow.RenderSectionHeader("NEXT", initflow.PanelWidth(s.Width()))
+	nextLines := []string{
+		nextHeader,
+		"  " + bark.Render("1") + "  " + white.Render("$ unset BONSAI_ADD_REDESIGN"),
+		"     " + dim.Render("drop the cinematic-flow gate for this shell"),
+		"  " + bark.Render("2") + "  " + white.Render("$ bonsai add"),
+		"     " + dim.Render("re-run via the legacy flow — add-items works there today"),
 	}
 
 	body := []string{

--- a/internal/tui/addflow/yield.go
+++ b/internal/tui/addflow/yield.go
@@ -1,0 +1,324 @@
+package addflow
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// yieldMode distinguishes the three terminal card variants.
+type yieldMode int
+
+const (
+	yieldModeSuccess yieldMode = iota
+	yieldModeAllInstalled
+	yieldModeTechLeadRequired
+)
+
+// YieldStage is the terminal completion card at rail position 5 (結 YIELD).
+// Three variants selected at construction time:
+//
+//   - success          — renders the installed ability tree + 3 next-steps.
+//   - all-installed    — "already full" panel + `bonsai catalog` CTA.
+//   - tech-lead-req    — error panel + `bonsai init` CTA.
+//
+// The stage is terminal: ↵ / q / esc flip Done and the harness exits.
+type YieldStage struct {
+	initflow.Stage
+
+	mode yieldMode
+
+	// success-mode inputs.
+	installed     *config.InstalledAgent
+	cat           *catalog.Catalog
+	isNewAgent    bool
+	totalSelected int
+
+	// all-installed-mode inputs.
+	agentDef *catalog.AgentDef
+
+	// tech-lead-required-mode inputs.
+	pickedAgentType string
+}
+
+// NewYieldSuccess renders the happy-path completion card. installed is the
+// InstalledAgent populated by the Grow action; cat is the loaded catalog;
+// isNewAgent distinguishes new-agent vs add-items success messaging;
+// totalSelected drives the add-items summary line.
+func NewYieldSuccess(ctx initflow.StageContext, installed *config.InstalledAgent, cat *catalog.Catalog, isNewAgent bool, totalSelected int) *YieldStage {
+	return newYield(ctx, yieldModeSuccess, func(y *YieldStage) {
+		y.installed = installed
+		y.cat = cat
+		y.isNewAgent = isNewAgent
+		y.totalSelected = totalSelected
+	})
+}
+
+// NewYieldAllInstalled renders the "every ability already installed" card.
+func NewYieldAllInstalled(ctx initflow.StageContext, agentDef *catalog.AgentDef) *YieldStage {
+	return newYield(ctx, yieldModeAllInstalled, func(y *YieldStage) {
+		y.agentDef = agentDef
+	})
+}
+
+// NewYieldTechLeadRequired renders the "tech-lead must come first" card.
+func NewYieldTechLeadRequired(ctx initflow.StageContext, agentType string) *YieldStage {
+	return newYield(ctx, yieldModeTechLeadRequired, func(y *YieldStage) {
+		y.pickedAgentType = agentType
+	})
+}
+
+func newYield(ctx initflow.StageContext, mode yieldMode, tail func(*YieldStage)) *YieldStage {
+	label := StageLabels[StageIdxYield]
+	base := initflow.NewStage(
+		StageIdxYield,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+	base.SetRailLabels(StageLabels)
+	y := &YieldStage{
+		Stage: base,
+		mode:  mode,
+	}
+	tail(y)
+	return y
+}
+
+// Init implements tea.Model — no cmd on entry.
+func (s *YieldStage) Init() tea.Cmd { return nil }
+
+// Update waits for ↵ / q / esc acknowledgement.
+func (s *YieldStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		switch m.String() {
+		case "enter", "q", "esc":
+			s.MarkDone()
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+// View composes the body inside the shared frame.
+func (s *YieldStage) View() string {
+	return s.RenderFrame(s.renderBody(), s.keyHints())
+}
+
+func (s *YieldStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "↵", Desc: "exit"},
+		{Key: "q", Desc: "quit"},
+	}
+}
+
+func (s *YieldStage) renderBody() string {
+	switch s.mode {
+	case yieldModeAllInstalled:
+		return s.renderAllInstalled()
+	case yieldModeTechLeadRequired:
+		return s.renderTechLeadRequired()
+	default:
+		return s.renderSuccess()
+	}
+}
+
+func (s *YieldStage) renderSuccess() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	value := initflow.ValueStyle()
+
+	var heroTitle string
+	if s.EnsoSafe() {
+		heroTitle = leaf.Render(s.Label().Kanji + " · YIELDED")
+	} else {
+		heroTitle = leaf.Render("YIELDED")
+	}
+
+	agentDisplay := ""
+	workspace := ""
+	if s.installed != nil {
+		workspace = s.installed.Workspace
+		if s.cat != nil {
+			if def := s.cat.GetAgent(s.installed.AgentType); def != nil {
+				agentDisplay = def.DisplayName
+				if agentDisplay == "" {
+					agentDisplay = catalog.DisplayNameFrom(def.Name)
+				}
+			}
+		}
+	}
+	if agentDisplay == "" {
+		agentDisplay = "agent"
+	}
+
+	var heroSub string
+	if s.isNewAgent {
+		heroSub = white.Render(fmt.Sprintf("%s is rooted.", agentDisplay))
+	} else {
+		heroSub = white.Render(fmt.Sprintf("Grafted %d new abilities onto %s.", s.totalSelected, agentDisplay))
+	}
+
+	summaryHeader := initflow.RenderSectionHeader("SUMMARY", initflow.PanelWidth(s.Width()))
+	const labelW = 14
+	const indent = "  "
+	totalAbilities := 0
+	if s.installed != nil {
+		totalAbilities = len(s.installed.Skills) + len(s.installed.Workflows) +
+			len(s.installed.Protocols) + len(s.installed.Sensors) + len(s.installed.Routines)
+	}
+	summaryRows := []string{
+		summaryHeader,
+		indent + bark.Render(initflow.PadRight("AGENT", labelW)) + value.Render(agentDisplay) +
+			dim.Render(" → "+workspace),
+		indent + bark.Render(initflow.PadRight("ABILITIES", labelW)) + value.Render(fmt.Sprintf("%d wired", totalAbilities)),
+	}
+	if s.installed != nil {
+		summaryRows = append(summaryRows,
+			indent+strings.Repeat(" ", labelW)+dim.Render(fmt.Sprintf(
+				"%d skills · %d workflows · %d protocols · %d sensors · %d routines",
+				len(s.installed.Skills), len(s.installed.Workflows), len(s.installed.Protocols),
+				len(s.installed.Sensors), len(s.installed.Routines),
+			)))
+	}
+
+	nextHeader := initflow.RenderSectionHeader("NEXT", initflow.PanelWidth(s.Width()))
+	steps := []struct {
+		num, cmd, caption string
+	}{
+		{"1", "$ bonsai list", "see every agent + ability in one view"},
+		{"2", fmt.Sprintf("$ cd %s", workspace), "open the workspace in your shell"},
+		{"3", "$ claude", "say \"hi, get started\" to warm the session"},
+	}
+	if !s.isNewAgent {
+		steps[1] = struct{ num, cmd, caption string }{"2", "$ claude", "restart the session so the new abilities load"}
+		steps[2] = struct{ num, cmd, caption string }{"3", "$ bonsai catalog", "browse more abilities any time"}
+	}
+	nextLines := []string{nextHeader}
+	for _, st := range steps {
+		nextLines = append(nextLines,
+			"  "+bark.Render(st.num)+"  "+white.Render(st.cmd))
+		nextLines = append(nextLines,
+			"     "+dim.Render(st.caption))
+	}
+
+	body := []string{
+		heroTitle,
+		heroSub,
+		"",
+		"",
+		strings.Join(summaryRows, "\n"),
+		"",
+		"",
+		strings.Join(nextLines, "\n"),
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+func (s *YieldStage) renderAllInstalled() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+
+	var heroTitle string
+	if s.EnsoSafe() {
+		heroTitle = leaf.Render(s.Label().Kanji + " · ALREADY FULL")
+	} else {
+		heroTitle = leaf.Render("ALREADY FULL")
+	}
+	agentName := "this agent"
+	if s.agentDef != nil {
+		agentName = s.agentDef.DisplayName
+		if agentName == "" {
+			agentName = catalog.DisplayNameFrom(s.agentDef.Name)
+		}
+	}
+
+	intro := white.Render(fmt.Sprintf("%s already has every compatible ability installed.", agentName))
+	helper := dim.Render("Nothing left to graft — browse the catalog for ideas to iterate on later.")
+
+	nextHeader := initflow.RenderSectionHeader("NEXT", initflow.PanelWidth(s.Width()))
+	nextLines := []string{
+		nextHeader,
+		"  " + bark.Render("1") + "  " + white.Render("$ bonsai catalog"),
+		"     " + dim.Render("survey every ability bundled in the current binary"),
+		"  " + bark.Render("2") + "  " + white.Render("$ bonsai list"),
+		"     " + dim.Render("inspect what's already installed per agent"),
+	}
+
+	body := []string{
+		heroTitle,
+		intro,
+		helper,
+		"",
+		"",
+		strings.Join(nextLines, "\n"),
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+func (s *YieldStage) renderTechLeadRequired() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	danger := lipgloss.NewStyle().Foreground(tui.ColorDanger).Bold(true)
+
+	var heroTitle string
+	if s.EnsoSafe() {
+		heroTitle = danger.Render(s.Label().Kanji + " · TECH-LEAD REQUIRED")
+	} else {
+		heroTitle = danger.Render("TECH-LEAD REQUIRED")
+	}
+	agentType := s.pickedAgentType
+	if agentType == "" {
+		agentType = "this agent"
+	}
+
+	intro := white.Render("No tech-lead agent is installed yet.")
+	helper := dim.Render(fmt.Sprintf("Bonsai roots every project on a tech-lead before grafting %q-type agents.", agentType))
+
+	nextHeader := initflow.RenderSectionHeader("NEXT", initflow.PanelWidth(s.Width()))
+	nextLines := []string{
+		nextHeader,
+		"  " + bark.Render("1") + "  " + white.Render("$ bonsai init"),
+		"     " + dim.Render("bootstrap the project scaffold + tech-lead agent"),
+		"  " + bark.Render("2") + "  " + white.Render(fmt.Sprintf("$ bonsai add %s", agentType)),
+		"     " + dim.Render("re-run this flow once the tech-lead is planted"),
+	}
+
+	body := []string{
+		heroTitle,
+		intro,
+		helper,
+		"",
+		"",
+		strings.Join(nextLines, "\n"),
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+// Result returns nil — Yield is the terminal stage.
+func (s *YieldStage) Result() any { return nil }
+
+// Reset clears the completion flag.
+func (s *YieldStage) Reset() tea.Cmd {
+	s.ClearDone()
+	return nil
+}

--- a/internal/tui/addflow/yield_test.go
+++ b/internal/tui/addflow/yield_test.go
@@ -1,0 +1,149 @@
+package addflow
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+func yieldPressKey(s *YieldStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if ys, ok := m.(*YieldStage); ok {
+		*s = *ys
+	}
+}
+
+func yieldPressRune(s *YieldStage, r rune) {
+	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	if ys, ok := m.(*YieldStage); ok {
+		*s = *ys
+	}
+}
+
+// TestYield_SuccessRendersAgent verifies the success-mode view contains the
+// agent display name.
+func TestYield_SuccessRendersAgent(t *testing.T) {
+	cat := &catalog.Catalog{
+		Agents: []catalog.AgentDef{
+			{Name: "backend", DisplayName: "Backend"},
+		},
+	}
+	installed := &config.InstalledAgent{
+		AgentType: "backend",
+		Workspace: "services/api/",
+		Skills:    []string{"s1", "s2"},
+	}
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldSuccess(ctx, installed, cat, true, 2)
+	s.SetSize(120, 40)
+	out := s.View()
+	if !strings.Contains(out, "Backend") {
+		t.Fatal("success view should include agent display name")
+	}
+	if !strings.Contains(out, "services/api/") {
+		t.Fatal("success view should include workspace")
+	}
+}
+
+// TestYield_AllInstalledRendersCatalogCTA verifies the all-installed mode
+// renders the `bonsai catalog` next-step.
+func TestYield_AllInstalledRendersCatalogCTA(t *testing.T) {
+	agentDef := &catalog.AgentDef{Name: "backend", DisplayName: "Backend"}
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldAllInstalled(ctx, agentDef)
+	s.SetSize(120, 40)
+	out := s.View()
+	if !strings.Contains(out, "bonsai catalog") {
+		t.Fatal("all-installed view should include bonsai catalog CTA")
+	}
+	if !strings.Contains(out, "ALREADY FULL") {
+		t.Fatal("all-installed view should include ALREADY FULL hero")
+	}
+}
+
+// TestYield_TechLeadRequiredRendersInitCTA verifies the tech-lead-required
+// mode renders the `bonsai init` next-step.
+func TestYield_TechLeadRequiredRendersInitCTA(t *testing.T) {
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldTechLeadRequired(ctx, "backend")
+	s.SetSize(120, 40)
+	out := s.View()
+	if !strings.Contains(out, "bonsai init") {
+		t.Fatal("tech-lead-required view should include bonsai init CTA")
+	}
+	if !strings.Contains(out, "TECH-LEAD REQUIRED") {
+		t.Fatal("tech-lead-required view should include hero")
+	}
+	if !strings.Contains(out, "backend") {
+		t.Fatal("tech-lead-required view should include picked agent type")
+	}
+}
+
+// TestYield_EnterMarksDone verifies Enter flips done on any variant.
+func TestYield_EnterMarksDone(t *testing.T) {
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldTechLeadRequired(ctx, "backend")
+	if s.Done() {
+		t.Fatal("should not be done before Enter")
+	}
+	yieldPressKey(s, tea.KeyEnter)
+	if !s.Done() {
+		t.Fatal("Enter should MarkDone")
+	}
+}
+
+// TestYield_QKeyMarksDone verifies q also exits the terminal card.
+func TestYield_QKeyMarksDone(t *testing.T) {
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldAllInstalled(ctx, &catalog.AgentDef{Name: "backend"})
+	yieldPressRune(s, 'q')
+	if !s.Done() {
+		t.Fatal("q should MarkDone")
+	}
+}
+
+// TestYield_EscMarksDone verifies esc also exits the terminal card.
+func TestYield_EscMarksDone(t *testing.T) {
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldSuccess(ctx, &config.InstalledAgent{AgentType: "backend", Workspace: "backend/"}, nil, true, 0)
+	yieldPressKey(s, tea.KeyEsc)
+	if !s.Done() {
+		t.Fatal("esc should MarkDone")
+	}
+}
+
+// TestYield_ResultNil verifies Yield returns nil (terminal — no payload).
+func TestYield_ResultNil(t *testing.T) {
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldSuccess(ctx, nil, nil, false, 0)
+	if s.Result() != nil {
+		t.Fatalf("Result = %v, want nil", s.Result())
+	}
+}
+
+// TestYield_SuccessAddItemsMessaging verifies the isNewAgent=false branch
+// renders the "Grafted N abilities" wording.
+func TestYield_SuccessAddItemsMessaging(t *testing.T) {
+	cat := &catalog.Catalog{
+		Agents: []catalog.AgentDef{
+			{Name: "backend", DisplayName: "Backend"},
+		},
+	}
+	installed := &config.InstalledAgent{
+		AgentType: "backend",
+		Workspace: "services/api/",
+	}
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldSuccess(ctx, installed, cat, false, 3)
+	s.SetSize(120, 40)
+	out := s.View()
+	if !strings.Contains(out, "Grafted 3") {
+		t.Fatal("add-items success view should include 'Grafted 3'")
+	}
+}

--- a/internal/tui/addflow/yield_test.go
+++ b/internal/tui/addflow/yield_test.go
@@ -127,6 +127,30 @@ func TestYield_ResultNil(t *testing.T) {
 	}
 }
 
+// TestYield_AddItemsDeferredRendersLegacyCTA verifies the Phase 1
+// deferred-add-items variant surfaces the "unset BONSAI_ADD_REDESIGN" +
+// legacy-flow CTA so the user has a concrete next step instead of the
+// silent "already full" lie the earlier splicer produced.
+func TestYield_AddItemsDeferredRendersLegacyCTA(t *testing.T) {
+	agentDef := &catalog.AgentDef{Name: "backend", DisplayName: "Backend"}
+	ctx := initflow.StageContext{StartedAt: time.Now()}
+	s := NewYieldAddItemsDeferred(ctx, agentDef)
+	s.SetSize(120, 40)
+	out := s.View()
+	if !strings.Contains(out, "PHASE 2") {
+		t.Fatal("add-items-deferred view should surface Phase 2 hero")
+	}
+	if !strings.Contains(out, "unset BONSAI_ADD_REDESIGN") {
+		t.Fatal("add-items-deferred view should direct user to unset the env flag")
+	}
+	if !strings.Contains(out, "bonsai add") {
+		t.Fatal("add-items-deferred view should include bonsai add legacy CTA")
+	}
+	if !strings.Contains(out, "Backend") {
+		t.Fatal("add-items-deferred view should include agent display name")
+	}
+}
+
 // TestYield_SuccessAddItemsMessaging verifies the isNewAgent=false branch
 // renders the "Grafted N abilities" wording.
 func TestYield_SuccessAddItemsMessaging(t *testing.T) {

--- a/internal/tui/initflow/chrome.go
+++ b/internal/tui/initflow/chrome.go
@@ -224,6 +224,17 @@ func RenderMinSizeFloor(width, height int) string {
 	return top + strings.Join(rendered, "\n") + bottom
 }
 
+// CenterBlock is the exported alias for centerBlock. Consumed by sibling
+// flow packages (e.g. addflow) that need the same centred-body layout as
+// initflow stages without reimplementing the helper. Behaviour is identical
+// to the unexported callers inside this package.
+func CenterBlock(block string, width int) string { return centerBlock(block, width) }
+
+// PadRight is the exported alias for padRight. Same rationale as CenterBlock
+// — sibling flow packages consume it to pin column widths identically to
+// initflow stage internals.
+func PadRight(s string, w int) string { return padRight(s, w) }
+
 // centerBlock left-pads every line in block so the widest line is
 // horizontally centred inside width. Used by stage bodies to sit visually
 // balanced inside the AltScreen rather than flush-left. Trailing whitespace

--- a/internal/tui/initflow/design.go
+++ b/internal/tui/initflow/design.go
@@ -155,3 +155,13 @@ func FocusedPrimaryStyle() lipgloss.Style {
 func FocusedAccentStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
 }
+
+// ConflictRowStyle returns the per-row style used by addflow's ConflictsStage
+// to render a conflict-file entry. Phase-1 stub — the style is intentionally
+// a no-op passthrough so Phase-2 can land the full body (colour-coded Keep /
+// Overwrite / Backup action glyphs + diff summary) without bloating the Phase-1
+// diff. The exported symbol is defined here so addflow's Phase-1 code imports
+// are wired against the final API shape. See Plan 23 decision Q10.
+func ConflictRowStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(tui.ColorAccent)
+}

--- a/internal/tui/initflow/enso.go
+++ b/internal/tui/initflow/enso.go
@@ -15,7 +15,7 @@ const (
 	railChar    = "─"
 )
 
-// RenderEnsoRail draws the 4-stage progress rail used above every stage's
+// RenderEnsoRail draws the N-stage progress rail used above every stage's
 // body. Rendered as two rows:
 //
 //	row 1: ● ─── ● ─── [枝] ─── ○        (dots + connector segments)
@@ -25,11 +25,20 @@ const (
 // set), the dots collapse to bracketed ASCII: [x] for done, [ ] for
 // pending, [N] for current.
 //
+// labels is the stage-label slice to render against. When nil or empty,
+// the function falls back to the package-level StageLabels (the init flow's
+// 4-stage set). Other flows (e.g. addflow's 6-stage set) pass their own
+// slice so the rail adapts to the active flow's length without reimplementing
+// this primitive.
+//
 // stageIdx is the 0-based current stage. width is the terminal column count
 // the rail should occupy. Layout tries to centre the rail inside width; the
 // dot/bracket glyphs sit at fixed anchors with equal-length connector runs
 // between them. Labels are centred under each anchor.
-func RenderEnsoRail(stageIdx int, width int, safe bool) string {
+func RenderEnsoRail(stageIdx int, labels []StageLabel, width int, safe bool) string {
+	if len(labels) == 0 {
+		labels = StageLabels[:]
+	}
 	if width <= 0 {
 		width = 80
 	}
@@ -38,16 +47,16 @@ func RenderEnsoRail(stageIdx int, width int, safe bool) string {
 	if stageIdx < 0 {
 		stageIdx = 0
 	}
-	if stageIdx > len(StageLabels)-1 {
-		stageIdx = len(StageLabels) - 1
+	if stageIdx > len(labels)-1 {
+		stageIdx = len(labels) - 1
 	}
 
 	// Glyph + styled rendering for each anchor and connector.
-	numStages := len(StageLabels)
+	numStages := len(labels)
 	anchors := make([]string, numStages)
 	anchorWidths := make([]int, numStages)
-	for i := range StageLabels {
-		glyph, w := anchorGlyph(i, stageIdx, safe)
+	for i := range labels {
+		glyph, w := anchorGlyph(i, stageIdx, labels, safe)
 		anchors[i] = glyph
 		anchorWidths[i] = w
 	}
@@ -104,7 +113,7 @@ func RenderEnsoRail(stageIdx int, width int, safe bool) string {
 	}
 
 	// Row 2: stage English labels, centred on each anchor.
-	row2 := placeLabels(colPositions, stageLabelTexts(safe, stageIdx), width, stageIdx, false)
+	row2 := placeLabels(colPositions, stageLabelTexts(labels, safe, stageIdx), width, stageIdx, false)
 
 	return row1.String() + "\n" + row2
 }
@@ -113,7 +122,7 @@ func RenderEnsoRail(stageIdx int, width int, safe bool) string {
 // i-th stage anchor. The current stage gets a bracketed kanji in Bark gold;
 // completed stages get a bright Primary ● (user-requested green-done badge);
 // pending stages get a muted ○.
-func anchorGlyph(i, current int, safe bool) (string, int) {
+func anchorGlyph(i, current int, labels []StageLabel, safe bool) (string, int) {
 	goldStyle := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
 	doneStyle := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
 	muted := lipgloss.NewStyle().Foreground(tui.ColorRule2)
@@ -126,7 +135,7 @@ func anchorGlyph(i, current int, safe bool) (string, int) {
 			// Render kanji in a small boxed form: [K] — 4 visible cells
 			// (bracket + 2-cell kanji + bracket). Kanji + brackets are Bark
 			// gold so the current stage reads as the active accent.
-			kanji := StageLabels[i].Kanji
+			kanji := labels[i].Kanji
 			return goldStyle.Render("[") + goldStyle.Render(kanji) + goldStyle.Render("]"), 4
 		default:
 			return muted.Render(ensoPending), 1
@@ -224,10 +233,10 @@ func placeLabels(colPositions []int, labels []string, width, current int, kana b
 // stageLabelTexts returns the English-label slice for the rail's row 2.
 // Safe vs ASCII has no effect on this row — the English labels always
 // render (the ASCII fallback is on the glyph row above).
-func stageLabelTexts(safe bool, current int) []string {
+func stageLabelTexts(labels []StageLabel, safe bool, current int) []string {
 	_ = safe // reserved for future styling toggles; labels are uniform today
-	out := make([]string, len(StageLabels))
-	for i, l := range StageLabels {
+	out := make([]string, len(labels))
+	for i, l := range labels {
 		out[i] = l.English
 	}
 	_ = current

--- a/internal/tui/initflow/generate.go
+++ b/internal/tui/initflow/generate.go
@@ -73,6 +73,20 @@ type GenerateStage struct {
 	err       error
 	startedAt time.Time // goroutine start for elapsed math
 	ticks     int       // frames drawn since start
+
+	// Optional body-title override. Sibling flow packages (addflow) swap
+	// "生 · PLANTING" for their own kanji/English pair. Zero value keeps
+	// the init-flow default.
+	bodyKanji   string
+	bodyEnglish string
+}
+
+// SetBodyTitle overrides the "生 · PLANTING" body header. Used by addflow's
+// GrowStage wrapper so the kanji reads 育 (Grow) instead of the init-flow
+// default. Empty kanji/english restore the default.
+func (s *GenerateStage) SetBodyTitle(kanji, english string) {
+	s.bodyKanji = kanji
+	s.bodyEnglish = english
 }
 
 // NewGenerateStage constructs the Generate stage. The action closure wraps
@@ -230,8 +244,22 @@ func (s *GenerateStage) renderBody() string {
 		if err != nil {
 			msg = err.Error()
 		}
+		errKanji := "生"
+		errEnglish := "GENERATE FAILED"
+		if s.bodyKanji != "" {
+			errKanji = s.bodyKanji
+		}
+		if s.bodyEnglish != "" {
+			// Addflow's Grow stage reads "育 · GROW FAILED" rather than
+			// GENERATE FAILED when the body title has been overridden.
+			errEnglish = s.bodyEnglish + " FAILED"
+		}
+		errTitle := errKanji + " · " + errEnglish
+		if !s.ensoSafe {
+			errTitle = errEnglish
+		}
 		block := strings.Join([]string{
-			danger.Render("生 · GENERATE FAILED"),
+			danger.Render(errTitle),
 			"",
 			dim.Render(msg),
 			"",
@@ -244,9 +272,17 @@ func (s *GenerateStage) renderBody() string {
 
 	label := progressLabel(ticks, s.ensoSafe)
 
-	title := "生 · PLANTING"
+	kanji := "生"
+	english := "PLANTING"
+	if s.bodyKanji != "" {
+		kanji = s.bodyKanji
+	}
+	if s.bodyEnglish != "" {
+		english = s.bodyEnglish
+	}
+	title := kanji + " · " + english
 	if !s.ensoSafe {
-		title = "PLANTING"
+		title = english
 	}
 
 	block := strings.Join([]string{

--- a/internal/tui/initflow/stage.go
+++ b/internal/tui/initflow/stage.go
@@ -21,12 +21,13 @@ import (
 // stamp them uniformly from cmd.runInit's context bundle.
 type Stage struct {
 	// Rendering context.
-	title    string     // breadcrumb title — unused today but kept for Step contract
-	idx      int        // 0..3 — stage index in the rail
-	label    StageLabel // kanji/kana/English triple
-	width    int        // last seen terminal width
-	height   int        // last seen terminal height
-	ensoSafe bool       // WideCharSafe() snapshot captured at ctor time
+	title    string       // breadcrumb title — unused today but kept for Step contract
+	idx      int          // 0..3 — stage index in the rail
+	label    StageLabel   // kanji/kana/English triple
+	labels   []StageLabel // full rail label set (nil = fall back to init's StageLabels)
+	width    int          // last seen terminal width
+	height   int          // last seen terminal height
+	ensoSafe bool         // WideCharSafe() snapshot captured at ctor time
 
 	// Project context — identical across all four stages, stamped by
 	// cmd.runInit at entry so each stage renders the same header.
@@ -70,6 +71,60 @@ func NewStage(
 // The harness yields Stage.View() verbatim and Stage composes its own frame
 // via renderFrame().
 func (s *Stage) Chromeless() bool { return true }
+
+// SetRailLabels installs a non-default label slice for the enso rail. Used by
+// flows outside initflow (e.g. addflow's 6-stage set) that embed Stage but
+// need their own rail segment count + kanji. A nil/empty slice restores the
+// init-flow default (see RenderEnsoRail).
+func (s *Stage) SetRailLabels(labels []StageLabel) { s.labels = labels }
+
+// SetRailIndex overrides the 0-based rail position baked in at ctor time.
+// Used by sibling flow packages that reuse an initflow stage at a different
+// rail slot — e.g. addflow's Grow stage wraps GenerateStage (ctor idx=3) but
+// actually sits at rail position 4 (育 GROW) in the 6-segment add rail.
+func (s *Stage) SetRailIndex(idx int) { s.idx = idx }
+
+// SetLabel overrides the stage's rendered kanji/kana/English triple. Used
+// in tandem with SetRailIndex when a sibling package reuses an initflow
+// stage struct but needs the body title to read from its own StageLabels
+// slice.
+func (s *Stage) SetLabel(label StageLabel) { s.label = label }
+
+// SetSize stores the live terminal dims. Sibling packages that embed Stage
+// (e.g. addflow) call this from their own Update on WindowSizeMsg because the
+// fields are unexported.
+func (s *Stage) SetSize(w, h int) { s.width = w; s.height = h }
+
+// Width returns the last-seen terminal width. Zero until the first
+// WindowSizeMsg lands.
+func (s *Stage) Width() int { return s.width }
+
+// Height returns the last-seen terminal height.
+func (s *Stage) Height() int { return s.height }
+
+// EnsoSafe returns the WideCharSafe() snapshot captured at ctor time. Stage
+// bodies gate kanji glyphs on this so ASCII-only terminals get safe
+// substitutes.
+func (s *Stage) EnsoSafe() bool { return s.ensoSafe }
+
+// Label returns the kanji/kana/English triple for this stage.
+func (s *Stage) Label() StageLabel { return s.label }
+
+// MarkDone flips the completion flag. Subclasses call this when Enter
+// advances; the harness reads Done() to drive the cursor forward.
+func (s *Stage) MarkDone() { s.done = true }
+
+// ClearDone resets the completion flag. Used by Reset overrides that need to
+// preserve other stage state.
+func (s *Stage) ClearDone() { s.done = false }
+
+// RenderFrame is the exported entry into the shared frame composer. Sibling
+// packages that embed Stage call this from their View() so every flow's
+// persistent chrome (header + enso rail + footer) renders identically. The
+// unexported renderFrame remains for internal callers.
+func (s *Stage) RenderFrame(body string, keys []KeyHint) string {
+	return s.renderFrame(body, keys)
+}
 
 // Title implements harness.Step. Used only if the harness ever had to
 // surface a breadcrumb — which it does not in the cinematic flow.
@@ -146,7 +201,7 @@ func (s *Stage) renderFrame(body string, keys []KeyHint) string {
 	}
 
 	header := RenderHeader(s.version, s.projectDir, width, s.ensoSafe)
-	rail := RenderEnsoRail(s.idx, width, s.ensoSafe)
+	rail := RenderEnsoRail(s.idx, s.labels, width, s.ensoSafe)
 	footer := RenderFooter(keys, width)
 
 	// Chrome budget: header(2) + blank + rail(2) + blank + blank + footer(2) = 9 rows.


### PR DESCRIPTION
## Summary

Stands up `internal/tui/addflow/` mirroring `initflow/`'s shape: 6-stage cinematic `bonsai add` flow (選 Select · 地 Ground · 接 Graft · 観 Observe · 育 Grow · 結 Yield) sharing chrome via initflow imports. Gated behind `BONSAI_ADD_REDESIGN=1` — default `./bonsai add` still routes through legacy `runAdd`. Phase 2 brings the add-items branch + ConflictsStage; Phase 3 flips the default and deletes legacy.

Plan: `station/Playbook/Plans/Active/23-uiux-phase2-add.md`.

### initflow additions (additive — defaults preserved, init behaviour unchanged)

- `RenderEnsoRail` now takes a labels slice (nil → init's `StageLabels`) so addflow's 6-segment rail can reuse the primitive.
- `Stage` exports `SetRailLabels` / `SetRailIndex` / `SetLabel` / `SetSize` / `RenderFrame` plus read-side accessors so sibling packages can embed + override.
- `GenerateStage.SetBodyTitle` overrides `生 · PLANTING` → `育 · GROWING` for the Grow wrapper.
- `CenterBlock` / `PadRight` exposed as package-level aliases.
- `ConflictRowStyle` stub lands here so the Phase 2 diff stays narrow.

### addflow stages (new)

- `SelectStage` — single-choice agent picker with `(installed)` suffix.
- `GroundStage` — workspace textinput with tech-lead `AutoComplete` skip.
- `GraftStage` — 5-tab picker mirroring `BranchesStage`. `NewNewAgentGraft` / `NewAddItemsGraft` ctors; add-items branch stubbed to the full list until Phase 2 wires filtering.
- `ObserveStage` — `SetPrior`-driven review panel with GRAFT / BACK CTA.
- `GrowStage` — 23-line wrapper over `initflow.GenerateStage`.
- `YieldStage` — 3 modes (success / all-installed / tech-lead-required).
- 46 unit tests across `select` / `ground` / `graft` / `observe` / `yield`.

`cmd/add_redesign.go` wires the harness step list: `Select → LazyGroup(splicer) → Conditional(Grow) → LazyGroup(conflicts placeholder) → Conditional(Yield)`. Legacy `runAdd` receives a 5-line env-flag branch at the top; every helper is kept for Phase 3 deletion.

### Verification

- `make build` green.
- `go test ./...` green (46 new addflow tests + full existing suite).
- `go vet ./...` clean.
- `grep -rnE '#[0-9A-Fa-f]{6}' internal/tui/addflow/` → zero hits.

## Test plan

- [ ] In a fresh scaffold, `BONSAI_ADD_REDESIGN=1 ./bonsai add` non-tech-lead agent → walks Select → Ground → Graft → Observe → Grow → YieldSuccess; file output matches legacy path for same inputs.
- [ ] `BONSAI_ADD_REDESIGN=1 ./bonsai add` tech-lead → Ground auto-skips.
- [ ] `BONSAI_ADD_REDESIGN=1 ./bonsai add` when all abilities already installed → terminates at `YieldAllInstalled`.
- [ ] `BONSAI_ADD_REDESIGN=1 ./bonsai add` non-tech-lead with no tech-lead installed → terminates at `YieldTechLeadRequired`.
- [ ] `./bonsai add` (no env var) runs legacy flow unchanged.
- [ ] Esc from Graft returns to Ground (new-agent); Esc from Observe returns to Graft; Esc from Select aborts.
- [ ] Resize to <70 cols in any stage → Min-size floor renders instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)