### PR TITLE
fix(plan-26): P2 knockoff bundle — 4 independent cleanups

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -326,7 +326,7 @@ func applyCinematicConflictPicks(picks map[string]config.ConflictAction,
 		}
 	}
 	if len(dropped) > 0 {
-		filtered := toOverwrite[:0]
+		filtered := make([]string, 0, len(toOverwrite)-len(dropped))
 		droppedList := make([]string, 0, len(dropped))
 		for _, rel := range toOverwrite {
 			if dropped[rel] {
@@ -529,7 +529,7 @@ func buildAddGrowAction(
 // order (skills → workflows → protocols → sensors → routines), so each take()
 // pulls from the slot that corresponds to the next non-empty category.
 func distributeAddItemPicks(cat *catalog.Catalog, installed *config.InstalledAgent, picks [][]string) (skills, workflows, protocols, sensors, routines []string) {
-	installedSet := func(items []string) map[string]bool {
+	installedItems := func(items []string) map[string]bool {
 		m := make(map[string]bool, len(items))
 		for _, item := range items {
 			m[item] = true
@@ -538,7 +538,7 @@ func distributeAddItemPicks(cat *catalog.Catalog, installed *config.InstalledAge
 	}
 	agentType := installed.AgentType
 	hasNew := func(available []catalog.CatalogItem, existing []string) bool {
-		have := installedSet(existing)
+		have := installedItems(existing)
 		for _, item := range available {
 			if !have[item.Name] {
 				return true
@@ -547,7 +547,7 @@ func distributeAddItemPicks(cat *catalog.Catalog, installed *config.InstalledAge
 		return false
 	}
 	hasNewSensor := func(available []catalog.SensorItem, existing []string) bool {
-		have := installedSet(existing)
+		have := installedItems(existing)
 		for _, item := range available {
 			if !have[item.Name] && item.Name != "routine-check" {
 				return true
@@ -556,7 +556,7 @@ func distributeAddItemPicks(cat *catalog.Catalog, installed *config.InstalledAge
 		return false
 	}
 	hasNewRoutine := func(available []catalog.RoutineItem, existing []string) bool {
-		have := installedSet(existing)
+		have := installedItems(existing)
 		for _, item := range available {
 			if !have[item.Name] {
 				return true
@@ -616,7 +616,7 @@ func (a availableAddSet) Total() int {
 func availableAddItems(cat *catalog.Catalog, installed *config.InstalledAgent) availableAddSet {
 	agentType := installed.AgentType
 
-	installedSet := func(items []string) map[string]bool {
+	installedItems := func(items []string) map[string]bool {
 		m := make(map[string]bool, len(items))
 		for _, item := range items {
 			m[item] = true
@@ -625,7 +625,7 @@ func availableAddItems(cat *catalog.Catalog, installed *config.InstalledAgent) a
 	}
 
 	filterItems := func(available []catalog.CatalogItem, existing []string) []catalog.CatalogItem {
-		have := installedSet(existing)
+		have := installedItems(existing)
 		var result []catalog.CatalogItem
 		for _, item := range available {
 			if !have[item.Name] {
@@ -636,7 +636,7 @@ func availableAddItems(cat *catalog.Catalog, installed *config.InstalledAgent) a
 	}
 
 	filterSensors := func(available []catalog.SensorItem, existing []string) []catalog.SensorItem {
-		have := installedSet(existing)
+		have := installedItems(existing)
 		var result []catalog.SensorItem
 		for _, item := range available {
 			if !have[item.Name] && item.Name != "routine-check" {
@@ -647,7 +647,7 @@ func availableAddItems(cat *catalog.Catalog, installed *config.InstalledAgent) a
 	}
 
 	filterRoutines := func(available []catalog.RoutineItem, existing []string) []catalog.RoutineItem {
-		have := installedSet(existing)
+		have := installedItems(existing)
 		var result []catalog.RoutineItem
 		for _, item := range available {
 			if !have[item.Name] {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -170,7 +170,7 @@ func applyConflictPicks(results []any, confIdx int, wr *generate.WriteResult,
 			}
 		}
 		if len(dropped) > 0 {
-			filtered := selected[:0]
+			filtered := make([]string, 0, len(selected)-len(dropped))
 			droppedList := make([]string, 0, len(dropped))
 			for _, relPath := range selected {
 				if dropped[relPath] {

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1228,3 +1228,140 @@ func TestInjectTriggerSection(t *testing.T) {
 		})
 	}
 }
+
+// TestRoutineDashboardNoBlankRows is a regression guard for the stale
+// routines.md dashboard bug: the generator must emit contiguous table body
+// rows — no blank lines splitting the Dashboard or the Routine Definitions
+// table. Builds an InstalledAgent with the 7 tech-lead default routines at
+// mixed frequencies, renders via RoutineDashboard, and scans the output.
+func TestRoutineDashboardNoBlankRows(t *testing.T) {
+	routineSpecs := []struct {
+		name      string
+		frequency string
+	}{
+		{"backlog-hygiene", "7 days"},
+		{"dependency-audit", "7 days"},
+		{"doc-freshness-check", "7 days"},
+		{"memory-consolidation", "5 days"},
+		{"roadmap-accuracy", "14 days"},
+		{"status-hygiene", "5 days"},
+		{"vulnerability-scan", "7 days"},
+	}
+
+	fsys := fstest.MapFS{
+		"core/memory.md.tmpl":          &fstest.MapFile{Data: []byte("memory")},
+		"core/self-awareness.md":       &fstest.MapFile{Data: []byte("self-awareness")},
+		"agents/test-agent/agent.yaml": &fstest.MapFile{Data: []byte("name: test-agent\ndescription: test\n")},
+	}
+	for _, r := range routineSpecs {
+		meta := "name: " + r.name + "\ndescription: " + r.name + "\nagents: [test-agent]\nfrequency: " + r.frequency + "\n"
+		fsys["routines/"+r.name+"/meta.yaml"] = &fstest.MapFile{Data: []byte(meta)}
+		fsys["routines/"+r.name+"/"+r.name+".md.tmpl"] = &fstest.MapFile{Data: []byte("# " + r.name + "\n")}
+	}
+
+	cat, err := catalog.New(fsys)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	workspaceRoot := tmpDir
+	routineNames := make([]string, 0, len(routineSpecs))
+	for _, r := range routineSpecs {
+		routineNames = append(routineNames, r.name)
+	}
+	installed := &config.InstalledAgent{
+		AgentType: "test-agent",
+		Workspace: ".",
+		Routines:  routineNames,
+	}
+	lock := config.NewLockFile()
+	var wr WriteResult
+	if err := RoutineDashboard(tmpDir, workspaceRoot, installed, cat, lock, &wr, false); err != nil {
+		t.Fatalf("RoutineDashboard: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workspaceRoot, "agent", "Core", "routines.md"))
+	if err != nil {
+		t.Fatalf("read routines.md: %v", err)
+	}
+	lines := strings.Split(string(data), "\n")
+
+	// Locate marker line indices.
+	dashStartIdx, dashEndIdx := -1, -1
+	for i, line := range lines {
+		if strings.Contains(line, "ROUTINE_DASHBOARD_START") {
+			dashStartIdx = i
+		} else if strings.Contains(line, "ROUTINE_DASHBOARD_END") {
+			dashEndIdx = i
+			break
+		}
+	}
+	if dashStartIdx == -1 || dashEndIdx == -1 {
+		t.Fatalf("dashboard markers not found (start=%d, end=%d)", dashStartIdx, dashEndIdx)
+	}
+
+	// Scan 1 — plan invariant: every non-empty non-comment line between the
+	// START and END markers must begin with `|` (i.e. it is a table row).
+	// Blank lines are permitted by markdown renderers adjacent to markers
+	// (the generator emits one right after START and one right before END);
+	// what matters is that no blank row sits between two body rows, which
+	// is equivalent to saying: blanks between markers are only valid if the
+	// run of `|`-prefixed rows is contiguous (no gaps inside the table).
+	seenBodyRow := false
+	lastWasBlank := false
+	for i := dashStartIdx + 1; i < dashEndIdx; i++ {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			if seenBodyRow {
+				lastWasBlank = true
+			}
+			continue
+		}
+		if !strings.HasPrefix(line, "|") {
+			t.Errorf("line %d between dashboard markers is not a comment and does not begin with `|`: %q", i+1, line)
+			continue
+		}
+		// It's a table row. If the previous non-blank was a body row and a
+		// blank sat between them, the table is split.
+		if seenBodyRow && lastWasBlank {
+			t.Errorf("blank row splits dashboard table at line %d (before body row: %q)", i, line)
+		}
+		seenBodyRow = true
+		lastWasBlank = false
+	}
+
+	// Scan 2: no blank lines between the Routine Definitions table header and
+	// its last body row.
+	defHeaderIdx := -1
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "| Routine | File |") {
+			defHeaderIdx = i
+			break
+		}
+	}
+	if defHeaderIdx == -1 {
+		t.Fatal("Routine Definitions header row not found")
+	}
+	// Find the last non-empty line with `|` prefix after the header — that is
+	// the final body row. Blank lines between header and that line are a bug.
+	lastBodyIdx := defHeaderIdx
+	for i := defHeaderIdx + 1; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "|") {
+			lastBodyIdx = i
+		}
+	}
+	for i := defHeaderIdx + 1; i < lastBodyIdx; i++ {
+		if strings.TrimSpace(lines[i]) == "" {
+			t.Errorf("blank row at line %d inside Routine Definitions table body (header=%d, last body=%d)", i+1, defHeaderIdx+1, lastBodyIdx+1)
+		}
+	}
+
+	// Sanity: every routine display name is present in the definitions table.
+	content := string(data)
+	for _, r := range routineSpecs {
+		if !strings.Contains(content, "`agent/Routines/"+r.name+".md`") {
+			t.Errorf("definition for routine %q not found in output", r.name)
+		}
+	}
+}

--- a/station/agent/Core/routines.md
+++ b/station/agent/Core/routines.md
@@ -35,7 +35,6 @@ description: Periodic self-maintenance routines — schedules, dashboard, execut
 | Backlog Hygiene | 7 days | 2026-04-21 | 2026-04-28 | done |
 | Dependency Audit | 7 days | 2026-04-21 | 2026-04-28 | done |
 | Doc Freshness Check | 7 days | 2026-04-21 | 2026-04-28 | done |
-
 | Memory Consolidation | 5 days | 2026-04-20 | 2026-04-25 | done |
 | Roadmap Accuracy | 14 days | 2026-04-14 | 2026-04-28 | done |
 | Status Hygiene | 5 days | 2026-04-20 | 2026-04-25 | done |
@@ -52,7 +51,6 @@ description: Periodic self-maintenance routines — schedules, dashboard, execut
 | Backlog Hygiene | `agent/Routines/backlog-hygiene.md` |
 | Dependency Audit | `agent/Routines/dependency-audit.md` |
 | Doc Freshness Check | `agent/Routines/doc-freshness-check.md` |
-
 | Memory Consolidation | `agent/Routines/memory-consolidation.md` |
 | Roadmap Accuracy | `agent/Routines/roadmap-accuracy.md` |
 | Status Hygiene | `agent/Routines/status-hygiene.md` |

--- a/station/agent/Sensors/context-guard.sh
+++ b/station/agent/Sensors/context-guard.sh
@@ -153,8 +153,8 @@ plan_patterns = [
 if not triggered and any(re.search(p, normalized) for p in plan_patterns):
     reminder = (
         '\nPLANNING DETECTED. Before drafting a plan:\n'
-        f'1. Load planning workflow: {os.path.join(root, "")}agent/Workflows/planning.md\n'
-        f'2. Load planning-template skill: {os.path.join(root, "")}agent/Skills/planning-template.md\n'
+        f'1. Load planning workflow: {docs_path}agent/Workflows/planning.md\n'
+        f'2. Load planning-template skill: {docs_path}agent/Skills/planning-template.md\n'
         '3. Follow the Tier rules and Verification requirements'
     )
     injection = (injection + '\n' + reminder) if injection else reminder


### PR DESCRIPTION
## Summary
Plan 26 bundle — 4 independent P2 cleanups: context-guard path prefix fix, stale routines dashboard regeneration, selected[:0] aliasing refactor, installedSet closure rename.

## Changes
- `station/agent/Sensors/context-guard.sh` — planning-reminder paths use `docs_path` (adds missing `station/` prefix)
- `station/agent/Core/routines.md` — drop 2 blank lines splitting tables
- `.bonsai-lock.yaml` — hash sync for routines.md
- `internal/generate/generate_test.go` — regression test: no blank rows between dashboard markers
- `cmd/root.go`, `cmd/add.go` — `filtered := slice[:0]` → `make([]string, 0, …)` (2 sites)
- `cmd/add.go` — rename inner `installedSet` closures → `installedItems` (2 sites)

## Plan
`station/Playbook/Plans/Active/26-p2-knockoff-bundle.md`

## Verification
- [x] `make build` — passes
- [x] `go test ./... -count=1` — passes
- [x] `go vet ./...` — passes
- [x] `gofmt -l` — empty

## Notes
`.bonsai-lock.yaml` is gitignored (local state only) so the hash-sync step is not reflected in this diff — only the main worktree's on-disk lockfile was updated alongside `station/agent/Core/routines.md` so `bonsai update` won't flag a spurious conflict.

The generator inherently emits a single blank line right after `ROUTINE_DASHBOARD_START` and a single blank before `ROUTINE_DASHBOARD_END` (both adjacent to markers — not splitting body rows). The plan's body ("Delete lines 38 and 55") was followed exactly; the verification-checklist phrasing "blank-row count … zero" is interpreted as "no blanks splitting body rows" (the actual bug). The new regression test enforces this invariant.