### PR TITLE
docs(audit): pre-release v0.2.0 cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.3] — 2026-04-15
+## [0.2.0] - 2026-04-22
+
+### Added
+- Cinematic `bonsai init` flow — Vessel (project name + docs path) → Soil (scaffolding) → Branches (tabbed ability picker) → Observe (review) → Generate → Planted summary, with kanji/kana stage rail, semantic palette, responsive resize, and ASCII fallback for terminals without wide-char support.
+- Cinematic `bonsai add` flow — Select → [Ground] → Graft → Observe → Grow → [Conflicts] → Yield, with a per-file conflict picker (Skip / Overwrite / Backup) and four terminal Yield variants (success, all-installed, tech-lead-required, unknown-agent).
+- Persistent statusline at `station/agent/Sensors/statusline.sh` — context %, 5h and 7d budget %, model, branch (with dirty marker), elapsed, cost, plus optional caveman-mode badge; sage/sand/rose 256-color tiers with `NO_COLOR` and `BONSAI_STATUSLINE_HIDE` honoured.
+- `compact-recovery` sensor — re-injects Quick Triggers and work state after `/compact` so the agent doesn't lose its operating context.
+- `context-guard` patterns expanded — verify and plan triggers in addition to existing tier-based context-percentage injections.
+- Trigger metadata system — `triggers:` blocks on skills/workflows feed both generated CLAUDE.md tables and `.claude/skills/{name}/SKILL.md` slash commands.
+- Starlight documentation site under `website/` — concepts, command reference, catalog browser (auto-generated), LLM-friendly llms.txt layer, deploy workflow.
+- `bonsai guide` extended from a single topic to four — `quickstart`, `concepts`, `cli`, `custom-files`.
+- `RenderFileTree` widget and palette chrome tokens (`ColorLeafDim`, `ColorRule`, `ColorRule2`, `ColorAccent`) used across the cinematic flows.
+
+### Changed
+- BubbleTea step/reducer harness in `internal/tui/harness/` is now the foundation for `init`, `add`, `remove`, and `update` — replaces the per-command Huh form chains.
+- README rewritten audience-first — new tagline "A workspace for your coding agent", `Who Bonsai is for` section, mechanism-over-personality bullets with concrete file references, `station/` tree snippet, demo gif.
+- `bonsai init` and `bonsai add` cinematic flows are now the default — no env flag required.
+- Adaptive color palette across the TUI — automatic light/dark detection, `NO_COLOR` honoured, `FatalPanel` and version banner consistency, structured error display via `ErrorDetail`.
+- Phase 2 UI consistency pass — ordering, item counts, key hints, "Up to date" no-op detection across pickers.
+- CI workflow widened to run on `push: branches: [main]` in addition to `pull_request` — closes the "gofmt drift on main silently hides because CI is PR-only" pattern.
+- `docs.yml` deploy workflow gains `pull_request` trigger (with deploy job guarded to push events) so broken MDX fails at PR time instead of post-merge.
+- `bonsai` binary now builds from `cmd/bonsai/main.go` so `go install github.com/LastStep/Bonsai/cmd/bonsai@latest` produces the correct lowercase binary name.
+- Go toolchain bumped to 1.25.8.
+- golangci-lint migrated from v1 to v2.
+
+### Removed
+- `BONSAI_REDESIGN` env gate — cinematic `bonsai init` is the only path; legacy harness body deleted.
+- `BONSAI_ADD_REDESIGN` env gate — cinematic `bonsai add` is the only path; legacy `runAddSpinner`, `buildNewAgentSteps`, `buildAddItemsSteps`, and `addOutcome` deleted.
+- Three orphan legacy guide topics (1,213 lines) replaced by the four-topic `bonsai guide` set.
+
+### Fixed
+- Plan 19 OSS-blocker bug sweep — CRLF handling on Windows checkouts, cross-workspace tree rendering, ability dedup across agents, spinner-step `errors.Join` so concurrent failures surface, and assorted harness polish.
+- `bonsai init` Planted stage shows the correct station path and the Observe stage no longer reports a misleading file count.
+- `chmod` is now re-applied on `ActionUnchanged` so sensor scripts stay executable across re-runs.
+- `.bak` write failures no longer silently discard files in the conflict picker — failed-backup paths are dropped from the overwrite list and a single warning is emitted.
+- Doubled path prefix in `bonsai add` output panels.
+
+### Security
+- CodeQL workflow added for Go SAST.
+- `govulncheck` job added to CI.
+- Dependabot configured for `gomod` and `github-actions`.
+- Two low-severity CodeQL `useless-assignment-to-local` alerts silenced after audit.
+- Astro XSS advisory (CVE-2026-41067) resolved by lockfile bump to `astro@6.1.7`.
+
+## [0.1.3] — 2026-04-16
 ### Changed
 - Apply `gofmt -s` across all Go source files for canonical formatting.
 
