### PR TITLE
feat(add): Plan 23 Phase 2 — add-items branch + cinematic conflict picker

### DIFF
--- a/cmd/add_redesign.go
+++ b/cmd/add_redesign.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -27,11 +28,11 @@ import (
 //	[0] Select             agent picker
 //	[1] LazyGroup          splices one of:
 //	      new-agent         [Ground(Lazy), Graft(NewAgent), Observe]
+//	      add-items         [Graft(AddItems, Installed), Observe]
 //	      all-installed     [YieldAllInstalled]                 (terminal)
 //	      tech-lead-req     [YieldTechLeadRequired]             (terminal)
-//	      add-items         (Phase 2 — nil for now, legacy handles it)
 //	[2] Conditional(Lazy(Grow))  gated on observeConfirmed
-//	[3] LazyGroup          conflicts placeholder (Phase 2 no-op)
+//	[3] LazyGroup          cinematic ConflictsStage iff wr.HasConflicts()
 //	[4] Conditional(Lazy(Yield)) gated on growSucceeded
 func runAddRedesign(cmd *cobra.Command, args []string) error {
 	startedAt := time.Now()
@@ -104,16 +105,33 @@ func runAddRedesign(cmd *cobra.Command, args []string) error {
 				return []harness.Step{addflow.NewYieldTechLeadRequired(ctx, agentType)}
 			}
 
-			// Add-items branch — Phase 1 terminal splices only. Plan 23
-			// Phase 2 wires the real filtered Graft + Observe path; until
-			// then this splicer either terminates at the "already full"
-			// card or directs the user to the legacy flow via the
-			// AddItemsDeferred variant. Never falls through silently.
+			// Add-items branch — Phase 2 wired. When the agent is already
+			// installed, either short-circuit to YieldAllInstalled (nothing
+			// uninstalled across any category) or splice the real sub-
+			// sequence [AddItemsGraft, Observe]. Ground is skipped — the
+			// workspace is already set. AgentDisplay stamps the agent's
+			// display name into the chrome header so every downstream
+			// stage inherits the correct "GRAFTING INTO" right-block.
 			if installedAgent, exists := cfg.Agents[agentType]; exists {
 				if availableAddItems(cat, installedAgent).Total() == 0 {
 					return []harness.Step{addflow.NewYieldAllInstalled(ctx, agentDef)}
 				}
-				return []harness.Step{addflow.NewYieldAddItemsDeferred(ctx, agentDef)}
+				agentCtx := ctx
+				agentCtx.AgentDisplay = agentDef.DisplayName
+				if agentCtx.AgentDisplay == "" {
+					agentCtx.AgentDisplay = catalog.DisplayNameFrom(agentDef.Name)
+				}
+				graft := addflow.NewAddItemsGraft(agentCtx, addflow.GraftContext{
+					Cat:       cat,
+					AgentType: agentType,
+					AgentDef:  agentDef,
+					Installed: installedAgent,
+				})
+				observe := addflow.NewObserveStage(agentCtx, cat)
+				// Ground is skipped on add-items — seed the workspace from
+				// the installed agent so Observe renders the real path.
+				observe.SetDefaultWorkspace(installedAgent.Workspace)
+				return []harness.Step{graft, observe}
 			}
 
 			// Tech-lead guard — non-tech-lead pick with no tech-lead installed.
@@ -156,7 +174,10 @@ func runAddRedesign(cmd *cobra.Command, args []string) error {
 			if !wr.HasConflicts() {
 				return nil
 			}
-			return buildConflictSteps(&wr)
+			// Cinematic path — one tabbed stage per conflict, Keep / Overwrite
+			// / Backup radio per tab. Returns map[string]config.ConflictAction
+			// consumed post-harness by applyCinematicConflictPicks.
+			return []harness.Step{addflow.NewConflictsStage(ctx, &wr)}
 		}),
 		harness.NewConditional(
 			harness.NewLazy("Yield", func(_ []any) harness.Step {
@@ -202,17 +223,71 @@ func runAddRedesign(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Conflict picker, when present, sits just before the trailing Yield slot.
-	confIdx := -1
+	// Cinematic conflict picker — single stage sitting just before the
+	// trailing Yield slot. Result is a per-file map of user picks. When
+	// nothing was picked the helper no-ops; when some files were flagged
+	// Overwrite/Backup it writes .bak files (Backup only) and dispatches to
+	// WriteResult.ForceSelected.
 	if wr.HasConflicts() {
-		confIdx = len(results) - 2
+		confIdx := len(results) - 2
+		if confIdx >= 0 && confIdx < len(results) {
+			if picks, ok := results[confIdx].(map[string]config.ConflictAction); ok {
+				applyCinematicConflictPicks(picks, &wr, lock, cwd)
+			}
+		}
 	}
-	applyConflictPicks(results, confIdx, &wr, lock, cwd)
 
 	if err := lock.Save(cwd); err != nil {
 		tui.Warning("Could not save lock file: " + err.Error())
 	}
 	return nil
+}
+
+// applyCinematicConflictPicks mutates wr + lock to apply the per-file
+// resolution picks produced by addflow.ConflictsStage. Mirrors the legacy
+// applyConflictPicks behaviour (wr.ForceSelected + optional .bak writes)
+// but reads a map[string]config.ConflictAction rather than the two-step
+// MultiSelect + Confirm shape legacy buildConflictSteps produces — written
+// fresh so the legacy helper stays unchanged (it is shared with remove /
+// update / legacy add).
+//
+// Selection semantics:
+//
+//   - ConflictActionKeep        — no write, no backup.
+//   - ConflictActionOverwrite   — ForceSelected(path), no backup.
+//   - ConflictActionBackup      — write <path>.bak, then ForceSelected(path).
+//
+// Returns true when at least one file mutated (for symmetry with the legacy
+// helper's return shape — currently unused by callers but kept for
+// diagnostic parity).
+func applyCinematicConflictPicks(picks map[string]config.ConflictAction,
+	wr *generate.WriteResult, lock *config.LockFile, projectRoot string) bool {
+	if len(picks) == 0 {
+		return false
+	}
+	toOverwrite := make([]string, 0, len(picks))
+	toBackup := make([]string, 0, len(picks))
+	for path, act := range picks {
+		switch act {
+		case config.ConflictActionBackup:
+			toBackup = append(toBackup, path)
+			toOverwrite = append(toOverwrite, path)
+		case config.ConflictActionOverwrite:
+			toOverwrite = append(toOverwrite, path)
+		}
+	}
+	if len(toOverwrite) == 0 {
+		return false
+	}
+	for _, rel := range toBackup {
+		abs := filepath.Join(projectRoot, rel)
+		data, readErr := os.ReadFile(abs)
+		if readErr == nil {
+			_ = os.WriteFile(abs+".bak", data, 0644)
+		}
+	}
+	wr.ForceSelected(toOverwrite, projectRoot, lock)
+	return true
 }
 
 // installedSet builds the "already installed" lookup for BuildAgentOptions.
@@ -224,10 +299,20 @@ func installedSet(cfg *config.ProjectConfig) map[string]bool {
 	return out
 }
 
-// buildAddGrowAction mirrors runAddSpinner's new-agent body but closes over
-// the cinematic flow's prev indices (agent at [0], workspace at [1], Graft
-// at [2], observe bool at [3]). Duplicated — not reused — so the cinematic
-// path has no back-import into legacy helpers beyond loadCatalog et al.
+// buildAddGrowAction returns the GenerateAction closure for the Grow stage.
+// Reads the upstream prev[] snapshot to decide which branch ran and applies
+// the appropriate config + filesystem mutation. The cinematic flow reuses
+// runAddSpinner's semantics exactly — same cfg.Save ordering, same generator
+// pipeline, same error plumbing — so file output is bit-identical to the
+// legacy path for the same picks.
+//
+// Branch detection is type-based rather than positional so the same helper
+// handles both prev shapes:
+//
+//	new-agent : [agent(string), workspace(string), graft(GraftResult), ...]
+//	add-items : [agent(string), graft(GraftResult), ...]
+//
+// cfg.Agents[agentType] exists ⇒ add-items branch; otherwise new-agent.
 func buildAddGrowAction(
 	prev []any,
 	cwd, configPath string,
@@ -250,13 +335,90 @@ func buildAddGrowAction(
 		}
 		outcome.AgentDef = agentDef
 
-		if _, exists := cfg.Agents[agentType]; exists {
-			// Phase 1: add-items path terminates at the Yield splice before
-			// reaching Grow. Defensive no-op.
+		// Locate the GraftResult by type. Both branches emit exactly one.
+		var graft addflow.GraftResult
+		var graftFound bool
+		for _, v := range prev {
+			if g, ok := v.(addflow.GraftResult); ok {
+				graft = g
+				graftFound = true
+				break
+			}
+		}
+		if !graftFound {
+			outcome.SpinnerErr = fmt.Errorf("no graft selection captured")
+			return outcome.SpinnerErr
+		}
+
+		// Add-items branch — mirror runAddSpinner's add-items body. The
+		// installed agent already exists; append only the newly-picked items
+		// per category, then regenerate. distributeAddItemPicks expects the
+		// picks slice to contain one entry per category with at least one
+		// uninstalled item (same order the legacy buildAddItemsSteps emits
+		// MultiSelect steps). Build picks the same way so both paths reach
+		// the shared helper with the same shape and produce bit-identical
+		// filesystem output.
+		if installedAgent, exists := cfg.Agents[agentType]; exists {
+			avail := availableAddItems(cat, installedAgent)
+			picks := make([][]string, 0, 5)
+			if len(avail.Skills) > 0 {
+				picks = append(picks, graft.Skills)
+			}
+			if len(avail.Workflows) > 0 {
+				picks = append(picks, graft.Workflows)
+			}
+			if len(avail.Protocols) > 0 {
+				picks = append(picks, graft.Protocols)
+			}
+			if len(avail.Sensors) > 0 {
+				picks = append(picks, graft.Sensors)
+			}
+			if len(avail.Routines) > 0 {
+				picks = append(picks, graft.Routines)
+			}
+			selectedSkills, selectedWorkflows, selectedProtocols, selectedSensors, selectedRoutines :=
+				distributeAddItemPicks(cat, installedAgent, picks)
+			totalSelected := len(selectedSkills) + len(selectedWorkflows) +
+				len(selectedProtocols) + len(selectedSensors) + len(selectedRoutines)
+			if totalSelected == 0 {
+				outcome.Workspace = installedAgent.Workspace
+				outcome.NewAgent = false
+				outcome.TotalSelected = 0
+				*installedOut = installedAgent
+				return nil
+			}
+
+			installedAgent.Skills = append(installedAgent.Skills, selectedSkills...)
+			installedAgent.Workflows = append(installedAgent.Workflows, selectedWorkflows...)
+			installedAgent.Protocols = append(installedAgent.Protocols, selectedProtocols...)
+			installedAgent.Sensors = append(installedAgent.Sensors, selectedSensors...)
+			installedAgent.Routines = append(installedAgent.Routines, selectedRoutines...)
+			generate.EnsureRoutineCheckSensor(installedAgent)
+
+			if err := cfg.Save(configPath); err != nil {
+				outcome.SpinnerErr = err
+				return err
+			}
+
+			var errs []error
+			errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installedAgent, cfg, cat, lock, wr, false))
+			errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, wr, false))
+			errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false))
+			errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+			if joined := errors.Join(errs...); joined != nil {
+				outcome.SpinnerErr = joined
+				return joined
+			}
+
+			outcome.Workspace = installedAgent.Workspace
+			outcome.NewAgent = false
+			outcome.TotalSelected = totalSelected
+			*installedOut = installedAgent
 			return nil
 		}
 
