### PR TITLE
docs(readme): credit llm-wiki as inspiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ station/
     └── Routines/            ← scheduled self-maintenance tasks
 ```
 
+### Where the idea comes from
+
+Bonsai's workspace model is directly inspired by Andrej Karpathy's [**llm-wiki**](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — the proposal that LLMs should *maintain* a markdown knowledge base incrementally, so context compounds across sessions instead of being re-retrieved from raw sources on every query.
+
+`station/` applies that to a single project: the agent's wiki about its own codebase, its own work, and its own decisions.
+
 ---
 
 ## Install


### PR DESCRIPTION
## Summary

Adds a brief "Where the idea comes from" subsection at the end of `## Who Bonsai is for`, crediting Andrej Karpathy's [llm-wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) as the conceptual parent for Bonsai's agent-maintained markdown workspace.

Two short paragraphs — one line on the idea (LLM incrementally maintains markdown knowledge, context compounds across sessions), one line framing `station/` as that idea scoped to a single project.

## Changes

- `README.md` — +6 lines (new `### Where the idea comes from` subsection between the `station/` tree snippet and `## Install`).

## Verification

- [x] Link resolves (gist is public).
- [x] Section renders as a sub-heading of `## Who Bonsai is for`, not a top-level section.
- [x] Tone matches the rest of the rewritten README (mechanism-forward, no marketing filler).