-## [0.1.2] — 2026-04-15
+## [0.1.2] — 2026-04-16
 ### Fixed
 - Restore Go Reference badge now that case-collision module-proxy issue is resolved.
 - Retract v0.1.0 release notice (see v0.1.1 fix).
 
-## [0.1.1] — 2026-04-15
+## [0.1.1] — 2026-04-16
 ### Added
 - Obsidian-compatible markdown links across generated workspace files (`[[link]]` syntax in nav tables and cross-references).
 - `workspace-guide` skill — installed with every agent to onboard humans into the generated workspace.
@@ -27,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI badge and Go version badge corrections in README.
 - Reverted stray `INSTRUCT` reference to backtick in memory protocol.
 
-## [0.1.0] — 2026-04-15
+## [0.1.0] — 2026-04-16
 
 First public release. Go CLI for scaffolding Claude Code agent workspaces.
 
@@ -47,7 +91,8 @@ First public release. Go CLI for scaffolding Claude Code agent workspaces.
 - Release pipeline — GoReleaser v2, GitHub Actions tag trigger, Homebrew tap (`LastStep/homebrew-tap`).
 - Dogfooding — Bonsai generates its own `station/` workspace with tech-lead agent.
 
-[Unreleased]: https://github.com/LastStep/Bonsai/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/LastStep/Bonsai/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/LastStep/Bonsai/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/LastStep/Bonsai/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/LastStep/Bonsai/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/LastStep/Bonsai/compare/v0.1.0...v0.1.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing to Bonsai! This guide covers everything
 
 ## Development Setup
 
-**Requirements:** Go 1.24+
+**Requirements:** Go 1.25+
 
 ```bash
 git clone https://github.com/LastStep/Bonsai.git

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Rohan Yadav
+Copyright (c) 2025-2026 Rohan Yadav
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ curl -sL https://github.com/LastStep/Bonsai/releases/latest/download/bonsai_Linu
 sudo mv bonsai /usr/local/bin/
 ```
 
-**From source** (Go 1.24+):
+**From source** (Go 1.25+):
 
 ```bash
 go install github.com/LastStep/Bonsai/cmd/bonsai@latest

--- a/catalog/skills/review-checklist/meta.yaml
+++ b/catalog/skills/review-checklist/meta.yaml
@@ -1,6 +1,6 @@
 name: review-checklist
 description: Structured code review checklist — correctness, security, performance, maintainability
-agents: [reviewer, security, tech-lead]
+agents: [security, tech-lead]
 triggers:
   scenarios:
     - Performing a structured code review

--- a/catalog/skills/test-strategy/meta.yaml
+++ b/catalog/skills/test-strategy/meta.yaml
@@ -1,6 +1,6 @@
 name: test-strategy
 description: Test architecture — which tests to write, when, and why; pyramid, coverage, anti-patterns
-agents: [backend, frontend, fullstack, qa]
+agents: [backend, frontend, fullstack]
 triggers:
   scenarios:
     - Defining the overall testing approach for a feature or module

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,18 @@
 # docs/
 
-Markdown files in this folder are embedded into the `bonsai` binary and rendered
-by `bonsai guide`. Current topics: `quickstart`, `concepts`, `cli`, `custom-files`.
+Terminal-rendered cheatsheets for the `bonsai` CLI.
 
-Full user documentation (tutorials, reference, catalog browser) lives on the
-Starlight site: <https://laststep.github.io/Bonsai/>. Source under [`website/`](../website/).
+`quickstart.md`, `concepts.md`, `cli.md`, and `custom-files.md` are embedded
+into the binary at build time via `embed.go` and surfaced through
+`bonsai guide <topic>`. They are the stripped-down, terminal-friendly subset
+of the project documentation.
 
-`docs/assets/` holds images referenced from `README.md`.
+The full reference — tutorials, catalog browser, API surface, deeper guides —
+lives at the Starlight site: <https://laststep.github.io/Bonsai/> (sources in
+[`website/`](../website/)).
+
+This is not duplication. The terminal needs short, scannable text without
+images or wide tables; the website expands the same topics with full prose,
+diagrams, and cross-links. When a concept changes, update both.
+
+`docs/assets/` holds images referenced from the repo `README.md`.

--- a/station/Playbook/Plans/Archive/23-uiux-phase2-add.md
+++ b/station/Playbook/Plans/Archive/23-uiux-phase2-add.md
@@ -1,7 +1,7 @@
 # Plan 23 — UI/UX Overhaul Phase 2: `bonsai add` Cinematic Port
 
 **Tier:** 2 (Feature)
-**Status:** Draft
+**Status:** Complete
 **Agent:** general-purpose (worktree isolation)
 **Source:** User request 2026-04-22 — Plan 22 complete; UI overhaul moves from `init` to the remaining user-facing commands. `bonsai add` is iteration 1 (closest shape match to init, highest post-init traffic).
 

--- a/station/code-index.md
+++ b/station/code-index.md
@@ -9,7 +9,7 @@ Quick-nav for the developer agent. Jump to what you need.
 | What | Where |
 |------|-------|
 | Embed catalog FS | `embed.go:8` — `//go:embed all:catalog` → `CatalogFS` |