-		// New-agent path.
+		// New-agent branch. Workspace sits at prev[1] (from Ground). Tech-
+		// lead overrides — its Ground stage auto-completed with DocsPath.
 		workspace, _ := prev[1].(string)
 		if workspace == "" {
 			workspace = addflow.NormaliseWorkspace(agentType + "/")
@@ -271,8 +433,6 @@ func buildAddGrowAction(
 			outcome.SpinnerErr = fmt.Errorf("workspace %q is already in use by another agent", workspace)
 			return outcome.SpinnerErr
 		}
-
-		graft, _ := prev[2].(addflow.GraftResult)
 
 		installed := &config.InstalledAgent{
 			AgentType: agentType,

--- a/internal/config/lockfile.go
+++ b/internal/config/lockfile.go
@@ -77,6 +77,25 @@ func (lf *LockFile) Untrack(relPath string) {
 	delete(lf.Files, relPath)
 }
 
+// ConflictAction describes the resolution the user selected for a single
+// conflict-file entry during the cinematic ConflictsStage. Consumed by
+// applyCinematicConflictPicks in cmd/add_redesign.go, which translates the
+// per-file action into the WriteResult.ForceSelected + optional .bak write
+// that the legacy buildConflictSteps / applyConflictPicks primitives
+// perform as a bulk two-step form.
+type ConflictAction int
+
+const (
+	// ConflictActionKeep keeps the user's local edits — no write happens.
+	ConflictActionKeep ConflictAction = iota
+	// ConflictActionOverwrite overwrites the local file with the source
+	// content. No backup is created.
+	ConflictActionOverwrite
+	// ConflictActionBackup writes the current local file to `<path>.bak`
+	// and then overwrites with source content.
+	ConflictActionBackup
+)
+
 // IsModified checks whether the file on disk differs from the lock file hash.
 // Returns exists=false if the file is not on disk (safe to write).
 // Returns modified=true if the file exists but differs from the lock hash,

--- a/internal/tui/addflow/addflow.go
+++ b/internal/tui/addflow/addflow.go
@@ -21,32 +21,38 @@ import (
 )
 
 // Stage indices in the add-flow rail. Kept as named constants so ctors and
-// splicers reference them by name rather than literal integers.
+// splicers reference them by name rather than literal integers. Plan 23
+// Phase 2 inserted Conflicts between Grow and Yield; the rail now carries
+// seven segments (six default + Conflicts visible only when writes collide).
 const (
-	StageIdxSelect  = 0
-	StageIdxGround  = 1
-	StageIdxGraft   = 2
-	StageIdxObserve = 3
-	StageIdxGrow    = 4
-	StageIdxYield   = 5
+	StageIdxSelect    = 0
+	StageIdxGround    = 1
+	StageIdxGraft     = 2
+	StageIdxObserve   = 3
+	StageIdxGrow      = 4
+	StageIdxConflicts = 5
+	StageIdxYield     = 6
 )
 
-// StageLabels holds the six canonical add-flow stage labels in order.
+// StageLabels holds the seven canonical add-flow stage labels in order.
 // Matches Plan 23 decision Q2 — bonsai-raising metaphor extended to the add
-// journey.
+// journey; Phase 2 added Conflicts (衝 しょう) between Grow and Yield so the
+// rail reflects the ConflictsStage when it renders.
 //
-//	選 えらぶ  Select   — pick the agent
-//	地 じ      Ground   — workspace (skipped for tech-lead)
-//	接 つぐ    Graft    — abilities (skills/workflows/protocols/sensors/routines)
-//	観 みる    Observe  — one last look before the write
-//	育 そだつ  Grow     — the write animation
-//	結 むすぶ  Yield    — completion card
+//	選 えらぶ    Select    — pick the agent
+//	地 じ        Ground    — workspace (skipped for tech-lead)
+//	接 つぐ      Graft     — abilities (skills/workflows/protocols/sensors/routines)
+//	観 みる      Observe   — one last look before the write
+//	育 そだつ    Grow      — the write animation
+//	衝 しょう    Conflicts — reconcile user-edited files (optional)
+//	結 むすぶ    Yield     — completion card
 var StageLabels = []initflow.StageLabel{
 	{Kanji: "選", Kana: "えらぶ", English: "SELECT"},
 	{Kanji: "地", Kana: "じ", English: "GROUND"},
 	{Kanji: "接", Kana: "つぐ", English: "GRAFT"},
 	{Kanji: "観", Kana: "みる", English: "OBSERVE"},
 	{Kanji: "育", Kana: "そだつ", English: "GROW"},
+	{Kanji: "衝", Kana: "しょう", English: "CONFLICT"},
 	{Kanji: "結", Kana: "むすぶ", English: "YIELD"},
 }
 

--- a/internal/tui/addflow/conflicts.go
+++ b/internal/tui/addflow/conflicts.go
@@ -1,0 +1,438 @@
+package addflow
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// ConflictsStage is the tabbed conflict-resolution picker at rail position 5
+// (衝 CONFLICT). Rendered only when the Grow action produced at least one
+// ActionConflict file — the harness gates construction on
+// wr.HasConflicts(), so this stage never instantiates for clean writes.
+//
+// Layout: one tab per conflict file. Each tab shows:
+//   - Header  : the conflict file's relative path
+//   - Summary : a short "local has edits · source has changes" line (until the
+//     generator surfaces an inline diff field, this is a placeholder — see
+//     the TODO next to diffSummary below)
+//   - Radio   : three rows — Keep local · Overwrite with source · Backup
+//     then overwrite. Default Keep.
+//
+// Keystrokes match the addflow house style:
+//   - ← → / h l     cycle tabs (wrap)
+//   - ↑ ↓ / j k     cycle radio (no-wrap)
+//   - ␣ / ↵         advance (to next tab, or complete if last)
+//   - shift+tab / esc   back to prior stage (Grow; harness handles the pop)
+//
+// Result: map[string]config.ConflictAction keyed by FileResult.RelPath — one
+// entry per conflict file. applyCinematicConflictPicks in cmd/add_redesign.go
+// reads the map and dispatches per-file mutations.
+type ConflictsStage struct {
+	initflow.Stage
+
+	files   []generate.FileResult
+	catIdx  int                              // focused tab
+	action  map[string]config.ConflictAction // per-file pick
+	radio   map[string]int                   // per-file radio focus row
+	toneOrd []config.ConflictAction          // index → action for radio rows
+}
+
+// NewConflictsStage constructs the stage over the conflict entries present
+// in wr. When wr has zero conflicts the ctor still returns a usable stage —
+// it simply renders an empty body with a single "nothing to reconcile" line
+// and completes on Enter. Callers should gate on wr.HasConflicts() before
+// splicing.
+func NewConflictsStage(ctx initflow.StageContext, wr *generate.WriteResult) *ConflictsStage {
+	label := StageLabels[StageIdxConflicts]
+	base := initflow.NewStage(
+		StageIdxConflicts,
+		label,
+		label.English,
+		ctx.Version,
+		ctx.ProjectDir,
+		ctx.StationDir,
+		ctx.AgentDisplay,
+		ctx.StartedAt,
+	)
+	base.SetRailLabels(StageLabels)
+
+	var conflicts []generate.FileResult
+	if wr != nil {
+		conflicts = wr.Conflicts()
+	}
+
+	action := make(map[string]config.ConflictAction, len(conflicts))
+	radio := make(map[string]int, len(conflicts))
+	for _, f := range conflicts {
+		action[f.RelPath] = config.ConflictActionKeep
+		radio[f.RelPath] = 0
+	}
+
+	return &ConflictsStage{
+		Stage:  base,
+		files:  conflicts,
+		catIdx: 0,
+		action: action,
+		radio:  radio,
+		toneOrd: []config.ConflictAction{
+			config.ConflictActionKeep,
+			config.ConflictActionOverwrite,
+			config.ConflictActionBackup,
+		},
+	}
+}
+
+// Init implements tea.Model — no cmd on entry.
+func (s *ConflictsStage) Init() tea.Cmd { return nil }
+
+// Update handles tab cycle + radio cycle + advance + back.
+func (s *ConflictsStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		if len(s.files) == 0 {
+			// Empty stage — ↵/␣ completes, everything else no-ops.
+			switch m.String() {
+			case "enter", " ":
+				s.MarkDone()
+			}
+			return s, nil
+		}
+		switch m.String() {
+		case "left", "h":
+			s.catIdx = (s.catIdx - 1 + len(s.files)) % len(s.files)
+		case "right", "l":
+			s.catIdx = (s.catIdx + 1) % len(s.files)
+		case "up", "k":
+			key := s.currentKey()
+			if key == "" {
+				return s, nil
+			}
+			cur := s.radio[key] - 1
+			if cur < 0 {
+				cur = 0
+			}
+			s.radio[key] = cur
+			s.action[key] = s.toneOrd[cur]
+		case "down", "j":
+			key := s.currentKey()
+			if key == "" {
+				return s, nil
+			}
+			cur := s.radio[key] + 1
+			if cur >= len(s.toneOrd) {
+				cur = len(s.toneOrd) - 1
+			}
+			s.radio[key] = cur
+			s.action[key] = s.toneOrd[cur]
+		case " ", "enter":
+			// Advance to the next tab; complete on the last.
+			if s.catIdx+1 < len(s.files) {
+				s.catIdx++
+				return s, nil
+			}
+			s.MarkDone()
+			return s, nil
+		}
+	}
+	return s, nil
+}
+
+// currentKey returns the RelPath of the focused tab's file, or "" if no tabs.
+func (s *ConflictsStage) currentKey() string {
+	if s.catIdx < 0 || s.catIdx >= len(s.files) {
+		return ""
+	}
+	return s.files[s.catIdx].RelPath
+}
+
+// View composes the body inside the shared frame.
+func (s *ConflictsStage) View() string {
+	return s.RenderFrame(s.renderBody(), s.keyHints())
+}
+
+func (s *ConflictsStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "←→", Desc: "file"},
+		{Key: "↑↓", Desc: "action"},
+		{Key: "↵", Desc: "next"},
+		{Key: "esc", Desc: "back"},
+		{Key: "ctrl-c", Desc: "quit"},
+	}
+}
+
+func (s *ConflictsStage) renderBody() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+
+	var title string
+	if s.EnsoSafe() {
+		title = bark.Render(s.Label().Kanji) + " " + white.Render(s.Label().English)
+	} else {
+		title = white.Render(s.Label().English)
+	}
+
+	intro := strings.Join([]string{
+		title,
+		white.Render("Reconcile edited files."),
+		dim.Render("Pick an action per file — nothing overwritten silently."),
+	}, "\n")
+
+	panelW := initflow.PanelWidth(s.Width())
+	divider := initflow.RenderSectionHeader("CONFLICTS", panelW)
+
+	if len(s.files) == 0 {
+		empty := dim.Render("  (nothing to reconcile)")
+		body := []string{intro, "", "", divider, "", empty}
+		return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+	}
+
+	tabRow := s.renderTabs()
+	header := s.renderFileHeader()
+	summary := s.renderDiffSummary()
+	radio := s.renderRadio()
+	counter := s.renderCounter()
+
+	body := []string{
+		intro,
+		"",
+		"",
+		divider,
+		"",
+		tabRow,
+		"",
+		header,
+		"",
+		summary,
+		"",
+		radio,
+		"",
+		dim.Render(counter),
+	}
+	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
+}
+
+// renderTabs draws a compact tab strip — one cell per conflict file, keyed
+// by file index. File paths are truncated to fit.
+func (s *ConflictsStage) renderTabs() string {
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	bracket := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
+	chevron := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
+
+	cells := make([]string, 0, len(s.files))
+	// Use a compact label — index + short basename — so the tab strip does
+	// not wrap on terminals with many conflicts. Full path is shown in the
+	// header block below.
+	for i, f := range s.files {
+		label := fmt.Sprintf("%d · %s", i+1, basename(f.RelPath))
+		// Clamp label to a conservative width so many conflicts still fit.
+		if lipgloss.Width(label) > 20 {
+			rr := []rune(label)
+			if len(rr) > 19 {
+				label = string(rr[:19]) + "…"
+			}
+		}
+		var cell string
+		if i == s.catIdx {
+			cell = bracket.Render("[ ") + leaf.Render(label) + bracket.Render(" ]")
+		} else {
+			cell = "  " + muted.Render(label) + "  "
+		}
+		cells = append(cells, cell)
+	}
+
+	row := strings.Join(cells, " ")
+	return chevron.Render("‹") + " " + row + " " + chevron.Render("›")
+}
+
+// renderFileHeader shows the focused file's full relative path, truncated to
+// the panel width if needed.
+func (s *ConflictsStage) renderFileHeader() string {
+	bark := initflow.LabelStyle()
+	value := initflow.ValueStyle()
+
+	key := s.currentKey()
+	if key == "" {
+		return ""
+	}
+	panelW := initflow.PanelWidth(s.Width())
+	// Reserve space for the "FILE " label prefix (4 + 2 gap).
+	labelW := 6
+	pathBudget := panelW - labelW - 2
+	if pathBudget < 10 {
+		pathBudget = 10
+	}
+	path := key
+	if lipgloss.Width(path) > pathBudget {
+		rr := []rune(path)
+		if len(rr) > pathBudget-1 {
+			// Head-truncate paths so the distinctive basename survives.
+			path = "…" + string(rr[len(rr)-pathBudget+1:])
+		}
+	}
+	return "  " + bark.Render(initflow.PadRight("FILE", labelW)) + value.Render(path)
+}
+
+// renderDiffSummary emits a short status line describing the conflict. TODO:
+// surface a real inline diff once FileResult carries one. Until then we read
+// Source (the catalog path the file came from) and the RelPath to compose a
+// one-line provenance summary — no partial diff leaks, no placeholder data
+// masquerades as content.
+func (s *ConflictsStage) renderDiffSummary() string {
+	dim := initflow.DimStyle()
+	bark := initflow.LabelStyle()
+	value := initflow.ValueStyle()
+
+	if s.catIdx < 0 || s.catIdx >= len(s.files) {
+		return ""
+	}
+	f := s.files[s.catIdx]
+
+	labelW := 6
+	source := f.Source
+	if source == "" {
+		source = "—"
+	}
+
+	panelW := initflow.PanelWidth(s.Width())
+	srcBudget := panelW - labelW - 2
+	if srcBudget < 10 {
+		srcBudget = 10
+	}
+	if lipgloss.Width(source) > srcBudget {
+		rr := []rune(source)
+		if len(rr) > srcBudget-1 {
+			source = string(rr[:srcBudget-1]) + "…"
+		}
+	}
+
+	// TODO(plan-23-phase2): replace the placeholder status with a real inline
+	// diff summary once generate.FileResult exposes one. Today the write
+	// pipeline only records Action=ActionConflict, not a per-file diff — so
+	// we surface provenance (source) + a stable status instead of mocking
+	// content deltas.
+	statusLine := dim.Render("local has edits · source has changes")
+	srcLine := "  " + bark.Render(initflow.PadRight("SOURCE", labelW)) + value.Render(source)
+	return "  " + bark.Render(initflow.PadRight("WHAT", labelW)) + statusLine + "\n" + srcLine
+}
+
+// renderRadio draws the three Keep / Overwrite / Backup rows for the focused
+// tab, using the colour-coded ConflictRowStyle tokens from initflow/design.
+func (s *ConflictsStage) renderRadio() string {
+	key := s.currentKey()
+	if key == "" {
+		return ""
+	}
+
+	rowFocus := s.radio[key]
+	rows := []struct {
+		tone  initflow.ConflictActionTone
+		label string
+		desc  string
+	}{
+		{initflow.ConflictToneKeep, "Keep local", "skip this file — your edits win"},
+		{initflow.ConflictToneOverwrite, "Overwrite with source", "discard edits and pull new content"},
+		{initflow.ConflictToneBackup, "Backup then overwrite", "save .bak and pull new content"},
+	}
+
+	out := make([]string, 0, len(rows))
+	for i, r := range rows {
+		style := initflow.ConflictRowStyle(r.tone)
+		glyph := initflow.ConflictActionGlyph(r.tone)
+
+		focused := i == rowFocus
+		border := initflow.UnfocusBorder()
+		if focused {
+			border = initflow.FocusBorder()
+		}
+
+		nameStyle := style
+		if focused {
+			nameStyle = nameStyle.Bold(true)
+		}
+
+		desc := initflow.UnfocusedDescStyle().Render(r.desc)
+		if focused {
+			desc = initflow.FocusedDescStyle().Render(r.desc)
+		}
+		line := border + style.Render(glyph) + " " + nameStyle.Render(r.label) + "  " + desc
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// renderCounter emits "file N of M — action: <label>" so the user always has
+// a sticky summary of where they are in the picker and what they picked.
+func (s *ConflictsStage) renderCounter() string {
+	if len(s.files) == 0 {
+		return ""
+	}
+	key := s.currentKey()
+	act := s.action[key]
+	return fmt.Sprintf("file %d of %d · action: %s", s.catIdx+1, len(s.files), actionLabel(act))
+}
+
+// actionLabel renders a ConflictAction as its user-facing label. Centralised
+// here so the counter + (future) confirm lines read from a single source.
+func actionLabel(a config.ConflictAction) string {
+	switch a {
+	case config.ConflictActionKeep:
+		return "keep local"
+	case config.ConflictActionOverwrite:
+		return "overwrite"
+	case config.ConflictActionBackup:
+		return "backup + overwrite"
+	default:
+		return "?"
+	}
+}
+
+// basename returns the last path segment of a forward-slash path. Kept local
+// so conflicts.go has no dependency on path/filepath on the hot render path.
+func basename(p string) string {
+	if p == "" {
+		return ""
+	}
+	idx := strings.LastIndex(p, "/")
+	if idx < 0 {
+		return p
+	}
+	return p[idx+1:]
+}
+
+// Result returns the per-file ConflictAction map. Keys are RelPath values;
+// every conflict entry is guaranteed to appear in the map (default Keep if
+// untouched). When the stage was aborted via esc the harness calls Reset and
+// discards the result — callers receiving a nil map on the read path should
+// fall through to a no-op.
+func (s *ConflictsStage) Result() any {
+	// Return a copy so later mutations on the stage (shouldn't happen, but
+	// defensive) cannot mutate the harness-held snapshot.
+	if len(s.action) == 0 {
+		return map[string]config.ConflictAction{}
+	}
+	out := make(map[string]config.ConflictAction, len(s.action))
+	for k, v := range s.action {
+		out[k] = v
+	}
+	return out
+}
+
+// Reset clears the completion flag but preserves per-file picks, tab focus,
+// and radio focus so Esc-back → re-entry reads exactly where the user left
+// off. Mirrors the Graft stage's preserve-everything-but-done policy.
+func (s *ConflictsStage) Reset() tea.Cmd {
+	s.ClearDone()
+	return nil
+}

--- a/internal/tui/addflow/conflicts_test.go
+++ b/internal/tui/addflow/conflicts_test.go
@@ -1,0 +1,222 @@
+package addflow
+
+import (
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// newTestConflicts builds a ConflictsStage over a synthetic WriteResult with
+// three conflict files spanning different categories. Used as the common
+// fixture for every test in this file.
+func newTestConflicts() *ConflictsStage {
+	wr := &generate.WriteResult{}
+	wr.Files = []generate.FileResult{
+		{RelPath: "station/agent/Skills/foo.md", Action: generate.ActionConflict, Source: "skills/foo/foo.md"},
+		{RelPath: "station/agent/Protocols/bar.md", Action: generate.ActionConflict, Source: "protocols/bar/bar.md"},
+		{RelPath: "station/agent/Core/identity.md", Action: generate.ActionConflict, Source: "agents/tech-lead/core/identity.md.tmpl"},
+	}
+	return NewConflictsStage(initflow.StageContext{StartedAt: time.Now()}, wr)
+}
+
+func conflictsPressKey(s *ConflictsStage, k tea.KeyType) {
+	m, _ := s.Update(tea.KeyMsg{Type: k})
+	if cs, ok := m.(*ConflictsStage); ok {
+		*s = *cs
+	}
+}
+
+// TestConflicts_TabCount verifies the stage surfaces one tab per conflict
+// file.
+func TestConflicts_TabCount(t *testing.T) {
+	s := newTestConflicts()
+	if len(s.files) != 3 {
+		t.Fatalf("tabs = %d, want 3 (one per conflict file)", len(s.files))
+	}
+}
+
+// TestConflicts_DefaultIsKeep verifies every conflict file defaults to
+// ConflictActionKeep — the destructive action (overwrite) must be opt-in.
+func TestConflicts_DefaultIsKeep(t *testing.T) {
+	s := newTestConflicts()
+	for _, f := range s.files {
+		act, ok := s.action[f.RelPath]
+		if !ok {
+			t.Fatalf("no action recorded for %q", f.RelPath)
+		}
+		if act != config.ConflictActionKeep {
+			t.Fatalf("default action for %q = %v, want ConflictActionKeep", f.RelPath, act)
+		}
+	}
+}
+
+// TestConflicts_TabCycleWraps verifies ← / → wraps around the end of the
+// tab list.
+func TestConflicts_TabCycleWraps(t *testing.T) {
+	s := newTestConflicts()
+	if s.catIdx != 0 {
+		t.Fatalf("initial catIdx = %d, want 0", s.catIdx)
+	}
+	// Right across the end: 0 → 1 → 2 → 0.
+	for i := 0; i < len(s.files); i++ {
+		conflictsPressKey(s, tea.KeyRight)
+	}
+	if s.catIdx != 0 {
+		t.Fatalf("after full cycle, catIdx = %d, want 0 (wrap)", s.catIdx)
+	}
+	// Left from 0 wraps to the last tab.
+	conflictsPressKey(s, tea.KeyLeft)
+	if s.catIdx != len(s.files)-1 {
+		t.Fatalf("after left from 0, catIdx = %d, want %d", s.catIdx, len(s.files)-1)
+	}
+}
+
+// TestConflicts_RadioCycleClamps verifies ↑/↓ cycles the radio focus without
+// wrapping.
+func TestConflicts_RadioCycleClamps(t *testing.T) {
+	s := newTestConflicts()
+	key := s.currentKey()
+	// Start at row 0 (Keep).
+	if s.radio[key] != 0 {
+		t.Fatalf("initial radio = %d, want 0", s.radio[key])
+	}
+	// Up from 0 clamps.
+	conflictsPressKey(s, tea.KeyUp)
+	if s.radio[key] != 0 {
+		t.Fatalf("up from 0 radio = %d, want 0", s.radio[key])
+	}
+	// Down → 1 (Overwrite) → 2 (Backup) → 2 (clamp).
+	conflictsPressKey(s, tea.KeyDown)
+	if s.radio[key] != 1 || s.action[key] != config.ConflictActionOverwrite {
+		t.Fatalf("after 1x down radio=%d action=%v, want 1 + Overwrite", s.radio[key], s.action[key])
+	}
+	conflictsPressKey(s, tea.KeyDown)
+	if s.radio[key] != 2 || s.action[key] != config.ConflictActionBackup {
+		t.Fatalf("after 2x down radio=%d action=%v, want 2 + Backup", s.radio[key], s.action[key])
+	}
+	conflictsPressKey(s, tea.KeyDown)
+	if s.radio[key] != 2 {
+		t.Fatalf("down from last radio=%d, want clamp at 2", s.radio[key])
+	}
+}
+
+// TestConflicts_EnterAdvancesTabsThenCompletes verifies Enter cycles through
+// the tabs in order and flips Done only on the last tab.
+func TestConflicts_EnterAdvancesTabsThenCompletes(t *testing.T) {
+	s := newTestConflicts()
+	// First Enter: tab 0 → tab 1, not done.
+	conflictsPressKey(s, tea.KeyEnter)
+	if s.catIdx != 1 {
+		t.Fatalf("after 1st Enter catIdx = %d, want 1", s.catIdx)
+	}
+	if s.Done() {
+		t.Fatal("Done flipped on intermediate Enter")
+	}
+	// Second Enter: tab 1 → tab 2, not done.
+	conflictsPressKey(s, tea.KeyEnter)
+	if s.catIdx != 2 || s.Done() {
+		t.Fatalf("after 2nd Enter catIdx=%d done=%v, want 2 + !done", s.catIdx, s.Done())
+	}
+	// Third Enter (from last tab): stays at 2, flips Done.
+	conflictsPressKey(s, tea.KeyEnter)
+	if !s.Done() {
+		t.Fatal("3rd Enter on last tab should flip Done")
+	}
+}
+
+// TestConflicts_ResultMapPopulated verifies Result returns a map with one
+// entry per conflict file carrying the user's current pick.
+func TestConflicts_ResultMapPopulated(t *testing.T) {
+	s := newTestConflicts()
+	// Pick Overwrite on tab 0 + Backup on tab 1.
+	conflictsPressKey(s, tea.KeyDown) // tab 0 → Overwrite
+	conflictsPressKey(s, tea.KeyRight)
+	conflictsPressKey(s, tea.KeyDown) // tab 1 → Overwrite
+	conflictsPressKey(s, tea.KeyDown) // tab 1 → Backup
+
+	res, ok := s.Result().(map[string]config.ConflictAction)
+	if !ok {
+		t.Fatalf("Result type = %T, want map[string]config.ConflictAction", s.Result())
+	}
+	if len(res) != 3 {
+		t.Fatalf("result size = %d, want 3", len(res))
+	}
+	if res[s.files[0].RelPath] != config.ConflictActionOverwrite {
+		t.Fatalf("tab 0 action = %v, want Overwrite", res[s.files[0].RelPath])
+	}
+	if res[s.files[1].RelPath] != config.ConflictActionBackup {
+		t.Fatalf("tab 1 action = %v, want Backup", res[s.files[1].RelPath])
+	}
+	if res[s.files[2].RelPath] != config.ConflictActionKeep {
+		t.Fatalf("tab 2 action = %v, want Keep (untouched)", res[s.files[2].RelPath])
+	}
+}
+
+// TestConflicts_EmptyWriteResultRendersGracefully verifies constructing over
+// a WriteResult with no conflicts produces a usable stage that completes on
+// Enter and returns an empty map.
+func TestConflicts_EmptyWriteResultRendersGracefully(t *testing.T) {
+	wr := &generate.WriteResult{}
+	s := NewConflictsStage(initflow.StageContext{StartedAt: time.Now()}, wr)
+	if len(s.files) != 0 {
+		t.Fatalf("empty wr should produce 0 tabs; got %d", len(s.files))
+	}
+	// Render should not panic even with no tabs. View depends on SetSize.
+	s.SetSize(100, 30)
+	_ = s.View()
+	// Enter completes.
+	conflictsPressKey(s, tea.KeyEnter)
+	if !s.Done() {
+		t.Fatal("Enter on empty conflicts should flip Done")
+	}
+	// Result is a non-nil empty map.
+	res, ok := s.Result().(map[string]config.ConflictAction)
+	if !ok {
+		t.Fatalf("Result type = %T, want map[string]config.ConflictAction", s.Result())
+	}
+	if len(res) != 0 {
+		t.Fatalf("empty stage result size = %d, want 0", len(res))
+	}
+}
+
+// TestConflicts_ResetPreservesPicks verifies Reset clears done but keeps tab
+// focus, radio focus, and per-file action picks.
+func TestConflicts_ResetPreservesPicks(t *testing.T) {
+	s := newTestConflicts()
+	// Pick Backup on tab 0, advance to tab 1.
+	conflictsPressKey(s, tea.KeyDown) // Overwrite
+	conflictsPressKey(s, tea.KeyDown) // Backup
+	conflictsPressKey(s, tea.KeyRight)
+	// Complete + reset.
+	s.MarkDone()
+	s.Reset()
+	if s.Done() {
+		t.Fatal("Reset should clear Done")
+	}
+	if s.catIdx != 1 {
+		t.Fatalf("Reset changed catIdx = %d, want 1", s.catIdx)
+	}
+	if s.action[s.files[0].RelPath] != config.ConflictActionBackup {
+		t.Fatalf("Reset changed action = %v, want Backup", s.action[s.files[0].RelPath])
+	}
+}
+
+// TestConflicts_RenderDoesNotPanic smokes View at a few dims to prove the
+// layout helpers don't index out of range.
+func TestConflicts_RenderDoesNotPanic(t *testing.T) {
+	s := newTestConflicts()
+	for _, dim := range []struct{ w, h int }{
+		{80, 24},
+		{120, 40},
+		{70, 20}, // min floor
+		{40, 10}, // below floor — should return the min-size floor view
+	} {
+		s.SetSize(dim.w, dim.h)
+		_ = s.View()
+	}
+}

--- a/internal/tui/addflow/graft_test.go
+++ b/internal/tui/addflow/graft_test.go
@@ -2,6 +2,7 @@ package addflow
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -255,6 +256,97 @@ func TestGraft_AddItemsPartialDropsEmpty(t *testing.T) {
 	}
 	if len(s.categories[0].items) != 1 || s.categories[0].items[0].name != "beta-skill" {
 		t.Fatalf("skills tab items = %v, want [beta-skill]", s.categories[0].items)
+	}
+}
+
+// TestGraft_TabCountUpdatesLive verifies the per-tab "(N)" counter rendered
+// in the tab strip reflects toggles as the user makes them — not a captured
+// ctor-time snapshot. Render the tab row before/after a toggle and compare
+// the focused tab's rendered count.
+func TestGraft_TabCountUpdatesLive(t *testing.T) {
+	s := newTestGraft()
+	// Find skills tab.
+	var skillIdx = -1
+	for i, c := range s.categories {
+		if c.key == graftCatSkills {
+			skillIdx = i
+			break
+		}
+	}
+	if skillIdx < 0 {
+		t.Fatal("skills tab missing")
+	}
+
+	// Initial: beta-skill is a default (pre-selected). Count = 1.
+	before := len(s.selected[skillIdx])
+	if before != 1 {
+		t.Fatalf("initial skills count = %d, want 1", before)
+	}
+
+	// Focus skills + toggle alpha-skill on (idx 0).
+	s.catIdx = skillIdx
+	s.itemIdx[skillIdx] = 0
+	graftPressRune(s, ' ')
+	after := len(s.selected[skillIdx])
+	if after != 2 {
+		t.Fatalf("after toggle skills count = %d, want 2", after)
+	}
+
+	// Rendered tab row should contain "SKILLS (2)" now, not "(1)".
+	row := s.renderTabs()
+	if !strings.Contains(row, "SKILLS (2)") {
+		t.Fatalf("tab row should contain SKILLS (2); got: %q", row)
+	}
+
+	// Toggle alpha back off — count returns to 1.
+	graftPressRune(s, ' ')
+	if len(s.selected[skillIdx]) != 1 {
+		t.Fatalf("after second toggle skills count = %d, want 1", len(s.selected[skillIdx]))
+	}
+	row = s.renderTabs()
+	if !strings.Contains(row, "SKILLS (1)") {
+		t.Fatalf("tab row should contain SKILLS (1); got: %q", row)
+	}
+}
+
+// TestGraft_NewAgentUnaffectedByFilter is a regression guard — the new-agent
+// ctor must NOT filter by Installed even when a non-nil Installed slice is
+// passed (Plan 23 Phase 2 added the filter path inside a shared helper; this
+// test proves the new-agent entry still seeds every catalog item regardless).
+func TestGraft_NewAgentUnaffectedByFilter(t *testing.T) {
+	cat, agentDef := newTestGraftCatalog()
+	// Installed carries every item in every category — if the new-agent path
+	// were mistakenly filtering, the tabs would all be empty.
+	installed := &config.InstalledAgent{
+		AgentType: "backend",
+		Workspace: "backend/",
+		Skills:    []string{"alpha-skill", "beta-skill"},
+		Workflows: []string{"wf-one"},
+		Protocols: []string{"proto-req"},
+		Sensors:   []string{"sensor-a"},
+		Routines:  []string{"routine-a"},
+	}
+	s := NewNewAgentGraft(initflow.StageContext{StartedAt: time.Now()}, GraftContext{
+		Cat:       cat,
+		AgentType: "backend",
+		AgentDef:  agentDef,
+		Installed: installed, // deliberately non-nil to prove the new-agent path ignores it
+	})
+	// All five tabs should survive.
+	if len(s.categories) != 5 {
+		t.Fatalf("new-agent ctor tabs = %d, want 5 (filter leaked into new-agent path)", len(s.categories))
+	}
+	// Skills tab should carry both alpha + beta — filter leak would drop them.
+	var skillIdx = -1
+	for i, c := range s.categories {
+		if c.key == graftCatSkills {
+			skillIdx = i
+			break
+		}
+	}
+	if skillIdx < 0 || len(s.categories[skillIdx].items) != 2 {
+		t.Fatalf("new-agent skills tab items = %v, want both alpha + beta",
+			s.categories[skillIdx].items)
 	}
 }
 

--- a/internal/tui/addflow/observe.go
+++ b/internal/tui/addflow/observe.go
@@ -60,23 +60,52 @@ func NewObserveStage(ctx initflow.StageContext, cat *catalog.Catalog) *ObserveSt
 	}
 }
 