-| Embed guide cheatsheets | `embed.go:11–20` — `GuideCustomFiles`, `GuideQuickstart`, `GuideConcepts`, `GuideCli` |
+| Embed guide cheatsheets | `embed.go:11–21` — `GuideCustomFiles`, `GuideQuickstart`, `GuideConcepts`, `GuideCli` |
 | Main | `cmd/bonsai/main.go:15` — `main()` → `cmd.Execute(sub, map[string]string{...})` |
 
 ---
@@ -18,40 +18,56 @@ Quick-nav for the developer agent. Jump to what you need.
 
 | Command | File | Entry Function |
 |---------|------|----------------|
-| `bonsai` (root) | `cmd/root.go:27` | `rootCmd` — shared helpers below |
-| `bonsai init` | `cmd/init.go:28` | `runInit()` — creates `.bonsai.yaml`, scaffolding, settings |
-| `bonsai add` | `cmd/add.go:57` | `runAdd()` — interactive wizard → agent type, workspace, items → generates files |
-| `bonsai remove` | `cmd/remove.go:39` | `runRemove()` — removes agent or individual items |
-| `bonsai list` | `cmd/list.go:24` | `runList()` — table of installed agents + components |
-| `bonsai catalog` | `cmd/catalog.go:20` | `runCatalog()` — browse available agents, skills, workflows, etc. |
-| `bonsai update` | `cmd/update.go:28` | `runUpdate()` — detect custom files, re-render abilities, refresh CLAUDE.md |
-| `bonsai guide` | `cmd/guide.go:22` | `runGuide()` — render custom files guide in terminal |
+| `bonsai` (root) | `cmd/root.go:28` | `rootCmd` — shared helpers below |
+| `bonsai init` | `cmd/init.go:11` | `initCmd` → `runInit()` in `cmd/init_flow.go:26` — cinematic init flow |
+| `bonsai add` | `cmd/add.go:26` | `addCmd` → `runAdd()` in `cmd/add.go:54` — cinematic add flow |
+| `bonsai remove` | `cmd/remove.go:32` | `runRemove()` — removes agent or individual items |
+| `bonsai list` | `cmd/list.go:19` | `runList()` — table of installed agents + components |
+| `bonsai catalog` | `cmd/catalog.go:16` | `runCatalog()` — browse available agents, skills, workflows, etc. |
+| `bonsai update` | `cmd/update.go:22` | `runUpdate()` — detect custom files, re-render abilities, refresh CLAUDE.md |
+| `bonsai guide` | `cmd/guide.go:34` | `guideCmd` → `runGuide()` at `:42` — render embedded docs in terminal |
 
 ### Shared Helpers (`cmd/root.go`)
 
 | Helper | Line | Purpose |
 |--------|------|---------|
-| `loadCatalog()` | `:32` | Load embedded catalog or exit |
-| `requireConfig()` | `:41` | Load `.bonsai.yaml` or exit |
-| `resolveConflicts()` | `:65` | TUI for handling user-modified files (skip / overwrite / backup) |
-| `showWriteResults()` | `:107` | Display categorized file trees (created / updated / skipped) |
+| `loadCatalog()` | `:42` | Load embedded catalog or exit |
+| `requireConfig()` | `:50` | Load `.bonsai.yaml` or exit |
+| `mustCwd()` | `:61` | Resolve current working dir or exit |
+| `Execute()` | `:80` | Wire catalog + guides into root command and run |
+| `buildConflictSteps()` | `:101` | Harness steps for legacy conflict picker |
+| `applyConflictPicks()` | `:147` | Apply per-file conflict choices to lock + disk |
+| `showWriteResults()` | `:198` | Display categorized file trees (created / updated / skipped) |
+
+### Init Helpers (`cmd/init_flow.go`)
+
+| Helper | Line | Purpose |
+|--------|------|---------|
+| `runInit()` | `:26` | Cinematic init: Vessel → Soil → Branches → Observe → Generate → Planted |
+| `buildGenerateAction()` | `:206` | Closure invoked by GenerateStage to write scaffolding + agent |
+| `plantedSummary()` | `:277` | Ability counts rendered in the Planted stage summary |
+| `scaffoldingToSoilOptions()` | `:292` | Map catalog scaffolding entries into Soil picker options |
 
 ### Add Helpers (`cmd/add.go`)
 
 | Helper | Line | Purpose |
 |--------|------|---------|