+// SetDefaultWorkspace seeds a fallback workspace value rendered when the
+// prior-results snapshot does not carry one. Used on the add-items branch,
+// where Ground is skipped — the installed agent's existing workspace is
+// stamped into the stage before SetPrior runs so the Observe panel reads
+// the durable workspace rather than "—".
+func (s *ObserveStage) SetDefaultWorkspace(ws string) { s.workspace = ws }
+
 // SetPrior captures Select / Ground / Graft results. Called on entry and
 // after every Esc-back edit.
+//
+// The add-flow splices differ in shape across branches — new-agent writes
+// (agent, workspace, graft, ...) while add-items writes (agent, graft, ...)
+// because Ground is skipped. Rather than hard-code positional indices (which
+// break the add-items branch), SetPrior scans prev[] for the first value of
+// each expected type. GraftResult is uniquely typed, so the match is
+// unambiguous; agent / workspace are both strings but agent is always
+// prev[0] (from SelectStage) so we grab it first and treat any later string
+// as the workspace.
 func (s *ObserveStage) SetPrior(prev []any) {
-	if len(prev) >= 1 {
-		if a, ok := prev[0].(string); ok {
-			s.agent = a
+	var firstString, secondString string
+	var stringIdx int
+	var graftSet bool
+	for _, v := range prev {
+		switch x := v.(type) {
+		case string:
+			if stringIdx == 0 {
+				firstString = x
+			} else if stringIdx == 1 {
+				secondString = x
+			}
+			stringIdx++
+		case GraftResult:
+			s.graft = x
+			graftSet = true
 		}
 	}
-	if len(prev) >= 2 {
-		if w, ok := prev[1].(string); ok {
-			s.workspace = w
-		}
+	s.agent = firstString
+	// Workspace only comes from Ground (new-agent branch). On add-items the
+	// second string slot does not exist — preserve whatever the splicer
+	// pre-stamped via SetDefaultWorkspace (installedAgent.Workspace) rather
+	// than clobbering it with "".
+	if secondString != "" {
+		s.workspace = secondString
 	}
-	if len(prev) >= 3 {
-		if g, ok := prev[2].(GraftResult); ok {
-			s.graft = g
-		}
+	if !graftSet {
+		s.graft = GraftResult{}
 	}
 	if s.agent != "" && s.cat != nil {
 		s.agentDef = s.cat.GetAgent(s.agent)

--- a/internal/tui/addflow/observe_test.go
+++ b/internal/tui/addflow/observe_test.go
@@ -79,6 +79,33 @@ func TestObserve_SetPriorMissingAgentTolerant(t *testing.T) {
 	}
 }
 
+// TestObserve_SetPriorAddItemsShape verifies SetPrior handles the add-items
+// branch's shorter prev[] slice (no Ground stage → no workspace string).
+// GraftResult is the second slot and must still be captured by type.
+func TestObserve_SetPriorAddItemsShape(t *testing.T) {
+	s := newTestObserve()
+	s.SetDefaultWorkspace("backend/")
+	graft := GraftResult{
+		Skills:   []string{"s1"},
+		Sensors:  []string{"sensor-a"},
+		Routines: []string{"routine-a"},
+	}
+	// prev layout on add-items: [agent, graft, ...].
+	s.SetPrior([]any{"backend", graft})
+	if s.agent != "backend" {
+		t.Fatalf("agent = %q, want backend", s.agent)
+	}
+	if s.workspace != "backend/" {
+		t.Fatalf("workspace = %q, want backend/ (preserved from SetDefaultWorkspace)", s.workspace)
+	}
+	if len(s.graft.Skills) != 1 || s.graft.Skills[0] != "s1" {
+		t.Fatalf("graft.Skills = %v, want [s1]", s.graft.Skills)
+	}
+	if len(s.graft.Sensors) != 1 || len(s.graft.Routines) != 1 {
+		t.Fatalf("graft not fully captured: %+v", s.graft)
+	}
+}
+
 // TestObserve_DefaultFocusGraft verifies btnFocus starts on GRAFT (1).
 func TestObserve_DefaultFocusGraft(t *testing.T) {
 	s := newTestObserve()

--- a/internal/tui/initflow/design.go
+++ b/internal/tui/initflow/design.go
@@ -156,12 +156,61 @@ func FocusedAccentStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
 }
 
-// ConflictRowStyle returns the per-row style used by addflow's ConflictsStage
-// to render a conflict-file entry. Phase-1 stub — the style is intentionally
-// a no-op passthrough so Phase-2 can land the full body (colour-coded Keep /
-// Overwrite / Backup action glyphs + diff summary) without bloating the Phase-1
-// diff. The exported symbol is defined here so addflow's Phase-1 code imports
-// are wired against the final API shape. See Plan 23 decision Q10.
-func ConflictRowStyle() lipgloss.Style {
-	return lipgloss.NewStyle().Foreground(tui.ColorAccent)
+// ConflictActionTone identifies one of the three radio options rendered by
+// addflow.ConflictsStage. Tokenised here (rather than hard-coded numeric
+// indices in addflow) so every stage that surfaces Keep / Overwrite / Backup
+// semantics can reach for the same colour-coded glyph set.
+type ConflictActionTone int
+
+const (
+	// ConflictToneKeep — local edits win, no write. Renders in Leaf green
+	// (ColorPrimary / ColorSuccess family) because the user's work survives.
+	ConflictToneKeep ConflictActionTone = iota
+	// ConflictToneOverwrite — source wins, local edits discarded. Renders in
+	// Ember red (ColorDanger) to signal the destructive action.
+	ConflictToneOverwrite
+	// ConflictToneBackup — local saved to .bak, then source wins. Renders in
+	// Amber (ColorWarning) — reversible but still mutates disk.
+	ConflictToneBackup
+)
+
+// ConflictRowStyle returns the foreground-tinted style for a single radio
+// row inside addflow.ConflictsStage — one tone per ConflictActionTone.
+// Selected rows are bolded by the caller; this helper only supplies the
+// colour so the palette swap happens in one place per Plan 23 decision Q10.
+//
+//	Keep      → ColorSuccess (leaf / moss) — user work survives
+//	Overwrite → ColorDanger  (ember)       — destructive
+//	Backup    → ColorWarning (amber)       — reversible
+//
+// Unknown tones fall back to ColorAccent so stages can't accidentally render
+// a blank row if a new tone is added without updating the switch.
+func ConflictRowStyle(tone ConflictActionTone) lipgloss.Style {
+	switch tone {
+	case ConflictToneKeep:
+		return lipgloss.NewStyle().Foreground(tui.ColorSuccess)
+	case ConflictToneOverwrite:
+		return lipgloss.NewStyle().Foreground(tui.ColorDanger)
+	case ConflictToneBackup:
+		return lipgloss.NewStyle().Foreground(tui.ColorWarning)
+	default:
+		return lipgloss.NewStyle().Foreground(tui.ColorAccent)
+	}
+}
+
+// ConflictActionGlyph returns the per-tone glyph used to anchor each radio
+// row. Chosen for visual hierarchy — a leaf-like mark for Keep, a burning
+// mark for Overwrite, and a save-disk glyph for Backup. Matched to
+// ConflictRowStyle's tones so the glyph + colour reinforce each other.
+func ConflictActionGlyph(tone ConflictActionTone) string {
+	switch tone {
+	case ConflictToneKeep:
+		return "◆"
+	case ConflictToneOverwrite:
+		return "✸"
+	case ConflictToneBackup:
+		return "⎘"
+	default:
+		return "•"
+	}
 }


### PR DESCRIPTION
## Summary

Plan 23 Phase 2 — cinematic `bonsai add`: wire the add-items branch (filtered Graft + real Grow mutation) and replace the legacy Huh conflict picker with a tabbed `ConflictsStage`. Still gated by `BONSAI_ADD_REDESIGN=1`; Phase 3 (default flip + legacy delete) follows.

## Changes

- `internal/tui/addflow/graft.go` — already had the `NewAddItemsGraft` filter body from Phase 1; Phase 2 adds the regression tests below.
- `internal/tui/addflow/conflicts.go` — **new**. `ConflictsStage` — one tab per conflict file, 3-way radio (Keep / Overwrite / Backup, default Keep), `Result() map[string]config.ConflictAction`. Stage sits at rail idx 5 (`衝 しょう CONFLICT`). Uses the `initflow.ConflictRowStyle(tone)` + `ConflictActionGlyph(tone)` helpers.
- `internal/tui/addflow/conflicts_test.go` — **new**. 9 tests: tab count, default-Keep, tab cycle wrap, radio clamp, Enter cycle/complete, Result map shape, empty-WriteResult, Reset preservation, multi-dim render smoke.
- `internal/tui/addflow/graft_test.go` — extended with `TestGraft_TabCountUpdatesLive` + `TestGraft_NewAgentUnaffectedByFilter`.
- `internal/tui/addflow/observe.go` — `SetPrior` now scans by type (so both new-agent `[agent,workspace,graft,...]` and add-items `[agent,graft,...]` prev shapes work), plus `SetDefaultWorkspace` so the splicer can seed `installedAgent.Workspace` when Ground is skipped.
- `internal/tui/addflow/observe_test.go` — new `TestObserve_SetPriorAddItemsShape`.
- `internal/tui/addflow/addflow.go` — added `StageIdxConflicts = 5` + StageLabels row `衝 しょう CONFLICT`. Yield shifts to idx 6.
- `internal/tui/initflow/design.go` — real `ConflictRowStyle(tone)` body (Keep=Success/leaf, Overwrite=Danger/ember, Backup=Warning/amber) + `ConflictActionGlyph(tone)`. Phase 1 stub replaced.
- `internal/config/lockfile.go` — new `ConflictAction` enum (Keep / Overwrite / Backup) — the payload shape used by `ConflictsStage.Result()` + `applyCinematicConflictPicks`.
- `cmd/add_redesign.go`:
  - Add-items splicer now returns `[AddItemsGraft, Observe]`. Ground skipped; `AgentDisplay` + `SetDefaultWorkspace` stamped from installed agent.
  - `buildAddGrowAction` handles both branches via type-scan for `GraftResult` in prev[]. Add-items arm mirrors `runAddSpinner` exactly — uses `availableAddItems` to shape picks so `distributeAddItemPicks` (shared helper) produces bit-identical category slices.
  - Conflict slot now splices `[NewConflictsStage(ctx, &wr)]` (was legacy `buildConflictSteps`). New `applyCinematicConflictPicks` consumes the `map[string]config.ConflictAction` result post-harness — legacy `applyConflictPicks` untouched (still used by remove/update/legacy add).

## Deviations

- **Conflicts stage label** — followed the brief's preferred option: extended `addflow.StageLabels` with `衝 しょう CONFLICT` at new index 5, pushed Yield to 6. Rail reflects Conflicts as current when that stage renders.
- **`config.ConflictAction` type** — not pre-existing. Added to `internal/config/lockfile.go` since the plan explicitly calls for `map[string]config.ConflictAction` as the stage's Result type. Minimal addition; no other code affected.
- **Diff summary placeholder** — `generate.FileResult` has no inline-diff field today, so `renderDiffSummary` emits a stable "local has edits · source has changes" line plus the source path, with a TODO comment calling out the need for a real diff. Consistent with plan §Deliverables 2 which allowed the placeholder.
- **Observe `SetPrior` refactor** — switched from positional indexing to type-scan so the same stage handles both branches without a branch-specific ctor. Also added `SetDefaultWorkspace` so the splicer can seed the installed agent's workspace where Ground is skipped.

## Plan

`station/Playbook/Plans/Active/23-uiux-phase2-add.md` (Phase 2 section)

## Verification

- [x] `gofmt -l cmd/ internal/` — clean
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass (including 9 new `conflicts_test.go` cases + 2 new graft tests + 1 new observe test)
- [x] `golangci-lint run ./...` — 0 issues
- [x] `grep -rnE '#[0-9A-Fa-f]{6}' internal/tui/addflow/` — 0 hits (palette tokens only)
- [ ] Manual smoke test of `BONSAI_ADD_REDESIGN=1 ./bonsai add` sequence — interactive TUI, not feasible in a non-TTY subagent session. Unit tests cover stage transitions + Result shapes; end-to-end dogfood belongs to the Tech Lead's review loop.

## Notes

- Phase 1's `NewYieldAddItemsDeferred` variant + `yieldModeAddItemsDeferred` enum are now unused by the splicer (add-items routes to the real pipeline) but are kept in `yield.go` with their tests — Phase 3 removes them as part of the legacy-delete sweep.
- The `conflictsPressKey` test helper uses `tea.KeyType`; `conflictsPressRune` was unused so omitted.