-| `toItemOptions()` | `:29` | Convert `CatalogItem` slice to TUI picker options |
-| `toSensorOptions()` | `:37` | Convert `SensorItem` slice to TUI picker options |
-| `toRoutineOptions()` | `:45` | Convert `RoutineItem` slice to TUI picker options |
+| `runAdd()` | `:54` | Cinematic add: Select → [Ground] → Graft → Observe → Grow → [Conflicts] → Yield |
+| `applyCinematicConflictPicks()` | `:293` | Apply per-file conflict choices from ConflictsStage |
+| `installedSet()` | `:349` | Build "already installed" lookup for agent picker |
+| `buildAddGrowAction()` | `:371` | Closure invoked by GrowStage to generate selected abilities |
+| `distributeAddItemPicks()` | `:531` | Split per-category picks into skills/workflows/protocols/sensors/routines |
+| `availableAddItems()` | `:616` | Uninstalled-per-category catalog filter (used by Select + Grow) |
 
 ### Remove Helpers (`cmd/remove.go`)
 
 | Helper | Line | Purpose |
 |--------|------|---------|
-| `runRemoveItem()` | `:198` | Remove a single skill/workflow/protocol/sensor/routine |
-| `agentItemList()` | `:366` | Get an agent's installed items by type |
-| `itemIsRequired()` | `:415` | Check if item is required for agent type |
-| `itemDisplayName()` | `:441` | Look up display name from catalog |
+| `runRemoveItem()` | `:248` | Remove a single skill/workflow/protocol/sensor/routine |
+| `runRemoveItemAction()` | `:466` | Execute removal + regenerate affected agents |
+| `agentItemList()` | `:519` | Get an agent's installed items by type |
+| `itemIsRequired()` | `:568` | Check if item is required for agent type |
+| `itemDisplayName()` | `:594` | Look up display name from catalog |
 
 ---
 
@@ -75,8 +91,8 @@ Quick-nav for the developer agent. Jump to what you need.
 
 | Function | Line | Purpose |
 |----------|------|---------|
-| `DisplayNameFrom()` | `:14` | Convert kebab-case name to title-case display name |
-| `New(fsys)` | `:177` | Load full catalog from embedded FS |
+| `DisplayNameFrom()` | `:49` | Convert kebab-case name to title-case display name |
+| `New(fsys)` | `:220` | Load full catalog from embedded FS |
 
 ### Lookup Methods on `Catalog`
 
@@ -100,11 +116,11 @@ Quick-nav for the developer agent. Jump to what you need.
 
 | Function | Line | Purpose |
 |----------|------|---------|
-| `loadItems()` | `:281` | Load skills/workflows/protocols from `meta.yaml` + `.md` |
-| `loadSensors()` | `:332` | Load sensors from `meta.yaml` + `.sh.tmpl` |
-| `loadRoutines()` | `:383` | Load routines from `meta.yaml` + `.md.tmpl` |
-| `loadScaffolding()` | `:434` | Load scaffolding from `manifest.yaml` |
-| `loadAgents()` | `:451` | Load agent defs from `agent.yaml` + `core/` |
+| `loadItems()` | `:324` | Load skills/workflows/protocols from `meta.yaml` + `.md` |
+| `loadSensors()` | `:375` | Load sensors from `meta.yaml` + `.sh.tmpl` |
+| `loadRoutines()` | `:426` | Load routines from `meta.yaml` + `.md.tmpl` |
+| `loadScaffolding()` | `:477` | Load scaffolding from `manifest.yaml` |
+| `loadAgents()` | `:494` | Load agent defs from `agent.yaml` + `core/` |
 
 ---
 
@@ -130,7 +146,8 @@ Quick-nav for the developer agent. Jump to what you need.
 | `ContentHash()` | `:62` | SHA-256 hash of file content |
 | `Track()` | `:68` | Record file path + hash + source |
 | `Untrack()` | `:76` | Remove file from tracking |
-| `IsModified()` | `:84` | Check if file has changed since generation |
+| `ConflictAction` | `:86` | Enum — Skip / Overwrite / Backup choices for conflicted files |
+| `IsModified()` | `:103` | Check if file has changed since generation |
 
 ---
 
@@ -140,41 +157,42 @@ Quick-nav for the developer agent. Jump to what you need.
 
 | Function | Line | Purpose |
 |----------|------|---------|
-| `Scaffolding()` | `:332` | Generate INDEX.md, Playbook/, Logs/, Reports/ |
-| `SettingsJSON()` | `:439` | Generate `.claude/settings.json` with sensor hooks |
-| `WorkspaceClaudeMD()` | `:615` | Generate workspace `CLAUDE.md` with nav tables |
-| `AgentWorkspace()` | `:1159` | Full agent workspace — core templates + items + CLAUDE.md |
-| `RoutineDashboard()` | `:884` | Generate `agent/Core/routines.md` dashboard |
-| `EnsureRoutineCheckSensor()` | `:846` | Auto-manage routine-check sensor |
-| `PathScopedRules()` | `:1032` | Generate `.claude/rules/skill-{name}.md` for path-scoped auto-loading |
-| `WorkflowSkills()` | `:1070` | Generate `.claude/skills/{name}/SKILL.md` for curated workflows |
+| `Scaffolding()` | `:359` | Generate INDEX.md, Playbook/, Logs/, Reports/ |
+| `SettingsJSON()` | `:466` | Generate `.claude/settings.json` with sensor hooks |
+| `WorkspaceClaudeMD()` | `:642` | Generate workspace `CLAUDE.md` with nav tables |
+| `AgentWorkspace()` | `:1216` | Full agent workspace — core templates + items + CLAUDE.md |
+| `RoutineDashboard()` | `:917` | Generate `agent/Core/routines.md` dashboard |
+| `EnsureRoutineCheckSensor()` | `:879` | Auto-manage routine-check sensor |
+| `PathScopedRules()` | `:1065` | Generate `.claude/rules/skill-{name}.md` for path-scoped auto-loading |
+| `WorkflowSkills()` | `:1103` | Generate `.claude/skills/{name}/SKILL.md` for curated workflows |
 
 ### Write System
 
 | Type / Function | Line | Purpose |
 |-----------------|------|---------|
-| `WriteResult` | — | Tracks all file operations (created, updated, skipped, conflict) |
-| `FileResult` | — | Single file operation result |
-| `writeFile()` | `:258` | Lock-aware file write (detects conflicts) |
-| `writeFileChmod()` | `:290` | Same as writeFile but sets file permissions (for scripts) |
-| `ForceConflicts()` | `:208` | Overwrite all conflicted files |
-| `ForceSelected()` | `:230` | Overwrite only user-selected conflict files |
+| `FileAction` | `:140` | Enum — Create / Update / Unchanged / Skipped / Conflict |
+| `FileResult` | `:152` | Single file operation result |
+| `WriteResult` | `:161` | Tracks all file operations (created, updated, skipped, conflict) |
+| `writeFile()` | `:276` | Lock-aware file write (detects conflicts) |
+| `writeFileChmod()` | `:316` | Same as writeFile but sets file permissions (for scripts) |
+| `ForceConflicts()` | `:212` | Overwrite all conflicted files |
+| `ForceSelected()` | `:234` | Overwrite only user-selected conflict files |
 
 ### Helpers
 
 | Function | Line | Purpose |
 |----------|------|---------|
-| `titleCase()` | `:46` | Custom template func — capitalize each word |
-| `renderTemplate()` | `:63` | Render a `.tmpl` file with Go template |
-| `renderContent()` | `:303` | Render or copy file content based on `.tmpl` extension |
-| `descFor()` | `:79` | Build name→description map for nav tables (supports custom items) |
-| `scenariosDesc()` | `:117` | Trigger-aware description for CLAUDE.md tables |
-| `CuratedSlashWorkflows` | `:130` | Package-level set of workflows that get slash-command files |
-| `hasScaffolding()` | `:318` | Check if scaffolding item is selected |
-| `howToWorkLines()` | `:518` | Generate "How to Work" heuristics section |
-| `quickTriggersLines()` | `:573` | Generate Quick Triggers reference table |
-| `triggerSection()` | `:1122` | Generate trigger header for ability files |
-| `parseFrequencyDays()` | `:872` | Parse frequency string (e.g. "5 days") to int |
+| `titleCase()` | `:47` | Custom template func — capitalize each word |
+| `renderTemplate()` | `:64` | Render a `.tmpl` file with Go template |
+| `renderContent()` | `:330` | Render or copy file content based on `.tmpl` extension |
+| `descFor()` | `:80` | Build name→description map for nav tables (supports custom items) |
+| `scenariosDesc()` | `:118` | Trigger-aware description for CLAUDE.md tables |
+| `CuratedSlashWorkflows` | `:131` | Package-level set of workflows that get slash-command files |
+| `hasScaffolding()` | `:345` | Check if scaffolding item is selected |
+| `howToWorkLines()` | `:545` | Generate "How to Work" heuristics section |
+| `quickTriggersLines()` | `:600` | Generate Quick Triggers reference table |
+| `triggerSection()` | `:1155` | Generate trigger header for ability files |
+| `parseFrequencyDays()` | `:905` | Parse frequency string (e.g. "5 days") to int |
 
 ### `frontmatter.go` — Custom File Parsing
 
@@ -197,28 +215,75 @@ Quick-nav for the developer agent. Jump to what you need.
 
 | Function | Line | Purpose |
 |----------|------|---------|
-| `Banner()` | `:77` | Bonsai ASCII banner |
-| `Success/Error/Warning/Hint/Info()` | `:97–117` | Styled single-line messages |
-| `Heading/Section/SectionHeader()` | `:122–132` | Section headers |
-| `SuccessPanel/ErrorPanel/WarningPanel/InfoPanel()` | `:141–164` | Boxed panels |
-| `EmptyPanel()` | `:167` | Dim panel for empty states |
-| `TitledPanel()` | `:172` | Generic titled box with custom color |
-| `Fields()` | `:220` | Key-value pair display |
-| `CardFields()` | `:235` | Card-style key-value (returns string) |
-| `ItemTree()` | `:266` | Categorized tree view (for catalog/list output) |
-| `FileTree()` | `:311` | File tree view (for write results) |
-| `CatalogTable()` | `:369` | Table display for catalog command |
+| `Banner()` | `:152` | Bonsai ASCII banner |
+| `Success/Error/Warning/Hint/Info()` | `:187–221` | Styled single-line messages |
+| `Heading/Section/SectionHeader()` | `:226–236` | Section headers |
+| `SuccessPanel/ErrorPanel/WarningPanel/InfoPanel()` | `:245–289` | Boxed panels |
+| `EmptyPanel()` | `:297` | Dim panel for empty states |
+| `TitledPanel()` | `:376` | Generic titled box with custom color |
+| `Fields()` | `:383` | Key-value pair display |
+| `CardFields()` | `:398` | Card-style key-value (returns string) |
+| `ItemTree()` | `:429` | Categorized tree view (for catalog/list output) |
+| `FileTree()` | `:475` | File tree view (for write results) |
+| `CatalogTable()` | `:533` | Table display for catalog command |
 
 ### Prompts (`prompts.go`)
 
 | Function | Line | Purpose |
 |----------|------|---------|
 | `BonsaiTheme()` | `:12` | Custom Huh form theme |
-| `AskText()` | `:62` | Text input prompt |
-| `AskSelect()` | `:92` | Single-select prompt |
-| `AskMultiSelect()` | `:106` | Multi-select prompt |
-| `AskConfirm()` | `:120` | Yes/no confirmation |
-| `PickItems()` | `:138` | Multi-select with pre-selected defaults + required items |
+| `AskText()` | `:66` | Text input prompt |
+| `AskSelect()` | `:96` | Single-select prompt |
+| `AskMultiSelect()` | `:110` | Multi-select prompt |
+| `AskConfirm()` | `:124` | Yes/no confirmation |
+| `PickItems()` | `:142` | Multi-select with pre-selected defaults + required items |
+
+### Harness (`harness/`) — step/reducer runtime for cinematic flows
+
+| Function / Type | Line | Purpose |
+|-----------------|------|---------|
+| `Step` interface | `harness.go:49` | Contract every flow stage implements (Title/Done/Result/Update/View) |
+| `Harness` | `harness.go:116` | BubbleTea reducer that drives a linear list of Steps |
+| `Run()` | `harness.go:523` | Build + run a Harness, return per-step results or `ErrAborted` |
+| `TextStep` | `steps.go:21` | Huh-backed text-input step |
+| `SelectStep` | `steps.go:135` | Huh-backed single-select step |
+| `MultiSelectStep` | `steps.go:193` | Huh-backed multi-select step (supports required + defaults) |
+| `ConfirmStep` / `ReviewStep` / `NoteStep` | `steps.go` | Confirmation, review-table, and static-note steps |
+| `SpinnerStep` | `steps.go` | Long-running action with spinner; captures action error |
+| `Conditional` / `Lazy` / `LazyGroup` | `steps.go` / `harness.go` | Predicate-gated, deferred, and splicing step wrappers |
+
+### InitFlow (`initflow/`) — `bonsai init` cinematic stages
+
+| Stage / File | Entry | Purpose |
+|--------------|-------|---------|
+| `VesselStage` | `vessel.go:48` | Project name + docs_path text inputs |
+| `SoilStage` | `soil.go:40` | Scaffolding multi-select (INDEX, Playbook, Logs, Reports) |
+| `BranchesStage` | `branches.go:88` | Tabbed ability picker (skills/workflows/protocols/sensors/routines) |
+| `ObserveStage` | `observe.go:56` | Pre-generation confirm — project + planting summary |
+| `GenerateStage` | `generate.go` | Spinner stage running `GenerateAction` closure |
+| `PlantedStage` | `planted.go:54` | Post-generation summary + written file tree |
+| Chrome | `chrome.go:41` / `:129` | `RenderHeader()` / `RenderFooter()` — kanji rail + key hints |
+| Layout | `layout.go:21` / `:48` / `:106` | `TerminalTooSmall`, `ClampColumns`, `Viewport` scroll helper |
+| Design tokens | `design.go:29` | `PanelWidth`, focused/unfocused styles, conflict tone palette |
+| Fallback | `fallback.go:33` / `:87` | `WideCharSafe()` detection + `StageLabels` (kanji + ASCII pair) |
+| Enso glyph | `enso.go` | Circle SVG-ish glyph rendered in chrome |
+| `StageContext` | `stage.go:258` | Shared context threaded into every stage (version, dirs, timings) |
+| `Stage` base | `stage.go:22` | Embedded helper for rail, size, title, done state |
+
+### AddFlow (`addflow/`) — `bonsai add` cinematic stages
+
+| Stage / File | Entry | Purpose |
+|--------------|-------|---------|
+| `SelectStage` | `select.go:34` | Agent type picker (marks already-installed) |
+| `GroundStage` | `ground.go:48` | Workspace path input (auto-complete for tech-lead) |
+| `GraftStage` | `graft.go:76` / `:84` | Tabbed ability picker — `NewAgent` or `AddItems` variant |
+| `ObserveStage` | `observe.go:43` | Pre-generation confirm — agent + abilities summary |
+| `GenerateStage` | `grow.go:16` | Wraps `initflow.GenerateStage` with add-specific copy |
+| `ConflictsStage` | `conflicts.go:53` | Per-file conflict picker (Skip / Overwrite / Backup) |
+| `YieldStage` | `yield.go:57–85` | Terminal outcomes: Success, AllInstalled, TechLeadRequired, UnknownAgent |
+| `StageLabels` | `addflow.go:49` | Per-stage kanji rail labels (SELECT / GROUND / GRAFT / …) |
+| `BuildAgentOptions()` | `select.go:57` | Catalog → `AgentOption` list with installed markers |
+| `NormaliseWorkspace()` | `ground.go:226` | Trim + slash-normalise user-entered workspace path |
 
 ---
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Bonsai',
-      description: 'A structured language for working with AI agents',
+      description: 'A workspace for your coding agent',
       social: [
         {
           icon: 'github',

--- a/website/public/catalog.json
+++ b/website/public/catalog.json
@@ -1,11 +1,11 @@
 {
-  "generated": "2026-04-16T21:04:30.212Z",
+  "generated": "2026-04-22T12:51:29.722Z",
   "counts": {
     "agents": 6,
     "skills": 17,
     "workflows": 10,
     "protocols": 4,
-    "sensors": 12,
+    "sensors": 13,
     "routines": 8
   },
   "agents": [
@@ -747,6 +747,14 @@
       "required": null
     },
     {
+      "name": "compact-recovery",
+      "description": "Re-injects minimal context after /compact (Quick Triggers + Work State only)",
+      "agents": "all",
+      "event": "SessionStart",
+      "matcher": "compact",
+      "required": "all"
+    },
+    {
       "name": "context-guard",
       "description": "Injects context-aware behavioral constraints and detects session wrap-up trigger words before each prompt",
       "agents": "all",
@@ -806,7 +814,7 @@
       "description": "Injects core identity, memory, protocols, and project status at session start",
       "agents": "all",
       "event": "SessionStart",
-      "matcher": null,
+      "matcher": "startup|resume|clear",
       "required": "all"
     },
     {

--- a/website/src/content/docs/catalog/overview.mdx
+++ b/website/src/content/docs/catalog/overview.mdx
@@ -32,7 +32,7 @@ The Bonsai catalog is the embedded collection of agents, abilities, and automati
     [Browse protocols](/Bonsai/catalog/protocols/)
   </Card>
   <Card title="Sensors" icon="seti:config">
-    **12 sensors** — Automated hook scripts that enforce boundaries, inject context, review output, and monitor code quality.
+    **13 sensors** — Automated hook scripts that enforce boundaries, inject context, review output, and monitor code quality.
 
     [Browse sensors](/Bonsai/catalog/sensors/)
   </Card>

--- a/website/src/content/docs/catalog/sensors.mdx
+++ b/website/src/content/docs/catalog/sensors.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sensors Catalog
-description: All 12 Bonsai sensors — automated hook scripts that enforce boundaries, inject context, review output, and guard code quality.
+description: All 13 Bonsai sensors — automated hook scripts that enforce boundaries, inject context, review output, and guard code quality.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -18,13 +18,14 @@ Sensors marked as **required** are auto-installed for all compatible agents and 
 |:-----|:-----------|:------|:--------|:-----------------|:---------|
 | agent-review | Outputs a review checklist after a dispatched agent completes work | PostToolUse | Agent | tech-lead | No |
 | api-security-check | Detects security anti-patterns in code changes — SQL injection, hardcoded secrets, eval, CORS wildcards | PreToolUse | Edit|Write | backend, fullstack, security | No |
+| compact-recovery | Re-injects minimal context after /compact (Quick Triggers + Work State only) | SessionStart | compact | all | Yes (all) |
 | context-guard | Injects context-aware behavioral constraints and detects session wrap-up trigger words before each prompt | UserPromptSubmit |  | all | Yes (all) |
 | dispatch-guard | Validates code agent dispatches — requires worktree isolation, plan reference, and plan existence before execution | PreToolUse | Agent | tech-lead | No |
 | iac-safety-guard | Blocks dangerous infrastructure commands — terraform destroy, kubectl delete namespace, unsafe docker ops | PreToolUse | Bash | devops | No |
 | routine-check | Checks routine dashboard at session start and flags overdue maintenance routines | SessionStart |  | all | Auto-managed |
 | scope-guard-commands | Blocks agent from running application execution commands (tests, builds, servers) | PreToolUse | Bash | security, tech-lead | No |
 | scope-guard-files | Blocks agent from editing files outside its workspace | PreToolUse | Edit|Write | all | Yes (all) |
-| session-context | Injects core identity, memory, protocols, and project status at session start | SessionStart |  | all | Yes (all) |
+| session-context | Injects core identity, memory, protocols, and project status at session start | SessionStart | startup|resume|clear | all | Yes (all) |
 | status-bar | Persistent status line showing context usage, session health, and git state after every response | Stop |  | all | Yes (all) |
 | subagent-stop-review | Outputs a structured review checklist when a dispatched agent finishes work | SubagentStop |  | tech-lead | No |
 | test-integrity-guard | Detects test quality issues — removed assertions, .skip/.only, empty test bodies, debug artifacts | PreToolUse | Edit|Write | backend, frontend, fullstack | No |

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Bonsai
-description: A structured language for working with AI agents. Give your Claude Code agents identity, memory, protocols, and purpose.
+description: A workspace for your coding agent. Give your Claude Code agents identity, memory, protocols, and purpose.
 template: splash
 hero:
   title: Bonsai
-  tagline: A structured language for working with AI agents
+  tagline: A workspace for your coding agent
   image:
     file: ../../assets/graph-view.png
   actions:
@@ -21,7 +21,7 @@ import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 ## The 6-Layer Architecture
 
-Bonsai treats agent instructions as a structured language — not a pile of markdown files, but a layered system with clear semantics.
+Bonsai gives your coding agent a workspace — not a pile of markdown files, but a layered system with clear semantics.
 
 <CardGrid>
   <Card title="Core" icon="star">

--- a/website/src/content/docs/why-bonsai.mdx
+++ b/website/src/content/docs/why-bonsai.mdx
@@ -13,7 +13,7 @@ And if you want multiple agents working in the same codebase? You're maintaining
 
 ## What Bonsai Does
 
-Bonsai treats agent instructions as a **structured language** — not a pile of markdown files, but a layered system with clear semantics:
+Bonsai gives your coding agent a **workspace** — not a pile of markdown files, but a layered system with clear semantics:
 
 ```
   Layer 6 │ Sensors       │ Automated enforcement via Claude Code hooks


### PR DESCRIPTION
## Summary

Pre-release docs audit fix-pass + v0.2.0 changelog cut. Bundles all P0 and P1 findings from a 4-surface audit (website, root community files, catalog, station/) plus P2 polish on code-index and docs/README.

**P0 — block-launch:**
- Sensor count drift: README + website now correctly say 13 (compact-recovery was added Plan 21, never propagated). `website/scripts/generate-catalog.mjs` re-run to sync `catalog.json` + `overview.mdx` + `sensors.mdx`.
- Tagline mechanical replace: \"structured language\" → \"workspace\" in `index.mdx` (3 spots), `astro.config.mjs`, `why-bonsai.mdx` — matches README PR #61 audience pivot.
- Invalid agent types stripped from `review-checklist` (`reviewer`) and `test-strategy` (`qa`) meta.yaml — neither agent type exists.

**P1:**
- `LICENSE` copyright `2025` → `2025-2026`
- `README` + `CONTRIBUTING` Go version `1.24+` → `1.25+` (matches `go.mod` 1.25.0)
- `station/CLAUDE.md.bak` deleted (gitignored leftover from Plan 01)
- `Plans/Archive/23-uiux-phase2-add.md` frontmatter `Status: Draft` → `Complete`

**P2:**
- `station/code-index.md` refreshed — drops deleted `cmd/add_redesign.go`, repoints `init_redesign.go` → `init_flow.go`, line-number drift fixes across catalog/generate/config/styles/prompts/root, adds tables for `internal/tui/harness/` + `initflow/` + `addflow/` (12 stages + 10 entry points were missing)
- `docs/README.md` rewritten to clarify embedded-binary vs Starlight-website split — answers \"why does this exist alongside website/?\"

**v0.2.0 release:**
- `CHANGELOG.md` `[Unreleased]` cut to `[0.2.0] - 2026-04-22`
- Curated entries grouped Added/Changed/Removed/Fixed/Security covering Plans 19-25 + statusLine + push-CI widening + binary path fix + Go bump
- v0.1.0–v0.1.3 dates backfilled `2026-04-15` → `2026-04-16` to match git tag creator dates
- Link refs rewired

**Plan 26 candidates filed (deferred from this PR per scope):**
- Full website concept-page rewrite (heavier framing pivot beyond mechanical tagline)
- Skills frontmatter convention decision (13 of 17 skills lack it; loader treats as cosmetic)

## Test plan

- [x] \`make build\` clean
- [x] \`go test -count=1 ./internal/catalog/ ./internal/generate/\` pass
- [x] \`cd website && npm run build\` — 45 pages, all internal links valid
- [ ] CI green (test/lint/Analyze Go/govulncheck/CodeQL/GitGuardian/Deploy Docs)
- [ ] Post-merge: tag \`v0.2.0\`, push tag, verify GoReleaser fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)