### PR TITLE
Plan 27 PR1 — add-flow foundations + bug fixes

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -142,7 +142,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				if agentCtx.AgentDisplay == "" {
 					agentCtx.AgentDisplay = catalog.DisplayNameFrom(agentDef.Name)
 				}
-				graft := addflow.NewAddItemsGraft(agentCtx, addflow.GraftContext{
+				graft := addflow.NewAddItemsBranches(agentCtx, addflow.BranchesContext{
 					Cat:       cat,
 					AgentType: agentType,
 					AgentDef:  agentDef,
@@ -173,7 +173,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 				DocsPath:           cfg.DocsPath,
 				ExistingWorkspaces: existingWorkspaces,
 			})
-			graft := addflow.NewNewAgentGraft(agentCtx, addflow.GraftContext{
+			graft := addflow.NewNewAgentBranches(agentCtx, addflow.BranchesContext{
 				Cat:       cat,
 				AgentType: agentType,
 				AgentDef:  agentDef,
@@ -391,10 +391,10 @@ func buildAddGrowAction(
 		outcome.AgentDef = agentDef
 
 		// Locate the GraftResult by type. Both branches emit exactly one.
-		var graft addflow.GraftResult
+		var graft addflow.BranchesResult
 		var graftFound bool
 		for _, v := range prev {
-			if g, ok := v.(addflow.GraftResult); ok {
+			if g, ok := v.(addflow.BranchesResult); ok {
 				graft = g
 				graftFound = true
 				break
@@ -456,9 +456,14 @@ func buildAddGrowAction(
 
 			var errs []error
 			errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installedAgent, cfg, cat, lock, wr, false))
-			errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, wr, false))
-			errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false))
-			errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+			// Plan 27 §B2: scope path-rules / workflow-skills / settings
+			// regeneration to the single agent being augmented. The all-
+			// agents variants (used by `bonsai update`) would regenerate
+			// files under every installed workspace and flag any user-edited
+			// rule / skill / settings file as a cross-agent conflict.
+			errs = append(errs, generate.PathScopedRulesForAgent(cwd, installedAgent, cfg, cat, lock, wr, false))
+			errs = append(errs, generate.WorkflowSkillsForAgent(cwd, installedAgent, cfg, cat, lock, wr, false))
+			errs = append(errs, generate.SettingsJSONForAgent(cwd, installedAgent, cfg, cat, lock, wr, false))
 			if joined := errors.Join(errs...); joined != nil {
 				outcome.SpinnerErr = joined
 				return joined
@@ -506,9 +511,11 @@ func buildAddGrowAction(
 
 		var errs []error
 		errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, wr, false))
-		errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, wr, false))
-		errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false))
-		errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+		// Plan 27 §B2: see the add-items branch above for rationale — scope
+		// to the single newly-installed agent.
+		errs = append(errs, generate.PathScopedRulesForAgent(cwd, installed, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.WorkflowSkillsForAgent(cwd, installed, cfg, cat, lock, wr, false))
+		errs = append(errs, generate.SettingsJSONForAgent(cwd, installed, cfg, cat, lock, wr, false))
 		if joined := errors.Join(errs...); joined != nil {
 			outcome.SpinnerErr = joined
 			return joined

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -461,9 +461,40 @@ func sortedKeys(m map[string]bool) []string {
 	return keys
 }
 
-// SettingsJSON generates or updates .claude/settings.json with sensor hooks.
-// Settings are written per-workspace so users can launch Claude Code from there directly.
+// SettingsJSON generates or updates .claude/settings.json with sensor hooks
+// for EVERY installed agent. Used by `bonsai update` which regenerates all
+// agents in one pass. `bonsai add` should use SettingsJSONForAgent to scope
+// regeneration to a single agent — otherwise a concurrent `bonsai add` would
+// flag user edits in unrelated agent workspaces as conflicts. Plan 27 §B2.
+//
+// Settings are written per-workspace so users can launch Claude Code from
+// there directly.
 func SettingsJSON(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
+	for _, installed := range cfg.Agents {
+		if err := writeSettingsJSONForAgent(projectRoot, installed, cat, lock, result, force); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SettingsJSONForAgent is the single-agent scoped variant of SettingsJSON.
+// Used by `bonsai add` so the regeneration pass only touches the agent being
+// added — prior `bonsai update` leaves SettingsJSON unchanged (still iterates
+// cfg.Agents). Plan 27 §B2 fix for the cross-agent conflict leak that tripped
+// dogfood finding #7b.
+func SettingsJSONForAgent(projectRoot string, agent *config.InstalledAgent, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
+	_ = cfg // retained for signature symmetry with the all-agents variant
+	if agent == nil {
+		return nil
+	}
+	return writeSettingsJSONForAgent(projectRoot, agent, cat, lock, result, force)
+}
+
+// writeSettingsJSONForAgent renders .claude/settings.json under the given
+// installed agent's workspace. Shared helper between SettingsJSON (all
+// agents) and SettingsJSONForAgent (single agent).
+func writeSettingsJSONForAgent(projectRoot string, installed *config.InstalledAgent, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
 	type hookEntry struct {
 		Type    string `json:"type"`
 		Command string `json:"command"`
@@ -474,70 +505,68 @@ func SettingsJSON(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Ca
 	}
 	type groupKey struct{ event, matcher string }
 
-	for _, installed := range cfg.Agents {
-		settingsPath := filepath.Join(projectRoot, installed.Workspace, ".claude", "settings.json")
+	settingsPath := filepath.Join(projectRoot, installed.Workspace, ".claude", "settings.json")
 
-		existing := make(map[string]interface{})
-		if data, err := os.ReadFile(settingsPath); err == nil {
-			_ = json.Unmarshal(data, &existing)
-		}
-
-		groups := make(map[groupKey][]string)
-
-		for _, sensorName := range installed.Sensors {
-			var event, matcher string
-			if sensor := cat.GetSensor(sensorName); sensor != nil {
-				event = sensor.Event
-				matcher = sensor.Matcher
-			} else if installed.CustomItems != nil {
-				if meta, ok := installed.CustomItems[sensorName]; ok && meta.Event != "" {
-					event = meta.Event
-					matcher = meta.Matcher
-				}
-			}
-			if event == "" {
-				continue
-			}
-			k := groupKey{event, matcher}
-			scriptPath := installed.Workspace + "agent/Sensors/" + sensorName + ".sh"
-			cmd := fmt.Sprintf(
-				`bash -c 'r="$PWD"; while [ "$r" != "/" ] && [ ! -f "$r/.bonsai.yaml" ]; do r=$(dirname "$r"); done; bash "$r/%s" "$r"'`,
-				scriptPath,
-			)
-			groups[k] = append(groups[k], cmd)
-		}
-
-		hooksConfig := make(map[string][]hookGroup)
-		for k, commands := range groups {
-			var hooks []hookEntry
-			for _, cmd := range commands {
-				hooks = append(hooks, hookEntry{Type: "command", Command: cmd})
-			}
-			g := hookGroup{Hooks: hooks}
-			if k.matcher != "" {
-				g.Matcher = k.matcher
-			}
-			hooksConfig[k.event] = append(hooksConfig[k.event], g)
-		}
-
-		if len(hooksConfig) > 0 {
-			existing["hooks"] = hooksConfig
-		} else {
-			delete(existing, "hooks")
-		}
-
-		if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
-			return err
-		}
-		data, err := json.MarshalIndent(existing, "", "  ")
-		if err != nil {
-			return err
-		}
-		content := append(data, '\n')
-		relPath := filepath.Join(installed.Workspace, ".claude", "settings.json")
-		r := writeFile(projectRoot, relPath, content, "generated:settings-json", lock, force)
-		result.Add(r)
+	existing := make(map[string]interface{})
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		_ = json.Unmarshal(data, &existing)
 	}
+
+	groups := make(map[groupKey][]string)
+
+	for _, sensorName := range installed.Sensors {
+		var event, matcher string
+		if sensor := cat.GetSensor(sensorName); sensor != nil {
+			event = sensor.Event
+			matcher = sensor.Matcher
+		} else if installed.CustomItems != nil {
+			if meta, ok := installed.CustomItems[sensorName]; ok && meta.Event != "" {
+				event = meta.Event
+				matcher = meta.Matcher
+			}
+		}
+		if event == "" {
+			continue
+		}
+		k := groupKey{event, matcher}
+		scriptPath := installed.Workspace + "agent/Sensors/" + sensorName + ".sh"
+		cmd := fmt.Sprintf(
+			`bash -c 'r="$PWD"; while [ "$r" != "/" ] && [ ! -f "$r/.bonsai.yaml" ]; do r=$(dirname "$r"); done; bash "$r/%s" "$r"'`,
+			scriptPath,
+		)
+		groups[k] = append(groups[k], cmd)
+	}
+
+	hooksConfig := make(map[string][]hookGroup)
+	for k, commands := range groups {
+		var hooks []hookEntry
+		for _, cmd := range commands {
+			hooks = append(hooks, hookEntry{Type: "command", Command: cmd})
+		}
+		g := hookGroup{Hooks: hooks}
+		if k.matcher != "" {
+			g.Matcher = k.matcher
+		}
+		hooksConfig[k.event] = append(hooksConfig[k.event], g)
+	}
+
+	if len(hooksConfig) > 0 {
+		existing["hooks"] = hooksConfig
+	} else {
+		delete(existing, "hooks")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return err
+	}
+	content := append(data, '\n')
+	relPath := filepath.Join(installed.Workspace, ".claude", "settings.json")
+	r := writeFile(projectRoot, relPath, content, "generated:settings-json", lock, force)
+	result.Add(r)
 	return nil
 }
 
@@ -1060,95 +1089,145 @@ func RoutineDashboard(projectRoot string, workspaceRoot string, installed *confi
 	return nil
 }
 
-// PathScopedRules generates .claude/rules/skill-{name}.md files for skills
-// that have triggers.paths defined. These auto-load when Claude reads matching files.
+// PathScopedRules generates .claude/rules/skill-{name}.md files for EVERY
+// installed agent's skills that have triggers.paths defined. Used by
+// `bonsai update` which regenerates all agents. `bonsai add` should call
+// PathScopedRulesForAgent instead to scope regeneration to the agent being
+// added and avoid flagging unrelated agents' user-edited rule files as
+// conflicts. Plan 27 §B2.
+//
+// These auto-load when Claude reads matching files.
 func PathScopedRules(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
 	for _, installed := range cfg.Agents {
-		for _, skillName := range installed.Skills {
-			item := cat.GetSkill(skillName)
-			if item == nil || item.Triggers == nil || len(item.Triggers.Paths) == 0 {
-				continue
-			}
-
-			// Build content
-			var lines []string
-			lines = append(lines, "---")
-			lines = append(lines, "paths:")
-			for _, p := range item.Triggers.Paths {
-				lines = append(lines, fmt.Sprintf("  - \"%s\"", p))
-			}
-			lines = append(lines, "---", "")
-			lines = append(lines, fmt.Sprintf("When working with files matching these paths, load and follow the **%s** skill at `%sagent/Skills/%s.md`.",
-				item.DisplayName, installed.Workspace, skillName))
-
-			if len(item.Triggers.Scenarios) > 0 {
-				lines = append(lines, "", "Activate when:")
-				for _, s := range item.Triggers.Scenarios {
-					lines = append(lines, "- "+s)
-				}
-			}
-			lines = append(lines, "")
-
-			content := []byte(strings.Join(lines, "\n"))
-			relPath := filepath.Join(installed.Workspace, ".claude", "rules", "skill-"+skillName+".md")
-			r := writeFile(projectRoot, relPath, content, "generated:rule-skill-"+skillName, lock, force)
-			result.Add(r)
-		}
+		writePathScopedRulesForAgent(projectRoot, installed, cat, lock, result, force)
 	}
 	return nil
 }
 
+// PathScopedRulesForAgent is the single-agent scoped variant of
+// PathScopedRules. Used by `bonsai add` so the regeneration pass only touches
+// the agent being added. Plan 27 §B2 fix for the cross-agent conflict leak
+// that tripped dogfood finding #7b — iterating cfg.Agents here regenerates
+// rule files in unrelated workspaces, and `writeFile` → `lock.IsModified`
+// then flags any user-edited rule as a conflict.
+func PathScopedRulesForAgent(projectRoot string, agent *config.InstalledAgent, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
+	_ = cfg // retained for signature symmetry with the all-agents variant
+	if agent == nil {
+		return nil
+	}
+	writePathScopedRulesForAgent(projectRoot, agent, cat, lock, result, force)
+	return nil
+}
+
+// writePathScopedRulesForAgent renders .claude/rules/skill-*.md for the skills
+// belonging to a single installed agent. Shared helper between PathScopedRules
+// and PathScopedRulesForAgent.
+func writePathScopedRulesForAgent(projectRoot string, installed *config.InstalledAgent, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) {
+	for _, skillName := range installed.Skills {
+		item := cat.GetSkill(skillName)
+		if item == nil || item.Triggers == nil || len(item.Triggers.Paths) == 0 {
+			continue
+		}
+
+		// Build content
+		var lines []string
+		lines = append(lines, "---")
+		lines = append(lines, "paths:")
+		for _, p := range item.Triggers.Paths {
+			lines = append(lines, fmt.Sprintf("  - \"%s\"", p))
+		}
+		lines = append(lines, "---", "")
+		lines = append(lines, fmt.Sprintf("When working with files matching these paths, load and follow the **%s** skill at `%sagent/Skills/%s.md`.",
+			item.DisplayName, installed.Workspace, skillName))
+
+		if len(item.Triggers.Scenarios) > 0 {
+			lines = append(lines, "", "Activate when:")
+			for _, s := range item.Triggers.Scenarios {
+				lines = append(lines, "- "+s)
+			}
+		}
+		lines = append(lines, "")
+
+		content := []byte(strings.Join(lines, "\n"))
+		relPath := filepath.Join(installed.Workspace, ".claude", "rules", "skill-"+skillName+".md")
+		r := writeFile(projectRoot, relPath, content, "generated:rule-skill-"+skillName, lock, force)
+		result.Add(r)
+	}
+}
+
 // WorkflowSkills generates .claude/skills/{name}/SKILL.md files for curated
-// workflows, enabling /slash-command invocation and description-based auto-invocation.
+// workflows across EVERY installed agent, enabling /slash-command invocation
+// and description-based auto-invocation. Used by `bonsai update` which
+// regenerates all agents. `bonsai add` should call WorkflowSkillsForAgent
+// instead so its regeneration pass does not touch unrelated agent workspaces
+// and flag user-edited SKILL.md files as conflicts. Plan 27 §B2.
 func WorkflowSkills(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
 	for _, installed := range cfg.Agents {
-		for _, wfName := range installed.Workflows {
-			if !CuratedSlashWorkflows[wfName] {
-				continue
-			}
-			item := cat.GetWorkflow(wfName)
-			if item == nil {
-				continue
-			}
-
-			var lines []string
-			lines = append(lines, "---")
-			lines = append(lines, fmt.Sprintf("name: %s", wfName))
-
-			// Description from scenarios or fallback
-			desc := item.Description
-			if item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
-				desc = strings.Join(item.Triggers.Scenarios, ". ")
-			}
-			lines = append(lines, fmt.Sprintf("description: %s", desc))
-
-			// when_to_use from scenarios
-			if item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
-				lines = append(lines, fmt.Sprintf("when_to_use: %s", strings.Join(item.Triggers.Scenarios, "; ")))
-			}
-
-			lines = append(lines, "---", "")
-			lines = append(lines, fmt.Sprintf("Load and follow the **%s** workflow at `%sagent/Workflows/%s.md`.",
-				item.DisplayName, installed.Workspace, wfName))
-
-			// Examples section
-			if item.Triggers != nil && len(item.Triggers.Examples) > 0 {
-				lines = append(lines, "", "## Examples", "")
-				for _, ex := range item.Triggers.Examples {
-					lines = append(lines, fmt.Sprintf("> **User:** \"%s\"", ex.Prompt))
-					lines = append(lines, fmt.Sprintf("> **Action:** %s", ex.Action))
-					lines = append(lines, "")
-				}
-			}
-			lines = append(lines, "")
-
-			content := []byte(strings.Join(lines, "\n"))
-			relPath := filepath.Join(installed.Workspace, ".claude", "skills", wfName, "SKILL.md")
-			r := writeFile(projectRoot, relPath, content, "generated:skill-workflow-"+wfName, lock, force)
-			result.Add(r)
-		}
+		writeWorkflowSkillsForAgent(projectRoot, installed, cat, lock, result, force)
 	}
 	return nil
+}
+
+// WorkflowSkillsForAgent is the single-agent scoped variant of WorkflowSkills.
+// Used by `bonsai add`. Plan 27 §B2 fix for the cross-agent conflict leak.
+func WorkflowSkillsForAgent(projectRoot string, agent *config.InstalledAgent, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
+	_ = cfg // retained for signature symmetry with the all-agents variant
+	if agent == nil {
+		return nil
+	}
+	writeWorkflowSkillsForAgent(projectRoot, agent, cat, lock, result, force)
+	return nil
+}
+
+// writeWorkflowSkillsForAgent renders .claude/skills/<workflow>/SKILL.md for
+// the curated workflows belonging to a single installed agent. Shared helper
+// between WorkflowSkills and WorkflowSkillsForAgent.
+func writeWorkflowSkillsForAgent(projectRoot string, installed *config.InstalledAgent, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) {
+	for _, wfName := range installed.Workflows {
+		if !CuratedSlashWorkflows[wfName] {
+			continue
+		}
+		item := cat.GetWorkflow(wfName)
+		if item == nil {
+			continue
+		}
+
+		var lines []string
+		lines = append(lines, "---")
+		lines = append(lines, fmt.Sprintf("name: %s", wfName))
+
+		// Description from scenarios or fallback
+		desc := item.Description
+		if item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
+			desc = strings.Join(item.Triggers.Scenarios, ". ")
+		}
+		lines = append(lines, fmt.Sprintf("description: %s", desc))
+
+		// when_to_use from scenarios
+		if item.Triggers != nil && len(item.Triggers.Scenarios) > 0 {
+			lines = append(lines, fmt.Sprintf("when_to_use: %s", strings.Join(item.Triggers.Scenarios, "; ")))
+		}
+
+		lines = append(lines, "---", "")
+		lines = append(lines, fmt.Sprintf("Load and follow the **%s** workflow at `%sagent/Workflows/%s.md`.",
+			item.DisplayName, installed.Workspace, wfName))
+
+		// Examples section
+		if item.Triggers != nil && len(item.Triggers.Examples) > 0 {
+			lines = append(lines, "", "## Examples", "")
+			for _, ex := range item.Triggers.Examples {
+				lines = append(lines, fmt.Sprintf("> **User:** \"%s\"", ex.Prompt))
+				lines = append(lines, fmt.Sprintf("> **Action:** %s", ex.Action))
+				lines = append(lines, "")
+			}
+		}
+		lines = append(lines, "")
+
+		content := []byte(strings.Join(lines, "\n"))
+		relPath := filepath.Join(installed.Workspace, ".claude", "skills", wfName, "SKILL.md")
+		r := writeFile(projectRoot, relPath, content, "generated:skill-workflow-"+wfName, lock, force)
+		result.Add(r)
+	}
 }
 
 // triggerSection generates a markdown trigger header from catalog triggers metadata.

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1365,3 +1365,110 @@ func TestRoutineDashboardNoBlankRows(t *testing.T) {
 		}
 	}
 }
+
+// TestPathScopedRulesForAgentScope is the Plan 27 §B2 regression guard. The
+// pre-fix `bonsai add` code path called generate.PathScopedRules which
+// iterates cfg.Agents — that regenerated rule files under every installed
+// agent's workspace and tripped a cross-agent conflict when the user had
+// hand-edited an unrelated agent's skill-*.md rule file.
+//
+// The scoped variant PathScopedRulesForAgent takes an explicit *InstalledAgent
+// and only writes rules under that agent's workspace. This test pins both
+// behaviours:
+//
+//  1. PathScopedRulesForAgent(frontend, ...) must NOT emit a conflict under
+//     tech-lead/ even when a tech-lead rule file exists on disk with local
+//     edits and the lockfile tracks the original content.
+//  2. The legacy PathScopedRules(cfg, ...) with the same fixture DOES produce
+//     the cross-agent conflict — proving the fix is at the call-site level
+//     and the scoped variant is the correct tool for `bonsai add`.
+func TestPathScopedRulesForAgentScope(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"skills/tech-lead-skill/meta.yaml":          "name: tech-lead-skill\ndescription: TL skill\nagents: all\ntriggers:\n  scenarios:\n    - TL\n  paths:\n    - \"**/tl/**\"\n",
+		"skills/tech-lead-skill/tech-lead-skill.md": "# TL\n",
+		"skills/frontend-skill/meta.yaml":           "name: frontend-skill\ndescription: FE skill\nagents: all\ntriggers:\n  scenarios:\n    - FE\n  paths:\n    - \"**/fe/**\"\n",
+		"skills/frontend-skill/frontend-skill.md":   "# FE\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	techLead := &config.InstalledAgent{
+		AgentType: "tech-lead",
+		Workspace: "station/",
+		Skills:    []string{"tech-lead-skill"},
+	}
+	frontend := &config.InstalledAgent{
+		AgentType: "frontend",
+		Workspace: "frontend/",
+		Skills:    []string{"frontend-skill"},
+	}
+
+	// helper: seed a fresh tempdir + cfg + lockfile, then first-pass generate
+	// rules under BOTH agents so the lockfile tracks their original content.
+	// Then hand-edit tech-lead's rule file (simulating the user's local
+	// change) so the next generate pass sees IsModified=true for that path.
+	seed := func(t *testing.T) (tmpDir string, cfg *config.ProjectConfig, lock *config.LockFile) {
+		t.Helper()
+		tmpDir = t.TempDir()
+		cfg = &config.ProjectConfig{
+			ProjectName: "TestProject",
+			Agents: map[string]*config.InstalledAgent{
+				"tech-lead": techLead,
+				"frontend":  frontend,
+			},
+		}
+		lock = config.NewLockFile()
+		var wr WriteResult
+		if err := PathScopedRules(tmpDir, cfg, cat, lock, &wr, false); err != nil {
+			t.Fatalf("initial PathScopedRules: %v", err)
+		}
+		// User edits the tech-lead rule file on disk. The content now differs
+		// from the lockfile hash, so subsequent generate passes that touch
+		// this path will report a conflict.
+		tlRule := filepath.Join(tmpDir, "station", ".claude", "rules", "skill-tech-lead-skill.md")
+		if err := os.WriteFile(tlRule, []byte("# USER-EDITED\n"), 0644); err != nil {
+			t.Fatalf("seed tech-lead edit: %v", err)
+		}
+		return tmpDir, cfg, lock
+	}
+
+	// 1. Scoped call with the frontend agent must not touch tech-lead files.
+	tmpDir, cfg, lock := seed(t)
+	var wrFE WriteResult
+	if err := PathScopedRulesForAgent(tmpDir, frontend, cfg, cat, lock, &wrFE, false); err != nil {
+		t.Fatalf("PathScopedRulesForAgent(frontend): %v", err)
+	}
+	for _, f := range wrFE.Conflicts() {
+		if strings.HasPrefix(f.RelPath, "station/") {
+			t.Fatalf("PathScopedRulesForAgent(frontend) leaked a conflict under tech-lead workspace: %s", f.RelPath)
+		}
+	}
+	// Sanity: the edited tech-lead file still contains the user's edit
+	// unchanged — the scoped call must not have touched it.
+	tlRulePath := filepath.Join(tmpDir, "station", ".claude", "rules", "skill-tech-lead-skill.md")
+	if data, err := os.ReadFile(tlRulePath); err != nil {
+		t.Fatalf("read tech-lead rule: %v", err)
+	} else if !bytes.Contains(data, []byte("USER-EDITED")) {
+		t.Fatalf("tech-lead rule was modified by frontend-scoped regeneration (content = %q)", data)
+	}
+
+	// 2. Negative case: the legacy all-agents PathScopedRules does trip the
+	// cross-agent conflict — proves the fix is the call-site swap, not a
+	// change to the shared writeFile machinery.
+	tmpDir2, cfg2, lock2 := seed(t)
+	var wrAll WriteResult
+	if err := PathScopedRules(tmpDir2, cfg2, cat, lock2, &wrAll, false); err != nil {
+		t.Fatalf("PathScopedRules (legacy): %v", err)
+	}
+	leaked := false
+	for _, f := range wrAll.Conflicts() {
+		if strings.HasPrefix(f.RelPath, "station/") && strings.Contains(f.RelPath, "skill-tech-lead-skill.md") {
+			leaked = true
+			break
+		}
+	}
+	if !leaked {
+		t.Fatalf("expected legacy PathScopedRules to surface a conflict under tech-lead/; got none (wr conflicts=%d total)", len(wrAll.Conflicts()))
+	}
+}

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1472,3 +1472,199 @@ func TestPathScopedRulesForAgentScope(t *testing.T) {
 		t.Fatalf("expected legacy PathScopedRules to surface a conflict under tech-lead/; got none (wr conflicts=%d total)", len(wrAll.Conflicts()))
 	}
 }
+
+// TestWorkflowSkillsForAgentScope mirrors TestPathScopedRulesForAgentScope for
+// the workflow-SKILL.md code path. `bonsai add` must only touch the agent
+// being added; pre-fix the call-site invoked WorkflowSkills which iterated
+// cfg.Agents and regenerated every agent's workflow skills, tripping a
+// cross-agent conflict when the user had local edits on an unrelated agent's
+// SKILL.md.
+//
+//  1. WorkflowSkillsForAgent(frontend, ...) must NOT emit a conflict under
+//     tech-lead/ even when a tech-lead workflow SKILL.md exists with local
+//     edits tracked in the lockfile.
+//  2. The legacy WorkflowSkills(cfg, ...) with the same fixture DOES produce
+//     the cross-agent conflict — proving the fix is at the call-site level.
+func TestWorkflowSkillsForAgentScope(t *testing.T) {
+	// Both agents get `planning`, which is in CuratedSlashWorkflows so the
+	// SKILL.md file is actually generated. Without a curated workflow, both
+	// scoped and legacy paths are no-ops and the test proves nothing.
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"workflows/planning/meta.yaml":   "name: planning\ndescription: End-to-end planning\nagents: all\ntriggers:\n  scenarios:\n    - Starting end-to-end planning\n",
+		"workflows/planning/planning.md": "# Planning\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	techLead := &config.InstalledAgent{
+		AgentType: "tech-lead",
+		Workspace: "station/",
+		Workflows: []string{"planning"},
+	}
+	frontend := &config.InstalledAgent{
+		AgentType: "frontend",
+		Workspace: "frontend/",
+		Workflows: []string{"planning"},
+	}
+
+	seed := func(t *testing.T) (tmpDir string, cfg *config.ProjectConfig, lock *config.LockFile) {
+		t.Helper()
+		tmpDir = t.TempDir()
+		cfg = &config.ProjectConfig{
+			ProjectName: "TestProject",
+			Agents: map[string]*config.InstalledAgent{
+				"tech-lead": techLead,
+				"frontend":  frontend,
+			},
+		}
+		lock = config.NewLockFile()
+		var wr WriteResult
+		if err := WorkflowSkills(tmpDir, cfg, cat, lock, &wr, false); err != nil {
+			t.Fatalf("initial WorkflowSkills: %v", err)
+		}
+		// User edits the tech-lead SKILL.md on disk — content now diverges
+		// from the lockfile hash so subsequent passes report a conflict.
+		tlSkill := filepath.Join(tmpDir, "station", ".claude", "skills", "planning", "SKILL.md")
+		if err := os.WriteFile(tlSkill, []byte("# USER-EDITED\n"), 0644); err != nil {
+			t.Fatalf("seed tech-lead edit: %v", err)
+		}
+		return tmpDir, cfg, lock
+	}
+
+	// 1. Scoped call with frontend must NOT touch tech-lead files.
+	tmpDir, cfg, lock := seed(t)
+	var wrFE WriteResult
+	if err := WorkflowSkillsForAgent(tmpDir, frontend, cfg, cat, lock, &wrFE, false); err != nil {
+		t.Fatalf("WorkflowSkillsForAgent(frontend): %v", err)
+	}
+	for _, f := range wrFE.Conflicts() {
+		if strings.HasPrefix(f.RelPath, "station/") {
+			t.Fatalf("WorkflowSkillsForAgent(frontend) leaked a conflict under tech-lead workspace: %s", f.RelPath)
+		}
+	}
+	// Sanity: edited tech-lead SKILL.md retains the user's edit.
+	tlSkillPath := filepath.Join(tmpDir, "station", ".claude", "skills", "planning", "SKILL.md")
+	if data, err := os.ReadFile(tlSkillPath); err != nil {
+		t.Fatalf("read tech-lead SKILL.md: %v", err)
+	} else if !bytes.Contains(data, []byte("USER-EDITED")) {
+		t.Fatalf("tech-lead SKILL.md was modified by frontend-scoped regeneration (content = %q)", data)
+	}
+
+	// 2. Negative case: the legacy all-agents WorkflowSkills DOES trip the
+	// cross-agent conflict.
+	tmpDir2, cfg2, lock2 := seed(t)
+	var wrAll WriteResult
+	if err := WorkflowSkills(tmpDir2, cfg2, cat, lock2, &wrAll, false); err != nil {
+		t.Fatalf("WorkflowSkills (legacy): %v", err)
+	}
+	leaked := false
+	for _, f := range wrAll.Conflicts() {
+		if strings.HasPrefix(f.RelPath, "station/") && strings.Contains(f.RelPath, "SKILL.md") {
+			leaked = true
+			break
+		}
+	}
+	if !leaked {
+		t.Fatalf("expected legacy WorkflowSkills to surface a conflict under tech-lead/; got none (wr conflicts=%d total)", len(wrAll.Conflicts()))
+	}
+}
+
+// TestSettingsJSONForAgentScope mirrors the scope-regression shape for the
+// per-agent `.claude/settings.json` writer. `bonsai add` must only touch the
+// agent being added; pre-fix the call-site invoked SettingsJSON which
+// iterated cfg.Agents and regenerated every agent's settings.json, tripping
+// a cross-agent conflict when the user had local edits on an unrelated
+// agent's settings.json.
+//
+//  1. SettingsJSONForAgent(frontend, ...) must NOT emit a conflict under
+//     tech-lead/ even when a tech-lead settings.json exists with local edits
+//     tracked in the lockfile.
+//  2. The legacy SettingsJSON(cfg, ...) with the same fixture DOES produce
+//     the cross-agent conflict.
+func TestSettingsJSONForAgentScope(t *testing.T) {
+	// Both agents wire at least one sensor so settings.json has non-empty
+	// hook entries. The specific event doesn't matter — writeSettingsJSON
+	// emits one group per (event, matcher) pair.
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"sensors/scope-guard/meta.yaml":           "name: scope-guard\ndescription: SG\nagents: all\nevent: PreToolUse\nmatcher: \"Edit|Write\"\n",
+		"sensors/scope-guard/scope-guard.sh.tmpl": "#!/usr/bin/env bash\necho sg\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	techLead := &config.InstalledAgent{
+		AgentType: "tech-lead",
+		Workspace: "station/",
+		Sensors:   []string{"scope-guard"},
+	}
+	frontend := &config.InstalledAgent{
+		AgentType: "frontend",
+		Workspace: "frontend/",
+		Sensors:   []string{"scope-guard"},
+	}
+
+	seed := func(t *testing.T) (tmpDir string, cfg *config.ProjectConfig, lock *config.LockFile) {
+		t.Helper()
+		tmpDir = t.TempDir()
+		cfg = &config.ProjectConfig{
+			ProjectName: "TestProject",
+			Agents: map[string]*config.InstalledAgent{
+				"tech-lead": techLead,
+				"frontend":  frontend,
+			},
+		}
+		lock = config.NewLockFile()
+		var wr WriteResult
+		if err := SettingsJSON(tmpDir, cfg, cat, lock, &wr, false); err != nil {
+			t.Fatalf("initial SettingsJSON: %v", err)
+		}
+		// User edits the tech-lead settings.json on disk — content now
+		// diverges from the lockfile hash so subsequent passes report a
+		// conflict for that path. Invalid JSON is fine for this test: the
+		// content-hash check happens before any parse.
+		tlSettings := filepath.Join(tmpDir, "station", ".claude", "settings.json")
+		if err := os.WriteFile(tlSettings, []byte("{ \"userEdited\": true }"), 0644); err != nil {
+			t.Fatalf("seed tech-lead edit: %v", err)
+		}
+		return tmpDir, cfg, lock
+	}
+
+	// 1. Scoped call with frontend must NOT touch tech-lead's settings.json.
+	tmpDir, cfg, lock := seed(t)
+	var wrFE WriteResult
+	if err := SettingsJSONForAgent(tmpDir, frontend, cfg, cat, lock, &wrFE, false); err != nil {
+		t.Fatalf("SettingsJSONForAgent(frontend): %v", err)
+	}
+	for _, f := range wrFE.Conflicts() {
+		if strings.HasPrefix(f.RelPath, "station/") {
+			t.Fatalf("SettingsJSONForAgent(frontend) leaked a conflict under tech-lead workspace: %s", f.RelPath)
+		}
+	}
+	// Sanity: the tech-lead settings.json is unchanged.
+	tlSettingsPath := filepath.Join(tmpDir, "station", ".claude", "settings.json")
+	if data, err := os.ReadFile(tlSettingsPath); err != nil {
+		t.Fatalf("read tech-lead settings.json: %v", err)
+	} else if !bytes.Contains(data, []byte("userEdited")) {
+		t.Fatalf("tech-lead settings.json was modified by frontend-scoped regeneration (content = %q)", data)
+	}
+
+	// 2. Negative case: the legacy all-agents SettingsJSON DOES trip the
+	// cross-agent conflict.
+	tmpDir2, cfg2, lock2 := seed(t)
+	var wrAll WriteResult
+	if err := SettingsJSON(tmpDir2, cfg2, cat, lock2, &wrAll, false); err != nil {
+		t.Fatalf("SettingsJSON (legacy): %v", err)
+	}
+	leaked := false
+	for _, f := range wrAll.Conflicts() {
+		if strings.HasPrefix(f.RelPath, "station/") && strings.Contains(f.RelPath, "settings.json") {
+			leaked = true
+			break
+		}
+	}
+	if !leaked {
+		t.Fatalf("expected legacy SettingsJSON to surface a conflict under tech-lead/; got none (wr conflicts=%d total)", len(wrAll.Conflicts()))
+	}
+}

--- a/internal/tui/addflow/addflow.go
+++ b/internal/tui/addflow/addflow.go
@@ -1,10 +1,10 @@
-// Package addflow implements the cinematic 6-stage `bonsai add` flow.
+// Package addflow implements the cinematic 4-stage `bonsai add` flow.
 //
 // The package mirrors internal/tui/initflow's shape — chromeless stages that
 // compose a shared persistent chrome (header + enso rail + footer) around a
-// per-stage body — but with a 6-segment rail specific to the add journey:
+// per-stage body — but with a 4-segment rail specific to the add journey:
 //
-//	選 SELECT  地 GROUND  接 GRAFT  観 OBSERVE  育 GROW  結 YIELD
+//	選 SELECT  枝 BRANCHES  観 OBSERVE  結 YIELD
 //
 // Every chrome primitive (RenderHeader, RenderEnsoRail, RenderFooter,
 // RenderMinSizeFloor, ClampColumns, Viewport, PanelContentWidth, design
@@ -13,6 +13,10 @@
 // explicit label slice (Plan 23 Phase 1 refactor).
 //
 // Plan 23 reference: station/Playbook/Plans/Active/23-uiux-phase2-add.md.
+// Plan 27 reference: station/Playbook/Plans/Active/27-add-flow-polish.md —
+// shrinks the visible rail from 7 → 4 segments; Ground, Grow, and Conflicts
+// stages remain in the splicer but render off-rail (rail index sentinel
+// StageIdxOffRail).
 package addflow
 
 import (
@@ -21,38 +25,35 @@ import (
 )
 
 // Stage indices in the add-flow rail. Kept as named constants so ctors and
-// splicers reference them by name rather than literal integers. Plan 23
-// Phase 2 inserted Conflicts between Grow and Yield; the rail now carries
-// seven segments (six default + Conflicts visible only when writes collide).
+// splicers reference them by name rather than literal integers. Plan 27
+// shrinks the rail to four visible stages; Ground, Grow, and Conflicts stages
+// are off-rail and use StageIdxOffRail as their rail index sentinel.
 const (
-	StageIdxSelect    = 0
-	StageIdxGround    = 1
-	StageIdxGraft     = 2
-	StageIdxObserve   = 3
-	StageIdxGrow      = 4
-	StageIdxConflicts = 5
-	StageIdxYield     = 6
+	StageIdxSelect   = 0
+	StageIdxBranches = 1
+	StageIdxObserve  = 2
+	StageIdxYield    = 3
+
+	// StageIdxOffRail is the sentinel rail index for stages that render
+	// without a visible rail tab (Ground, Grow, Conflicts). The base Stage
+	// skips the rail row when its idx is negative.
+	StageIdxOffRail = -1
 )
 
-// StageLabels holds the seven canonical add-flow stage labels in order.
-// Matches Plan 23 decision Q2 — bonsai-raising metaphor extended to the add
-// journey; Phase 2 added Conflicts (衝 しょう) between Grow and Yield so the
-// rail reflects the ConflictsStage when it renders.
+// StageLabels holds the four canonical add-flow stage labels in order.
+// Matches Plan 27's rail canon — Ground / Grow / Conflicts stages still exist
+// as steps in the splicer but do not appear as rail tabs; their rail index is
+// StageIdxOffRail and the base Stage.renderFrame skips the rail render when
+// the index is negative.
 //
 //	選 えらぶ    Select    — pick the agent
-//	地 じ        Ground    — workspace (skipped for tech-lead)
-//	接 つぐ      Graft     — abilities (skills/workflows/protocols/sensors/routines)
+//	枝 えだ      Branches  — abilities (skills/workflows/protocols/sensors/routines)
 //	観 みる      Observe   — one last look before the write
-//	育 そだつ    Grow      — the write animation
-//	衝 しょう    Conflicts — reconcile user-edited files (optional)
 //	結 むすぶ    Yield     — completion card
 var StageLabels = []initflow.StageLabel{
 	{Kanji: "選", Kana: "えらぶ", English: "SELECT"},
-	{Kanji: "地", Kana: "じ", English: "GROUND"},
-	{Kanji: "接", Kana: "つぐ", English: "GRAFT"},
+	{Kanji: "枝", Kana: "えだ", English: "BRANCHES"},
 	{Kanji: "観", Kana: "みる", English: "OBSERVE"},
-	{Kanji: "育", Kana: "そだつ", English: "GROW"},
-	{Kanji: "衝", Kana: "しょう", English: "CONFLICT"},
 	{Kanji: "結", Kana: "むすぶ", English: "YIELD"},
 }
 
@@ -67,12 +68,12 @@ type AgentOption struct {
 	Installed   bool   // true when cfg.Agents[name] exists
 }
 
-// GraftResult is the advance-payload returned from GraftStage.Result() on
-// Enter. Slices preserve catalog iteration order (alphabetical per
+// BranchesResult is the advance-payload returned from BranchesStage.Result()
+// on Enter. Slices preserve catalog iteration order (alphabetical per
 // catalog.loadItems). Required items are always present. Mirrors
 // initflow.BranchesResult shape so the action closure can read either path
 // with a type switch.
-type GraftResult struct {
+type BranchesResult struct {
 	Skills    []string
 	Workflows []string
 	Protocols []string
@@ -82,7 +83,7 @@ type GraftResult struct {
 
 // Total returns the sum of selection counts across the five categories. Used
 // by Observe for the CTA's "Graft ~N items" line.
-func (r GraftResult) Total() int {
+func (r BranchesResult) Total() int {
 	return len(r.Skills) + len(r.Workflows) + len(r.Protocols) +
 		len(r.Sensors) + len(r.Routines)
 }
@@ -98,7 +99,7 @@ func (r GraftResult) Total() int {
 //   - AgentDef       — resolved catalog AgentDef (nil on unknown-agent error).
 //   - Workspace      — normalised workspace path actually written.
 //   - NewAgent       — true for the new-agent branch, false for add-items.
-//   - TotalSelected  — GraftResult.Total() captured at write time.
+//   - TotalSelected  — BranchesResult.Total() captured at write time.
 //   - SpinnerErr     — non-nil when the write pipeline failed; routed to a
 //     tui.Warning by the caller and short-circuits the Yield render.
 type Outcome struct {

--- a/internal/tui/addflow/branches.go
+++ b/internal/tui/addflow/branches.go
@@ -13,27 +13,27 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
 
-// Graft category keys — same five ability types as initflow.BranchesStage.
+// Branches category keys — same five ability types as initflow.BranchesStage.
 const (
-	graftCatSkills    = "skills"
-	graftCatWorkflows = "workflows"
-	graftCatProtocols = "protocols"
-	graftCatSensors   = "sensors"
-	graftCatRoutines  = "routines"
+	branchCatSkills    = "skills"
+	branchCatWorkflows = "workflows"
+	branchCatProtocols = "protocols"
+	branchCatSensors   = "sensors"
+	branchCatRoutines  = "routines"
 )
 
-// graftCat is a single tab in the GraftStage — mirrors branchCat from
-// initflow but kept package-local so Phase 1 doesn't couple to unexported
-// initflow types.
-type graftCat struct {
+// branchCat is a single tab in the BranchesStage — mirrors initflow's
+// branchCat but kept package-local so addflow does not couple to
+// unexported initflow types.
+type branchCat struct {
 	key         string
 	displayName string
 	introLine1  string
 	introLine2  string
-	items       []graftItem
+	items       []branchItem
 }
 
-type graftItem struct {
+type branchItem struct {
 	name        string
 	displayName string
 	description string
@@ -42,16 +42,16 @@ type graftItem struct {
 	filePath    string
 }
 
-// GraftStage is the tabbed ability picker at rail position 2 (接 GRAFT).
+// BranchesStage is the tabbed ability picker at rail position 1 (枝 BRANCHES).
 // Keystroke model matches initflow.BranchesStage: ← → tab, ↑ ↓ focus, ␣
 // toggle, ? details, ↵ advance. Required items are pre-selected and
 // immutable; defaults are pre-selected but toggleable.
 //
-// Result: GraftResult with per-category slices of selected machine names.
-type GraftStage struct {
+// Result: BranchesResult with per-category slices of selected machine names.
+type BranchesStage struct {
 	initflow.Stage
 
-	categories []graftCat
+	categories []branchCat
 	catIdx     int
 	expanded   bool
 	itemIdx    map[int]int
@@ -60,10 +60,10 @@ type GraftStage struct {
 	viewport initflow.Viewport
 }
 
-// GraftContext bundles everything a Graft ctor needs. Kept separate from
-// StageContext so the add-items branch can pass an Installed pointer
+// BranchesContext bundles everything a Branches ctor needs. Kept separate
+// from StageContext so the add-items branch can pass an Installed pointer
 // without polluting the shared context type.
-type GraftContext struct {
+type BranchesContext struct {
 	Cat       *catalog.Catalog
 	AgentType string
 	AgentDef  *catalog.AgentDef
@@ -71,26 +71,24 @@ type GraftContext struct {
 	Installed *config.InstalledAgent
 }
 
-// NewNewAgentGraft constructs a Graft stage for the new-agent branch — all
-// five tabs, defaults seeded from agentDef.
-func NewNewAgentGraft(ctx initflow.StageContext, gctx GraftContext) *GraftStage {
-	return newGraft(ctx, gctx, false)
+// NewNewAgentBranches constructs a Branches stage for the new-agent branch —
+// all five tabs, defaults seeded from agentDef.
+func NewNewAgentBranches(ctx initflow.StageContext, gctx BranchesContext) *BranchesStage {
+	return newBranches(ctx, gctx, false)
 }
 
-// NewAddItemsGraft constructs a Graft stage for the add-items branch —
-// filters each category to uninstalled items, drops empty tabs. Phase 1
-// stub returns a stage with no tabs (add-items branch falls back to legacy
-// runAdd until Phase 2).
-func NewAddItemsGraft(ctx initflow.StageContext, gctx GraftContext) *GraftStage {
-	return newGraft(ctx, gctx, true)
+// NewAddItemsBranches constructs a Branches stage for the add-items branch —
+// filters each category to uninstalled items, drops empty tabs.
+func NewAddItemsBranches(ctx initflow.StageContext, gctx BranchesContext) *BranchesStage {
+	return newBranches(ctx, gctx, true)
 }
 
-// newGraft is the shared constructor. filter=true excludes already-installed
+// newBranches is the shared constructor. filter=true excludes already-installed
 // items per category and drops empty tabs.
-func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftStage {
-	label := StageLabels[StageIdxGraft]
+func newBranches(ctx initflow.StageContext, gctx BranchesContext, filter bool) *BranchesStage {
+	label := StageLabels[StageIdxBranches]
 	base := initflow.NewStage(
-		StageIdxGraft,
+		StageIdxBranches,
 		label,
 		label.English,
 		ctx.Version,
@@ -132,12 +130,12 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 	sensorsDefaults := stringSet(agentDef.DefaultSensors)
 	routinesDefaults := stringSet(agentDef.DefaultRoutines)
 
-	skills := make([]graftItem, 0)
+	skills := make([]branchItem, 0)
 	for _, it := range cat.SkillsFor(agentType) {
 		if filter && installedSkills[it.Name] {
 			continue
 		}
-		skills = append(skills, graftItem{
+		skills = append(skills, branchItem{
 			name:        it.Name,
 			displayName: it.DisplayName,
 			description: it.Description,
@@ -146,12 +144,12 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 			filePath:    it.ContentPath,
 		})
 	}
-	workflows := make([]graftItem, 0)
+	workflows := make([]branchItem, 0)
 	for _, it := range cat.WorkflowsFor(agentType) {
 		if filter && installedWorkflows[it.Name] {
 			continue
 		}
-		workflows = append(workflows, graftItem{
+		workflows = append(workflows, branchItem{
 			name:        it.Name,
 			displayName: it.DisplayName,
 			description: it.Description,
@@ -160,12 +158,12 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 			filePath:    it.ContentPath,
 		})
 	}
-	protocols := make([]graftItem, 0)
+	protocols := make([]branchItem, 0)
 	for _, it := range cat.ProtocolsFor(agentType) {
 		if filter && installedProtocols[it.Name] {
 			continue
 		}
-		protocols = append(protocols, graftItem{
+		protocols = append(protocols, branchItem{
 			name:        it.Name,
 			displayName: it.DisplayName,
 			description: it.Description,
@@ -174,7 +172,7 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 			filePath:    it.ContentPath,
 		})
 	}
-	sensors := make([]graftItem, 0)
+	sensors := make([]branchItem, 0)
 	for _, it := range cat.SensorsFor(agentType) {
 		// routine-check is auto-managed — never user-picked.
 		if it.Name == "routine-check" {
@@ -183,7 +181,7 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 		if filter && installedSensors[it.Name] {
 			continue
 		}
-		sensors = append(sensors, graftItem{
+		sensors = append(sensors, branchItem{
 			name:        it.Name,
 			displayName: it.DisplayName,
 			description: it.Description,
@@ -192,12 +190,12 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 			filePath:    it.ContentPath,
 		})
 	}
-	routines := make([]graftItem, 0)
+	routines := make([]branchItem, 0)
 	for _, it := range cat.RoutinesFor(agentType) {
 		if filter && installedRoutines[it.Name] {
 			continue
 		}
-		routines = append(routines, graftItem{
+		routines = append(routines, branchItem{
 			name:        it.Name,
 			displayName: it.DisplayName,
 			description: it.Description,
@@ -207,33 +205,33 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 		})
 	}
 
-	all := []graftCat{
+	all := []branchCat{
 		{
-			key: graftCatSkills, displayName: "SKILLS",
+			key: branchCatSkills, displayName: "SKILLS",
 			introLine1: "Rulebooks for specific domains.",
 			introLine2: "Standards the agent consults when doing focused work.",
 			items:      skills,
 		},
 		{
-			key: graftCatWorkflows, displayName: "WORKFLOWS",
+			key: branchCatWorkflows, displayName: "WORKFLOWS",
 			introLine1: "Activity-level procedures.",
 			introLine2: "Playbooks for multi-phase tasks from intake to ship.",
 			items:      workflows,
 		},
 		{
-			key: graftCatProtocols, displayName: "PROTOCOLS",
+			key: branchCatProtocols, displayName: "PROTOCOLS",
 			introLine1: "Always-on guardrails.",
 			introLine2: "Rules every session follows, regardless of task.",
 			items:      protocols,
 		},
 		{
-			key: graftCatSensors, displayName: "SENSORS",
+			key: branchCatSensors, displayName: "SENSORS",
 			introLine1: "Hook-triggered automations.",
 			introLine2: "Event scripts the harness runs without prompting.",
 			items:      sensors,
 		},
 		{
-			key: graftCatRoutines, displayName: "ROUTINES",
+			key: branchCatRoutines, displayName: "ROUTINES",
 			introLine1: "Periodic self-maintenance.",
 			introLine2: "Recurring checks on a time-based schedule.",
 			items:      routines,
@@ -241,7 +239,7 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 	}
 
 	// Add-items branch: drop empty tabs entirely.
-	categories := make([]graftCat, 0, len(all))
+	categories := make([]branchCat, 0, len(all))
 	for _, c := range all {
 		if filter && len(c.items) == 0 {
 			continue
@@ -262,7 +260,7 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 		itemIdx[i] = 0
 	}
 
-	return &GraftStage{
+	return &BranchesStage{
 		Stage:      base,
 		categories: categories,
 		catIdx:     0,
@@ -272,10 +270,10 @@ func newGraft(ctx initflow.StageContext, gctx GraftContext, filter bool) *GraftS
 }
 
 // Init implements tea.Model — nothing to fire on entry.
-func (s *GraftStage) Init() tea.Cmd { return nil }
+func (s *BranchesStage) Init() tea.Cmd { return nil }
 
 // Update handles tab cycling, row focus, toggle, inline-expand, and Enter.
-func (s *GraftStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (s *BranchesStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m := msg.(type) {
 	case tea.WindowSizeMsg:
 		s.SetSize(m.Width, m.Height)
@@ -340,7 +338,7 @@ func (s *GraftStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return s, nil
 }
 
-func (s *GraftStage) currentCat() *graftCat {
+func (s *BranchesStage) currentCat() *branchCat {
 	if s.catIdx < 0 || s.catIdx >= len(s.categories) {
 		return nil
 	}
@@ -348,11 +346,11 @@ func (s *GraftStage) currentCat() *graftCat {
 }
 
 // View composes the stage body inside the shared frame.
-func (s *GraftStage) View() string {
+func (s *BranchesStage) View() string {
 	return s.RenderFrame(s.renderBody(), s.keyHints())
 }
 
-func (s *GraftStage) keyHints() []initflow.KeyHint {
+func (s *BranchesStage) keyHints() []initflow.KeyHint {
 	return []initflow.KeyHint{
 		{Key: "←→", Desc: "tab"},
 		{Key: "↑↓", Desc: "move"},
@@ -364,7 +362,7 @@ func (s *GraftStage) keyHints() []initflow.KeyHint {
 	}
 }
 
-func (s *GraftStage) renderBody() string {
+func (s *BranchesStage) renderBody() string {
 	dim := initflow.DimStyle()
 	bark := initflow.LabelStyle()
 	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
@@ -428,7 +426,7 @@ func (s *GraftStage) renderBody() string {
 	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
 }
 
-func (s *GraftStage) renderTabIntro() string {
+func (s *BranchesStage) renderTabIntro() string {
 	c := s.currentCat()
 	if c == nil {
 		return ""
@@ -452,7 +450,7 @@ func (s *GraftStage) renderTabIntro() string {
 	return white.Render(clamp(c.introLine1)) + "\n" + dim.Render(clamp(c.introLine2))
 }
 
-func (s *GraftStage) renderTabs() string {
+func (s *BranchesStage) renderTabs() string {
 	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
 	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
 	bracket := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
@@ -476,7 +474,7 @@ func (s *GraftStage) renderTabs() string {
 	return chevron.Render("‹") + " " + row + " " + chevron.Render("›")
 }
 
-func (s *GraftStage) renderList() string {
+func (s *BranchesStage) renderList() string {
 	c := s.currentCat()
 	if c == nil {
 		return ""
@@ -499,7 +497,7 @@ func (s *GraftStage) renderList() string {
 	return s.viewport.View()
 }
 
-func (s *GraftStage) renderRow(idx int) string {
+func (s *BranchesStage) renderRow(idx int) string {
 	c := s.currentCat()
 	if c == nil || idx < 0 || idx >= len(c.items) {
 		return ""
@@ -576,7 +574,7 @@ func (s *GraftStage) renderRow(idx int) string {
 	return border + glyphStyle.Render(glyph) + " " + nameCol + descCol
 }
 
-func (s *GraftStage) renderDetails() string {
+func (s *BranchesStage) renderDetails() string {
 	dim := initflow.DimStyle()
 	bark := initflow.LabelStyle()
 	value := lipgloss.NewStyle().Foreground(tui.ColorAccent)
@@ -648,7 +646,7 @@ func (s *GraftStage) renderDetails() string {
 	return header + "\n" + aboutRow1 + "\n" + aboutRow2 + "\n" + aboutRow3 + "\n" + fileRow
 }
 
-func (s *GraftStage) renderCounter() string {
+func (s *BranchesStage) renderCounter() string {
 	total := 0
 	for i := range s.categories {
 		total += len(s.selected[i])
@@ -658,7 +656,7 @@ func (s *GraftStage) renderCounter() string {
 
 // listHeight mirrors BranchesStage.listHeight — same chrome + non-list body
 // row accounting.
-func (s *GraftStage) listHeight() int {
+func (s *BranchesStage) listHeight() int {
 	if s.Height() <= 0 {
 		return 0
 	}
@@ -671,7 +669,7 @@ func (s *GraftStage) listHeight() int {
 	return h
 }
 
-func (s *GraftStage) availableWidth() int {
+func (s *BranchesStage) availableWidth() int {
 	w := s.Width() - 4
 	if w < 0 {
 		return 0
@@ -679,10 +677,10 @@ func (s *GraftStage) availableWidth() int {
 	return w
 }
 
-// Result returns a GraftResult with per-category slices of selected machine
+// Result returns a BranchesResult with per-category slices of selected machine
 // names, preserving catalog iteration order. Required items are always
 // present.
-func (s *GraftStage) Result() any {
+func (s *BranchesStage) Result() any {
 	pick := func(idx int) []string {
 		picks := s.selected[idx]
 		c := s.categories[idx]
@@ -694,19 +692,19 @@ func (s *GraftStage) Result() any {
 		}
 		return out
 	}
-	res := GraftResult{}
+	res := BranchesResult{}
 	for i, c := range s.categories {
 		slice := pick(i)
 		switch c.key {
-		case graftCatSkills:
+		case branchCatSkills:
 			res.Skills = slice
-		case graftCatWorkflows:
+		case branchCatWorkflows:
 			res.Workflows = slice
-		case graftCatProtocols:
+		case branchCatProtocols:
 			res.Protocols = slice
-		case graftCatSensors:
+		case branchCatSensors:
 			res.Sensors = slice
-		case graftCatRoutines:
+		case branchCatRoutines:
 			res.Routines = slice
 		}
 	}
@@ -715,7 +713,7 @@ func (s *GraftStage) Result() any {
 
 // Reset clears the completion flag. Per-tab selections, cursor positions,
 // and the inline-expand toggle are all preserved across Esc-back.
-func (s *GraftStage) Reset() tea.Cmd {
+func (s *BranchesStage) Reset() tea.Cmd {
 	s.ClearDone()
 	return nil
 }

--- a/internal/tui/addflow/branches_test.go
+++ b/internal/tui/addflow/branches_test.go
@@ -46,27 +46,27 @@ func newTestGraftCatalog() (*catalog.Catalog, *catalog.AgentDef) {
 	return cat, agentDef
 }
 
-func newTestGraft() *GraftStage {
+func newTestGraft() *BranchesStage {
 	cat, agentDef := newTestGraftCatalog()
-	return NewNewAgentGraft(initflow.StageContext{
+	return NewNewAgentBranches(initflow.StageContext{
 		StartedAt: time.Now(),
-	}, GraftContext{
+	}, BranchesContext{
 		Cat:       cat,
 		AgentType: "backend",
 		AgentDef:  agentDef,
 	})
 }
 
-func graftPressKey(s *GraftStage, k tea.KeyType) {
+func graftPressKey(s *BranchesStage, k tea.KeyType) {
 	m, _ := s.Update(tea.KeyMsg{Type: k})
-	if gs, ok := m.(*GraftStage); ok {
+	if gs, ok := m.(*BranchesStage); ok {
 		*s = *gs
 	}
 }
 
-func graftPressRune(s *GraftStage, r rune) {
+func graftPressRune(s *BranchesStage, r rune) {
 	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
-	if gs, ok := m.(*GraftStage); ok {
+	if gs, ok := m.(*BranchesStage); ok {
 		*s = *gs
 	}
 }
@@ -76,7 +76,7 @@ func graftPressRune(s *GraftStage, r rune) {
 func TestGraft_FiltersRoutineCheck(t *testing.T) {
 	s := newTestGraft()
 	for _, c := range s.categories {
-		if c.key != graftCatSensors {
+		if c.key != branchCatSensors {
 			continue
 		}
 		for _, it := range c.items {
@@ -94,7 +94,7 @@ func TestGraft_RequiredPreSelected(t *testing.T) {
 	// proto-req is in category protocols.
 	var protoIdx int = -1
 	for i, c := range s.categories {
-		if c.key == graftCatProtocols {
+		if c.key == branchCatProtocols {
 			protoIdx = i
 			break
 		}
@@ -120,7 +120,7 @@ func TestGraft_DefaultPreSelectedButToggleable(t *testing.T) {
 	// beta-skill is default in category skills.
 	var skillIdx int = -1
 	for i, c := range s.categories {
-		if c.key == graftCatSkills {
+		if c.key == branchCatSkills {
 			skillIdx = i
 			break
 		}
@@ -185,13 +185,13 @@ func TestGraft_EnterAdvances(t *testing.T) {
 	}
 }
 
-// TestGraft_ResultShape verifies Result returns a GraftResult with the
+// TestGraft_ResultShape verifies Result returns a BranchesResult with the
 // expected pre-selected items (required + defaults).
 func TestGraft_ResultShape(t *testing.T) {
 	s := newTestGraft()
-	res, ok := s.Result().(GraftResult)
+	res, ok := s.Result().(BranchesResult)
 	if !ok {
-		t.Fatalf("Result type = %T, want GraftResult", s.Result())
+		t.Fatalf("Result type = %T, want BranchesResult", s.Result())
 	}
 	if !reflect.DeepEqual(res.Skills, []string{"beta-skill"}) {
 		t.Fatalf("Skills = %v, want [beta-skill]", res.Skills)
@@ -217,7 +217,7 @@ func TestGraft_AddItemsFiltersInstalled(t *testing.T) {
 		Sensors:   []string{"sensor-a"},
 		Routines:  []string{"routine-a"},
 	}
-	s := NewAddItemsGraft(initflow.StageContext{StartedAt: time.Now()}, GraftContext{
+	s := NewAddItemsBranches(initflow.StageContext{StartedAt: time.Now()}, BranchesContext{
 		Cat:       cat,
 		AgentType: "backend",
 		AgentDef:  agentDef,
@@ -242,7 +242,7 @@ func TestGraft_AddItemsPartialDropsEmpty(t *testing.T) {
 		Sensors:   []string{"sensor-a"},    // empty after filter
 		Routines:  []string{"routine-a"},   // empty after filter
 	}
-	s := NewAddItemsGraft(initflow.StageContext{StartedAt: time.Now()}, GraftContext{
+	s := NewAddItemsBranches(initflow.StageContext{StartedAt: time.Now()}, BranchesContext{
 		Cat:       cat,
 		AgentType: "backend",
 		AgentDef:  agentDef,
@@ -251,7 +251,7 @@ func TestGraft_AddItemsPartialDropsEmpty(t *testing.T) {
 	if len(s.categories) != 1 {
 		t.Fatalf("len(categories) = %d, want 1 (only skills should remain)", len(s.categories))
 	}
-	if s.categories[0].key != graftCatSkills {
+	if s.categories[0].key != branchCatSkills {
 		t.Fatalf("remaining tab = %q, want skills", s.categories[0].key)
 	}
 	if len(s.categories[0].items) != 1 || s.categories[0].items[0].name != "beta-skill" {
@@ -268,7 +268,7 @@ func TestGraft_TabCountUpdatesLive(t *testing.T) {
 	// Find skills tab.
 	var skillIdx = -1
 	for i, c := range s.categories {
-		if c.key == graftCatSkills {
+		if c.key == branchCatSkills {
 			skillIdx = i
 			break
 		}
@@ -326,7 +326,7 @@ func TestGraft_NewAgentUnaffectedByFilter(t *testing.T) {
 		Sensors:   []string{"sensor-a"},
 		Routines:  []string{"routine-a"},
 	}
-	s := NewNewAgentGraft(initflow.StageContext{StartedAt: time.Now()}, GraftContext{
+	s := NewNewAgentBranches(initflow.StageContext{StartedAt: time.Now()}, BranchesContext{
 		Cat:       cat,
 		AgentType: "backend",
 		AgentDef:  agentDef,
@@ -339,7 +339,7 @@ func TestGraft_NewAgentUnaffectedByFilter(t *testing.T) {
 	// Skills tab should carry both alpha + beta — filter leak would drop them.
 	var skillIdx = -1
 	for i, c := range s.categories {
-		if c.key == graftCatSkills {
+		if c.key == branchCatSkills {
 			skillIdx = i
 			break
 		}

--- a/internal/tui/addflow/branches_test.go
+++ b/internal/tui/addflow/branches_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
 
-// newTestGraftCatalog builds a fixture catalog covering all five ability
+// newTestBranchesCatalog builds a fixture catalog covering all five ability
 // categories with a mix of required / default / plain items.
-func newTestGraftCatalog() (*catalog.Catalog, *catalog.AgentDef) {
+func newTestBranchesCatalog() (*catalog.Catalog, *catalog.AgentDef) {
 	none := catalog.AgentCompat{}
 	all := catalog.AgentCompat{All: true}
 
@@ -46,8 +46,8 @@ func newTestGraftCatalog() (*catalog.Catalog, *catalog.AgentDef) {
 	return cat, agentDef
 }
 
-func newTestGraft() *BranchesStage {
-	cat, agentDef := newTestGraftCatalog()
+func newTestBranches() *BranchesStage {
+	cat, agentDef := newTestBranchesCatalog()
 	return NewNewAgentBranches(initflow.StageContext{
 		StartedAt: time.Now(),
 	}, BranchesContext{
@@ -57,24 +57,24 @@ func newTestGraft() *BranchesStage {
 	})
 }
 
-func graftPressKey(s *BranchesStage, k tea.KeyType) {
+func branchesPressKey(s *BranchesStage, k tea.KeyType) {
 	m, _ := s.Update(tea.KeyMsg{Type: k})
 	if gs, ok := m.(*BranchesStage); ok {
 		*s = *gs
 	}
 }
 
-func graftPressRune(s *BranchesStage, r rune) {
+func branchesPressRune(s *BranchesStage, r rune) {
 	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
 	if gs, ok := m.(*BranchesStage); ok {
 		*s = *gs
 	}
 }
 
-// TestGraft_FiltersRoutineCheck verifies the routine-check sensor is dropped
+// TestBranches_FiltersRoutineCheck verifies the routine-check sensor is dropped
 // from the sensors tab regardless of filter mode.
-func TestGraft_FiltersRoutineCheck(t *testing.T) {
-	s := newTestGraft()
+func TestBranches_FiltersRoutineCheck(t *testing.T) {
+	s := newTestBranches()
 	for _, c := range s.categories {
 		if c.key != branchCatSensors {
 			continue
@@ -87,10 +87,10 @@ func TestGraft_FiltersRoutineCheck(t *testing.T) {
 	}
 }
 
-// TestGraft_RequiredPreSelected verifies required items are pre-selected and
+// TestBranches_RequiredPreSelected verifies required items are pre-selected and
 // cannot be toggled off.
-func TestGraft_RequiredPreSelected(t *testing.T) {
-	s := newTestGraft()
+func TestBranches_RequiredPreSelected(t *testing.T) {
+	s := newTestBranches()
 	// proto-req is in category protocols.
 	var protoIdx int = -1
 	for i, c := range s.categories {
@@ -107,16 +107,16 @@ func TestGraft_RequiredPreSelected(t *testing.T) {
 	}
 	// Navigate to protocols tab + try to toggle.
 	s.catIdx = protoIdx
-	graftPressRune(s, ' ')
+	branchesPressRune(s, ' ')
 	if !s.selected[protoIdx]["proto-req"] {
 		t.Fatal("␣ on required item should be no-op")
 	}
 }
 
-// TestGraft_DefaultPreSelectedButToggleable verifies defaults are
+// TestBranches_DefaultPreSelectedButToggleable verifies defaults are
 // pre-selected and can be toggled off.
-func TestGraft_DefaultPreSelectedButToggleable(t *testing.T) {
-	s := newTestGraft()
+func TestBranches_DefaultPreSelectedButToggleable(t *testing.T) {
+	s := newTestBranches()
 	// beta-skill is default in category skills.
 	var skillIdx int = -1
 	for i, c := range s.categories {
@@ -134,61 +134,61 @@ func TestGraft_DefaultPreSelectedButToggleable(t *testing.T) {
 	// Focus beta-skill (second row, idx=1) and toggle off.
 	s.catIdx = skillIdx
 	s.itemIdx[skillIdx] = 1
-	graftPressRune(s, ' ')
+	branchesPressRune(s, ' ')
 	if s.selected[skillIdx]["beta-skill"] {
 		t.Fatal("␣ on default should toggle off")
 	}
 }
 
-// TestGraft_TabCycles verifies ← → cycles tabs with wrap.
-func TestGraft_TabCycles(t *testing.T) {
-	s := newTestGraft()
+// TestBranches_TabCycles verifies ← → cycles tabs with wrap.
+func TestBranches_TabCycles(t *testing.T) {
+	s := newTestBranches()
 	start := s.catIdx
-	graftPressKey(s, tea.KeyRight)
+	branchesPressKey(s, tea.KeyRight)
 	if s.catIdx != start+1 {
 		t.Fatalf("right tab = %d, want %d", s.catIdx, start+1)
 	}
 	// Walk to end + wrap.
 	for range s.categories {
-		graftPressKey(s, tea.KeyRight)
+		branchesPressKey(s, tea.KeyRight)
 	}
 	if s.catIdx != start+1 {
 		t.Fatalf("after full cycle, catIdx = %d, want %d (wrap)", s.catIdx, start+1)
 	}
 }
 
-// TestGraft_ExpandToggle verifies ? flips the expanded flag.
-func TestGraft_ExpandToggle(t *testing.T) {
-	s := newTestGraft()
+// TestBranches_ExpandToggle verifies ? flips the expanded flag.
+func TestBranches_ExpandToggle(t *testing.T) {
+	s := newTestBranches()
 	if s.expanded {
 		t.Fatal("expanded should start false")
 	}
-	graftPressRune(s, '?')
+	branchesPressRune(s, '?')
 	if !s.expanded {
 		t.Fatal("? should set expanded=true")
 	}
-	graftPressRune(s, '?')
+	branchesPressRune(s, '?')
 	if s.expanded {
 		t.Fatal("?? should toggle back to false")
 	}
 }
 
-// TestGraft_EnterAdvances verifies Enter flips done.
-func TestGraft_EnterAdvances(t *testing.T) {
-	s := newTestGraft()
+// TestBranches_EnterAdvances verifies Enter flips done.
+func TestBranches_EnterAdvances(t *testing.T) {
+	s := newTestBranches()
 	if s.Done() {
 		t.Fatal("should not be done before Enter")
 	}
-	graftPressKey(s, tea.KeyEnter)
+	branchesPressKey(s, tea.KeyEnter)
 	if !s.Done() {
 		t.Fatal("should be done after Enter")
 	}
 }
 
-// TestGraft_ResultShape verifies Result returns a BranchesResult with the
+// TestBranches_ResultShape verifies Result returns a BranchesResult with the
 // expected pre-selected items (required + defaults).
-func TestGraft_ResultShape(t *testing.T) {
-	s := newTestGraft()
+func TestBranches_ResultShape(t *testing.T) {
+	s := newTestBranches()
 	res, ok := s.Result().(BranchesResult)
 	if !ok {
 		t.Fatalf("Result type = %T, want BranchesResult", s.Result())
@@ -204,10 +204,10 @@ func TestGraft_ResultShape(t *testing.T) {
 	}
 }
 
-// TestGraft_AddItemsFiltersInstalled verifies add-items mode filters out
+// TestBranches_AddItemsFiltersInstalled verifies add-items mode filters out
 // items already in the installed agent + drops empty tabs.
-func TestGraft_AddItemsFiltersInstalled(t *testing.T) {
-	cat, agentDef := newTestGraftCatalog()
+func TestBranches_AddItemsFiltersInstalled(t *testing.T) {
+	cat, agentDef := newTestBranchesCatalog()
 	installed := &config.InstalledAgent{
 		AgentType: "backend",
 		Workspace: "backend/",
@@ -229,10 +229,10 @@ func TestGraft_AddItemsFiltersInstalled(t *testing.T) {
 	}
 }
 
-// TestGraft_AddItemsPartialDropsEmpty verifies add-items mode drops only the
+// TestBranches_AddItemsPartialDropsEmpty verifies add-items mode drops only the
 // tabs that go empty after filtering.
-func TestGraft_AddItemsPartialDropsEmpty(t *testing.T) {
-	cat, agentDef := newTestGraftCatalog()
+func TestBranches_AddItemsPartialDropsEmpty(t *testing.T) {
+	cat, agentDef := newTestBranchesCatalog()
 	installed := &config.InstalledAgent{
 		AgentType: "backend",
 		Workspace: "backend/",
@@ -259,12 +259,12 @@ func TestGraft_AddItemsPartialDropsEmpty(t *testing.T) {
 	}
 }
 
-// TestGraft_TabCountUpdatesLive verifies the per-tab "(N)" counter rendered
+// TestBranches_TabCountUpdatesLive verifies the per-tab "(N)" counter rendered
 // in the tab strip reflects toggles as the user makes them — not a captured
 // ctor-time snapshot. Render the tab row before/after a toggle and compare
 // the focused tab's rendered count.
-func TestGraft_TabCountUpdatesLive(t *testing.T) {
-	s := newTestGraft()
+func TestBranches_TabCountUpdatesLive(t *testing.T) {
+	s := newTestBranches()
 	// Find skills tab.
 	var skillIdx = -1
 	for i, c := range s.categories {
@@ -286,7 +286,7 @@ func TestGraft_TabCountUpdatesLive(t *testing.T) {
 	// Focus skills + toggle alpha-skill on (idx 0).
 	s.catIdx = skillIdx
 	s.itemIdx[skillIdx] = 0
-	graftPressRune(s, ' ')
+	branchesPressRune(s, ' ')
 	after := len(s.selected[skillIdx])
 	if after != 2 {
 		t.Fatalf("after toggle skills count = %d, want 2", after)
@@ -299,7 +299,7 @@ func TestGraft_TabCountUpdatesLive(t *testing.T) {
 	}
 
 	// Toggle alpha back off — count returns to 1.
-	graftPressRune(s, ' ')
+	branchesPressRune(s, ' ')
 	if len(s.selected[skillIdx]) != 1 {
 		t.Fatalf("after second toggle skills count = %d, want 1", len(s.selected[skillIdx]))
 	}
@@ -309,12 +309,12 @@ func TestGraft_TabCountUpdatesLive(t *testing.T) {
 	}
 }
 
-// TestGraft_NewAgentUnaffectedByFilter is a regression guard — the new-agent
+// TestBranches_NewAgentUnaffectedByFilter is a regression guard — the new-agent
 // ctor must NOT filter by Installed even when a non-nil Installed slice is
 // passed (Plan 23 Phase 2 added the filter path inside a shared helper; this
 // test proves the new-agent entry still seeds every catalog item regardless).
-func TestGraft_NewAgentUnaffectedByFilter(t *testing.T) {
-	cat, agentDef := newTestGraftCatalog()
+func TestBranches_NewAgentUnaffectedByFilter(t *testing.T) {
+	cat, agentDef := newTestBranchesCatalog()
 	// Installed carries every item in every category — if the new-agent path
 	// were mistakenly filtering, the tabs would all be empty.
 	installed := &config.InstalledAgent{
@@ -350,14 +350,14 @@ func TestGraft_NewAgentUnaffectedByFilter(t *testing.T) {
 	}
 }
 
-// TestGraft_ResetPreservesState verifies Reset clears done but preserves
+// TestBranches_ResetPreservesState verifies Reset clears done but preserves
 // selections + cursor + expanded.
-func TestGraft_ResetPreservesState(t *testing.T) {
-	s := newTestGraft()
+func TestBranches_ResetPreservesState(t *testing.T) {
+	s := newTestBranches()
 	// Move around + toggle.
-	graftPressKey(s, tea.KeyRight)
-	graftPressRune(s, '?')
-	graftPressKey(s, tea.KeyEnter)
+	branchesPressKey(s, tea.KeyRight)
+	branchesPressRune(s, '?')
+	branchesPressKey(s, tea.KeyEnter)
 	catIdx := s.catIdx
 	expanded := s.expanded
 	s.Reset()

--- a/internal/tui/addflow/conflicts.go
+++ b/internal/tui/addflow/conflicts.go
@@ -57,6 +57,10 @@ type ConflictsStage struct {
 // Bonsai-metaphor identity is retained.
 var conflictsLabel = initflow.StageLabel{Kanji: "衝", Kana: "しょう", English: "CONFLICT"}
 
+// Rail suppression is implicit: passing StageIdxOffRail (-1) into the base
+// ctor trips the negative-index branch in internal/tui/initflow/stage.go
+// (railHidden := s.railHidden || s.idx < 0), so no SetRailIndex call is
+// needed here.
 func NewConflictsStage(ctx initflow.StageContext, wr *generate.WriteResult) *ConflictsStage {
 	label := conflictsLabel
 	base := initflow.NewStage(

--- a/internal/tui/addflow/conflicts.go
+++ b/internal/tui/addflow/conflicts.go
@@ -50,10 +50,17 @@ type ConflictsStage struct {
 // it simply renders an empty body with a single "nothing to reconcile" line
 // and completes on Enter. Callers should gate on wr.HasConflicts() before
 // splicing.
+// conflictsLabel is the kanji/kana/English triple shown in the Conflicts
+// stage body title. Plan 27 shrunk the rail to four visible stages so the
+// Conflicts stage renders off-rail; its rail index is StageIdxOffRail and
+// the rail row is suppressed. The body still reads "衝 CONFLICT" so the
+// Bonsai-metaphor identity is retained.
+var conflictsLabel = initflow.StageLabel{Kanji: "衝", Kana: "しょう", English: "CONFLICT"}
+
 func NewConflictsStage(ctx initflow.StageContext, wr *generate.WriteResult) *ConflictsStage {
-	label := StageLabels[StageIdxConflicts]
+	label := conflictsLabel
 	base := initflow.NewStage(
-		StageIdxConflicts,
+		StageIdxOffRail,
 		label,
 		label.English,
 		ctx.Version,

--- a/internal/tui/addflow/ground.go
+++ b/internal/tui/addflow/ground.go
@@ -42,13 +42,20 @@ type GroundContext struct {
 	ExistingWorkspaces map[string]bool // keys already taken by installed agents
 }
 
+// groundLabel is the kanji/kana/English triple shown in the Ground stage's
+// body title. Plan 27 shrunk the rail to four visible stages, so Ground no
+// longer has a rail tab — its rail index is StageIdxOffRail and the rail row
+// is suppressed by the base Stage's renderFrame. The body title still reads
+// from this local label so the stage retains its bonsai-metaphor identity.
+var groundLabel = initflow.StageLabel{Kanji: "地", Kana: "じ", English: "GROUND"}
+
 // NewGroundStage constructs the Ground stage. When agentType is "tech-lead"
 // the stage is in auto-complete mode — AutoComplete() returns (workspace,
 // true) and the harness's NewLazy wrapper should skip it.
 func NewGroundStage(ctx initflow.StageContext, gc GroundContext) *GroundStage {
-	label := StageLabels[StageIdxGround]
+	label := groundLabel
 	base := initflow.NewStage(
-		StageIdxGround,
+		StageIdxOffRail,
 		label,
 		label.English,
 		ctx.Version,
@@ -57,6 +64,7 @@ func NewGroundStage(ctx initflow.StageContext, gc GroundContext) *GroundStage {
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.SetRailLabels(StageLabels)
 
 	ti := textinput.New()
 	ti.Prompt = "❯ "

--- a/internal/tui/addflow/grow.go
+++ b/internal/tui/addflow/grow.go
@@ -4,7 +4,17 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
 
-// NewGrowStage constructs the Grow stage (育 GROW) at rail position 4.
+// growLabel is the kanji/kana/English triple shown in the Grow stage's body
+// title. Plan 27 shrunk the rail to four visible stages, so Grow no longer
+// owns a rail tab — its rail index is StageIdxOffRail and the rail row is
+// suppressed. Retained here (rather than pulled from StageLabels) so the
+// body title + spinner still read "育 GROWING" unchanged.
+var growLabel = initflow.StageLabel{Kanji: "育", Kana: "そだつ", English: "GROW"}
+
+// NewGrowStage constructs the Grow stage (育 GROW). Renders off-rail —
+// the visible rail stays anchored on OBSERVE while Grow runs so there is
+// no rail churn between Observe and the spinner.
+//
 // Thin wrapper around initflow.NewGenerateStage — installs the add-flow
 // rail labels on the embedded Stage and overrides the body title kanji
 // from 生 (init's Generate) to 育 (Grow) so the visual language matches
@@ -16,9 +26,9 @@ import (
 func NewGrowStage(ctx initflow.StageContext, action initflow.GenerateAction) *initflow.GenerateStage {
 	g := initflow.NewGenerateStage(ctx, action)
 	g.SetRailLabels(StageLabels)
-	g.SetRailIndex(StageIdxGrow)
-	g.SetLabel(StageLabels[StageIdxGrow])
-	g.SetBodyTitle(StageLabels[StageIdxGrow].Kanji, "GROWING")
+	g.SetRailIndex(StageIdxOffRail)
+	g.SetLabel(growLabel)
+	g.SetBodyTitle(growLabel.Kanji, "GROWING")
 	g.SetRailHidden(true)
 	return g
 }

--- a/internal/tui/addflow/observe.go
+++ b/internal/tui/addflow/observe.go
@@ -12,9 +12,9 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
 
-// ObserveStage is the pre-write "one last look" stage at rail position 3
-// (観 OBSERVE). Composes a read-only summary of the Select / Ground / Graft
-// results into a single review panel with a GRAFT / BACK CTA.
+// ObserveStage is the pre-write "one last look" stage at rail position 2
+// (観 OBSERVE). Composes a read-only summary of the Select / Ground /
+// Branches results into a single review panel with a GRAFT / BACK CTA.
 //
 // Result:
 //   - true  → user confirmed GRAFT — harness proceeds to Grow.
@@ -27,9 +27,9 @@ type ObserveStage struct {
 
 	cat *catalog.Catalog
 
-	agent     string      // machine name — prev[0]
-	workspace string      // resolved path — prev[1] (tech-lead auto-fills)
-	graft     GraftResult // prev[2]
+	agent     string         // machine name — prev[0]
+	workspace string         // resolved path — prev[1] (tech-lead auto-fills)
+	graft     BranchesResult // prev[2]
 
 	// agentDef + agentDisplay resolved from cat on each SetPrior.
 	agentDef     *catalog.AgentDef
@@ -74,7 +74,7 @@ func (s *ObserveStage) SetDefaultWorkspace(ws string) { s.workspace = ws }
 // (agent, workspace, graft, ...) while add-items writes (agent, graft, ...)
 // because Ground is skipped. Rather than hard-code positional indices (which
 // break the add-items branch), SetPrior scans prev[] for the first value of
-// each expected type. GraftResult is uniquely typed, so the match is
+// each expected type. BranchesResult is uniquely typed, so the match is
 // unambiguous; agent / workspace are both strings but agent is always
 // prev[0] (from SelectStage) so we grab it first and treat any later string
 // as the workspace.
@@ -91,7 +91,7 @@ func (s *ObserveStage) SetPrior(prev []any) {
 				secondString = x
 			}
 			stringIdx++
-		case GraftResult:
+		case BranchesResult:
 			s.graft = x
 			graftSet = true
 		}
@@ -105,7 +105,7 @@ func (s *ObserveStage) SetPrior(prev []any) {
 		s.workspace = secondString
 	}
 	if !graftSet {
-		s.graft = GraftResult{}
+		s.graft = BranchesResult{}
 	}
 	if s.agent != "" && s.cat != nil {
 		s.agentDef = s.cat.GetAgent(s.agent)
@@ -203,7 +203,7 @@ func (s *ObserveStage) renderAgentBlock() string {
 	bark := initflow.LabelStyle()
 	value := initflow.ValueStyle()
 
-	panelW := observePanelW(s.Width())
+	panelW := initflow.PanelWidth(s.Width())
 	header := initflow.RenderSectionHeader("AGENT", panelW)
 
 	name := s.agentDisplay
@@ -238,7 +238,7 @@ func (s *ObserveStage) renderAbilitiesBlock() string {
 	dim := initflow.DimStyle()
 	value := initflow.ValueStyle()
 
-	panelW := observePanelW(s.Width())
+	panelW := initflow.PanelWidth(s.Width())
 	header := initflow.RenderSectionHeader("ABILITIES", panelW)
 
 	const labelW = 14
@@ -305,16 +305,6 @@ func (s *ObserveStage) renderCTA() string {
 	line2 := dim.Render("Conflicts will prompt — nothing overwritten silently.")
 	line3 := backBtn + "   " + graftBtn
 	return strings.Join([]string{line1, line2, "", line3}, "\n")
-}
-
-// observePanelW caps Observe's panel width at 60 cells so the review card
-// reads as a compact summary rather than stretching to full terminal width.
-func observePanelW(termWidth int) int {
-	w := initflow.PanelWidth(termWidth)
-	if w > 60 {
-		return 60
-	}
-	return w
 }
 
 // Result returns a bool: true = proceed to Grow, false = cancel.

--- a/internal/tui/addflow/observe_test.go
+++ b/internal/tui/addflow/observe_test.go
@@ -44,7 +44,7 @@ func observePressRune(s *ObserveStage, r rune) {
 // upstream results into the stage.
 func TestObserve_SetPriorCapturesFields(t *testing.T) {
 	s := newTestObserve()
-	graft := GraftResult{
+	graft := BranchesResult{
 		Skills:    []string{"s1"},
 		Workflows: []string{"w1"},
 	}
@@ -70,7 +70,7 @@ func TestObserve_SetPriorCapturesFields(t *testing.T) {
 // unknown agent without panicking.
 func TestObserve_SetPriorMissingAgentTolerant(t *testing.T) {
 	s := newTestObserve()
-	s.SetPrior([]any{"unknown-agent", "x/", GraftResult{}})
+	s.SetPrior([]any{"unknown-agent", "x/", BranchesResult{}})
 	if s.agent != "unknown-agent" {
 		t.Fatalf("agent = %q, want unknown-agent", s.agent)
 	}
@@ -81,11 +81,11 @@ func TestObserve_SetPriorMissingAgentTolerant(t *testing.T) {
 
 // TestObserve_SetPriorAddItemsShape verifies SetPrior handles the add-items
 // branch's shorter prev[] slice (no Ground stage → no workspace string).
-// GraftResult is the second slot and must still be captured by type.
+// BranchesResult is the second slot and must still be captured by type.
 func TestObserve_SetPriorAddItemsShape(t *testing.T) {
 	s := newTestObserve()
 	s.SetDefaultWorkspace("backend/")
-	graft := GraftResult{
+	graft := BranchesResult{
 		Skills:   []string{"s1"},
 		Sensors:  []string{"sensor-a"},
 		Routines: []string{"routine-a"},
@@ -176,7 +176,7 @@ func TestObserve_EnterOnBackCancels(t *testing.T) {
 func TestObserve_ViewRendersWorkspace(t *testing.T) {
 	s := newTestObserve()
 	s.SetSize(120, 40)
-	s.SetPrior([]any{"backend", "services/api/", GraftResult{Skills: []string{"s1"}}})
+	s.SetPrior([]any{"backend", "services/api/", BranchesResult{Skills: []string{"s1"}}})
 	out := s.View()
 	if !strings.Contains(out, "services/api/") {
 		t.Fatal("view should contain workspace path")
@@ -187,7 +187,7 @@ func TestObserve_ViewRendersWorkspace(t *testing.T) {
 // confirmation state but preserves prior.
 func TestObserve_ResetClearsConfirmation(t *testing.T) {
 	s := newTestObserve()
-	s.SetPrior([]any{"backend", "ws/", GraftResult{}})
+	s.SetPrior([]any{"backend", "ws/", BranchesResult{}})
 	observePressRune(s, 'y')
 	s.Reset()
 	if s.Done() {

--- a/internal/tui/harness/harness.go
+++ b/internal/tui/harness/harness.go
@@ -214,6 +214,12 @@ func (h *Harness) Init() tea.Cmd {
 // but the splicer interface is extensible) are not recorded; the cast is
 // guarded by type assertion so unknown splicer shapes fall back to the
 // unchanged "splice once, never unwind" behaviour.
+//
+// Zero-child splices (builder returned nil or an all-nil slice) are NOT
+// recorded: there is nothing to reinstate on esc-back — the group's slot
+// contains no children, so unwinding would be a no-op. Skipping the record
+// also keeps the h.splices table tidy and avoids ambiguous "unsplice the
+// zero-length run" semantics in unspliceAbove's slice math.
 func (h *Harness) expandSplicer() {
 	if h.cursor >= len(h.steps) {
 		return
@@ -248,7 +254,7 @@ func (h *Harness) expandSplicer() {
 	head := append([]Step{}, h.steps[:h.cursor]...)
 	tail := append([]Step(nil), h.steps[h.cursor+1:]...)
 	h.steps = append(append(head, inserted...), tail...)
-	if lg != nil {
+	if lg != nil && len(inserted) > 0 {
 		h.splices = append(h.splices, spliceRecord{
 			lg:       lg,
 			insertAt: insertAt,

--- a/internal/tui/harness/harness.go
+++ b/internal/tui/harness/harness.go
@@ -112,6 +112,23 @@ type Chromeless interface {
 	Chromeless() bool
 }
 
+// spliceRecord captures a LazyGroup expansion so the harness's Esc-back
+// path can undo the splice when the cursor pops above the group's original
+// slot. Plan 27 §B1: the pre-fix harness replaced the LazyGroup with its
+// children in h.steps and lost the reference, leaving stale child branches
+// in place when an upstream answer changed. Tracking the original group +
+// slot + child count lets Update reconstruct the pre-splice h.steps shape
+// and reset the group so the next forward advance invokes Splice with fresh
+// prior results.
+//
+// Only LazyGroup currently produces records — single-step lazy builders
+// (LazyStep) do not reshape h.steps and are rebuilt in place via Reset.
+type spliceRecord struct {
+	lg       *LazyGroup // retained ref to the original splicer
+	insertAt int        // absolute index in h.steps where the group originally sat
+	length   int        // count of inserted children occupying that slot
+}
+
 // Harness is the root tea.Model that frames the active step.
 type Harness struct {
 	steps        []Step
@@ -123,6 +140,7 @@ type Harness struct {
 	quitting     bool
 	aborted      bool
 	builderPanic *BuilderPanicError
+	splices      []spliceRecord // ordered by insertAt ascending; see spliceRecord
 }
 
 // New constructs a Harness. The caller should usually invoke Run rather than
@@ -190,6 +208,12 @@ func (h *Harness) Init() tea.Cmd {
 // index, now pointing at the first of the new steps. Idempotent and guarded by
 // Spliced(). On panic in the builder closure, sets h.builderPanic and returns
 // without mutating h.steps so the next Update can return tea.Quit cleanly.
+//
+// LazyGroup expansions are recorded in h.splices so Esc-back can unsplice —
+// see spliceRecord for the rationale. Non-LazyGroup splicers (none today,
+// but the splicer interface is extensible) are not recorded; the cast is
+// guarded by type assertion so unknown splicer shapes fall back to the
+// unchanged "splice once, never unwind" behaviour.
 func (h *Harness) expandSplicer() {
 	if h.cursor >= len(h.steps) {
 		return
@@ -199,6 +223,10 @@ func (h *Harness) expandSplicer() {
 		return
 	}
 	stepTitle := h.steps[h.cursor].Title()
+	// Capture the LazyGroup reference BEFORE Splice mutates state. Splice
+	// flips g.spliced=true so we retain the pointer here to later reset it.
+	lg, _ := sp.(*LazyGroup)
+	insertAt := h.cursor
 	var inserted []Step
 	func() {
 		defer h.recoverBuilder(stepTitle)
@@ -220,6 +248,65 @@ func (h *Harness) expandSplicer() {
 	head := append([]Step{}, h.steps[:h.cursor]...)
 	tail := append([]Step(nil), h.steps[h.cursor+1:]...)
 	h.steps = append(append(head, inserted...), tail...)
+	if lg != nil {
+		h.splices = append(h.splices, spliceRecord{
+			lg:       lg,
+			insertAt: insertAt,
+			length:   len(inserted),
+		})
+	}
+}
+
+// unspliceAbove unwinds every spliceRecord whose insertAt slot sits at or
+// above the new cursor position, reinstating the original LazyGroup at its
+// slot and calling Reset so the next forward advance invokes Splice with
+// fresh prior results. Must be invoked AFTER h.cursor has been popped back
+// to its new value.
+//
+// Iterates the record list in reverse so the tail-first unwind keeps earlier
+// records' offsets stable — each unsplice replaces `length` children with a
+// single group, so records at larger insertAt don't shift records at smaller
+// insertAt. No offset adjustment required.
+//
+// Records kept are those whose insertAt is still strictly BELOW h.cursor —
+// they sit upstream of the new cursor and their spliced children remain
+// valid. Plan 27 §B1.
+func (h *Harness) unspliceAbove() {
+	if len(h.splices) == 0 {
+		return
+	}
+	kept := h.splices[:0:0]
+	// Walk in reverse so tail records unwind first (keeping offsets stable).
+	for i := len(h.splices) - 1; i >= 0; i-- {
+		rec := h.splices[i]
+		if rec.insertAt < h.cursor {
+			// This splice sits strictly above the new cursor — its children
+			// remain valid. Record is retained (prepended, since we iterate
+			// in reverse).
+			kept = append([]spliceRecord{rec}, kept...)
+			continue
+		}
+		// Splice sits at or below h.cursor — unwind it. Replace the child
+		// range with the original LazyGroup and reset so Splice re-fires on
+		// the next forward advance.
+		end := rec.insertAt + rec.length
+		if end > len(h.steps) {
+			end = len(h.steps)
+		}
+		if rec.insertAt > len(h.steps) {
+			// Defensive: record is stale somehow. Drop it silently; retaining
+			// would invite a panic on a bogus slice range.
+			continue
+		}
+		replacement := []Step{rec.lg}
+		newSteps := make([]Step, 0, len(h.steps)-rec.length+1)
+		newSteps = append(newSteps, h.steps[:rec.insertAt]...)
+		newSteps = append(newSteps, replacement...)
+		newSteps = append(newSteps, h.steps[end:]...)
+		h.steps = newSteps
+		rec.lg.Reset()
+	}
+	h.splices = kept
 }
 
 // rebroadcastWindowSize forwards a synthetic WindowSizeMsg with the harness's
@@ -280,6 +367,15 @@ func (h *Harness) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if h.cursor == origCursor {
 				return h, nil
 			}
+			// Unsplice any LazyGroup expansion whose insert-slot sits at or
+			// above the new cursor. The child steps are removed from h.steps
+			// and the original group is reinstated at its slot + reset so a
+			// subsequent forward advance invokes Splice again with fresh
+			// prior results. Plan 27 §B1 regression fix for stale Select
+			// state on esc-back + re-pick — without this step, picking a
+			// different agent on re-advance lands back on the previously-
+			// spliced Branches instance with the old agent's categories.
+			h.unspliceAbove()
 			// Reset every step from the new cursor through origCursor
 			// (inclusive) so that:
 			//   1. The active step's form leaves StateCompleted (otherwise
@@ -291,8 +387,17 @@ func (h *Harness) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			//      that captured prior results at build time) rebuilds on
 			//      re-entry so its panel reflects the user's NEW picks
 			//      rather than the stale pre-Esc snapshot.
+			//
+			// The upper bound (origCursor) is clamped to the current step
+			// count because unspliceAbove may have collapsed several spliced
+			// children back into a single LazyGroup, so origCursor can now
+			// point past len(h.steps).
+			upper := origCursor
+			if upper >= len(h.steps) {
+				upper = len(h.steps) - 1
+			}
 			var cmds []tea.Cmd
-			for i := h.cursor; i <= origCursor && i < len(h.steps); i++ {
+			for i := h.cursor; i <= upper && i < len(h.steps); i++ {
 				// Refresh prior-results snapshot BEFORE Reset so a
 				// ConditionalStep's predicate can re-evaluate against the
 				// user's newly-chosen upstream picks. Without this, the

--- a/internal/tui/harness/steps.go
+++ b/internal/tui/harness/steps.go
@@ -624,6 +624,19 @@ func (g *LazyGroup) Splice(prev []any) []Step {
 // Spliced reports whether Splice has already run.
 func (g *LazyGroup) Spliced() bool { return g.spliced }
 
+// Reset clears the spliced flag so the next forward advance onto the group
+// invokes Splice again against fresh prior results. Used by the harness's
+// Esc-back path when the cursor pops over an already-expanded splice — the
+// inserted children are removed from h.steps and this group is reinstated at
+// its original slot (see harness.Update's splice-record unwind loop). Without
+// this hook, changing an upstream answer and re-advancing would leave the
+// stale child branch in place. Returns nil; LazyGroup does not own any
+// tea.Cmd-worthy state. Plan 27 §B1.
+func (g *LazyGroup) Reset() tea.Cmd {
+	g.spliced = false
+	return nil
+}
+
 // Title implements Step. Only surfaces in a breadcrumb if the harness somehow
 // fails to splice before View() runs — in normal operation the user never sees
 // this title.

--- a/internal/tui/harness/steps_test.go
+++ b/internal/tui/harness/steps_test.go
@@ -727,3 +727,240 @@ func TestLazyGroupResplicesOnEscBack(t *testing.T) {
 		t.Fatalf("after re-advance: h.steps = %v, want [picker, fakeBar]", h.steps)
 	}
 }
+
+// TestLazyGroupResplicesMultiple exercises the multi-group unsplice path:
+// two LazyGroups declared back-to-back after a Picker, each returning a
+// distinct child shape. Advancing past both splices then esc-backing all the
+// way to the Picker must reinstate BOTH groups at their original slots and
+// Reset both so a subsequent forward pass re-splices each one with fresh
+// prior results.
+//
+// Scenario:
+//
+//  1. Declaration: [Picker, LG_A(fn_A), LG_B(fn_B)].
+//     fn_A returns 2 children ([fooA1, fooA2]); fn_B returns 1 child ([fooB]).
+//  2. Advance: picker→LG_A splices in 2 → cursor now on fooA1 → LG_B splices
+//     right after (as the harness advances through fooA1, fooA2 each time
+//     they answer); we drive the advance manually by flipping the fake steps
+//     Done and sending keys.
+//  3. Esc all the way back to Picker.
+//  4. Assert: h.steps matches declaration-time shape — [Picker, LG_A, LG_B] —
+//     both groups Reset (Spliced()==false).
+//  5. Re-advance with the same picker; assert fn_A and fn_B both re-fire and
+//     h.steps ends with the spliced children again.
+func TestLazyGroupResplicesMultiple(t *testing.T) {
+	picker := &answerableFakeStep{fakeStep: fakeStep{title: "pick"}}
+
+	var buildCallsA, buildCallsB int
+	fooA1 := newFake("foo-A-1")
+	fooA2 := newFake("foo-A-2")
+	fooB := newFake("foo-B")
+
+	groupA := NewLazyGroup("BranchA", func(prev []any) []Step {
+		buildCallsA++
+		return []Step{fooA1, fooA2}
+	})
+	groupB := NewLazyGroup("BranchB", func(prev []any) []Step {
+		buildCallsB++
+		return []Step{fooB}
+	})
+
+	h := New("BANNER", "TEST", []Step{picker, groupA, groupB})
+	_, _ = h.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	// Advance: picker answers, harness splices LG_A (2 children).
+	picker.answer("go")
+	_, _ = h.Update(runeKey('x'))
+	if buildCallsA != 1 {
+		t.Fatalf("after first advance: buildCallsA = %d, want 1", buildCallsA)
+	}
+	// Harness cursor now sits at fooA1 (index 1). h.steps shape:
+	// [picker, fooA1, fooA2, groupB].
+	if len(h.steps) != 4 {
+		t.Fatalf("after LG_A splice: len(h.steps) = %d, want 4", len(h.steps))
+	}
+	if h.cursor != 1 {
+		t.Fatalf("after LG_A splice: cursor = %d, want 1", h.cursor)
+	}
+
+	// Advance fooA1 → fooA2 → LG_B splices.
+	fooA1.done = true
+	_, _ = h.Update(runeKey('x'))
+	if h.cursor != 2 {
+		t.Fatalf("after fooA1 done: cursor = %d, want 2", h.cursor)
+	}
+	fooA2.done = true
+	_, _ = h.Update(runeKey('x'))
+	if buildCallsB != 1 {
+		t.Fatalf("after LG_B splice: buildCallsB = %d, want 1", buildCallsB)
+	}
+	// h.steps now: [picker, fooA1, fooA2, fooB]. cursor on fooB (idx 3).
+	if len(h.steps) != 4 {
+		t.Fatalf("after LG_B splice: len(h.steps) = %d, want 4", len(h.steps))
+	}
+	if h.cursor != 3 {
+		t.Fatalf("after LG_B splice: cursor = %d, want 3", h.cursor)
+	}
+
+	// Esc all the way back to Picker. Each esc moves cursor back one
+	// non-auto-complete step; fakeStep is not auto-complete so each esc
+	// moves by one.
+	for h.cursor > 0 {
+		_, _ = h.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	}
+
+	if h.cursor != 0 {
+		t.Fatalf("after esc-all: cursor = %d, want 0", h.cursor)
+	}
+	// Both groups should be reinstated at their original slots.
+	if len(h.steps) != 3 {
+		t.Fatalf("after esc-all: len(h.steps) = %d, want 3 (both groups reinstated)", len(h.steps))
+	}
+	if _, ok := h.steps[1].(*LazyGroup); !ok {
+		t.Fatalf("after esc-all: h.steps[1] = %T, want *LazyGroup", h.steps[1])
+	}
+	if _, ok := h.steps[2].(*LazyGroup); !ok {
+		t.Fatalf("after esc-all: h.steps[2] = %T, want *LazyGroup", h.steps[2])
+	}
+	if gA := h.steps[1].(*LazyGroup); gA.Spliced() {
+		t.Fatalf("after esc-all: LG_A.Spliced() = true, want false (should be reset)")
+	}
+	if gB := h.steps[2].(*LazyGroup); gB.Spliced() {
+		t.Fatalf("after esc-all: LG_B.Spliced() = true, want false (should be reset)")
+	}
+
+	// Re-advance: picker answers again; both groups must re-splice.
+	// Reset downstream fake steps so they aren't already-Done.
+	fooA1.done = false
+	fooA2.done = false
+	fooB.done = false
+	picker.done = false
+	picker.answer("go-again")
+	_, _ = h.Update(runeKey('x'))
+	if buildCallsA != 2 {
+		t.Fatalf("after re-advance: buildCallsA = %d, want 2 (re-splice)", buildCallsA)
+	}
+	if h.cursor != 1 {
+		t.Fatalf("after re-advance: cursor = %d, want 1", h.cursor)
+	}
+	// Walk fooA1, fooA2 forward to trigger LG_B re-splice.
+	fooA1.done = true
+	_, _ = h.Update(runeKey('x'))
+	fooA2.done = true
+	_, _ = h.Update(runeKey('x'))
+	if buildCallsB != 2 {
+		t.Fatalf("after re-advance through fooA2: buildCallsB = %d, want 2 (LG_B re-splice)", buildCallsB)
+	}
+	if len(h.steps) != 4 || h.steps[3] != Step(fooB) {
+		t.Fatalf("after re-advance: h.steps = %v, want [picker, fooA1, fooA2, fooB]", h.steps)
+	}
+}
+
+// TestLazyGroupRespliceEmptyChildren covers the empty-splice corner case:
+// a LazyGroup builder returning nil (zero children) must still be tracked
+// well enough that esc-back reinstates the group AND a subsequent re-advance
+// can invoke the builder again with a different prior-result to produce
+// non-empty children.
+//
+// Post-Fix 4 the Harness guards spliceRecord append on len(inserted) > 0,
+// so an empty splice is not recorded (there is nothing to reinstate — the
+// group is effectively skipped). This test codifies that contract: an
+// empty-splice group is consumed like an auto-complete, but a user re-entry
+// to the step BEFORE it that flips the builder's return path must still re-
+// splice against the new prior results, with no state leaking from the
+// previous zero-child pass.
+//
+// Scenario:
+//
+//  1. Steps: [Picker, LG(fn)] where fn returns nil on the first pass, then
+//     returns []Step{fakeAfter} on the second pass (prior[0] flips).
+//  2. Advance: picker answers, harness splices LG → zero children → harness
+//     continues past it (cursor advances off the end), flow quits.
+//  3. We inspect buildCalls pre-quit: must be 1, and no splice record was
+//     retained (h.splices is empty). The LG must report Spliced()=true since
+//     its splice method fired and Spliced flips unconditionally.
+//  4. This test does NOT exercise the full esc-back path because a
+//     zero-child splice completes the flow; what we verify is that the
+//     guard (Fix 4) prevents an over-eager record from being written. A
+//     non-recorded empty splice means a hypothetical second pass with a
+//     different prev[0] cannot accidentally reinstate stale zero-children —
+//     there was never a record to begin with.
+func TestLazyGroupRespliceEmptyChildren(t *testing.T) {
+	picker := &answerableFakeStep{fakeStep: fakeStep{title: "pick"}}
+
+	var buildCalls int
+	var lastPrev []any
+	fakeAfter := newFake("after")
+
+	group := NewLazyGroup("Branch", func(prev []any) []Step {
+		buildCalls++
+		lastPrev = append([]any(nil), prev...)
+		if len(prev) > 0 && prev[0] == "refill" {
+			return []Step{fakeAfter}
+		}
+		return nil // zero-child splice
+	})
+
+	h := New("BANNER", "TEST", []Step{picker, group})
+	_, _ = h.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	// Advance: picker answers; fn returns nil; harness walks past.
+	picker.answer("empty")
+	_, _ = h.Update(runeKey('x'))
+
+	if buildCalls != 1 {
+		t.Fatalf("after first advance: buildCalls = %d, want 1", buildCalls)
+	}
+	if len(lastPrev) != 1 || lastPrev[0] != "empty" {
+		t.Fatalf("first splice prev = %v, want [empty]", lastPrev)
+	}
+	// Fix 4 contract: zero-child splice must NOT be recorded — the record
+	// table stays empty so a later esc-back doesn't try to "unsplice"
+	// something that was never spliced.
+	if len(h.splices) != 0 {
+		t.Fatalf("after empty splice: len(h.splices) = %d, want 0 (guard in expandSplicer)", len(h.splices))
+	}
+	// LazyGroup.Spliced() flips on any Splice invocation regardless of
+	// child count, so the harness won't re-fire Splice on a second Init.
+	if !group.Spliced() {
+		t.Fatalf("LazyGroup.Spliced() = false after empty splice; want true (Splice fired)")
+	}
+
+	// Forward-advance behaviour: with zero children spliced, the group is
+	// effectively dropped from h.steps (len drops from 2 → 1). Cursor
+	// should now sit past the end → quitting.
+	if len(h.steps) != 1 {
+		t.Fatalf("after empty splice: len(h.steps) = %d, want 1 (group dropped)", len(h.steps))
+	}
+	if !h.quitting {
+		t.Fatalf("after empty splice reaching end: quitting = false, want true")
+	}
+
+	// Build a fresh harness to prove the builder can still return non-empty
+	// on a different prev. This mirrors the "esc-back + repick" flow without
+	// needing to resurrect a quit harness.
+	group2 := NewLazyGroup("Branch", func(prev []any) []Step {
+		buildCalls++
+		if len(prev) > 0 && prev[0] == "refill" {
+			return []Step{fakeAfter}
+		}
+		return nil
+	})
+	picker2 := &answerableFakeStep{fakeStep: fakeStep{title: "pick"}}
+	h2 := New("BANNER", "TEST", []Step{picker2, group2})
+	_, _ = h2.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	picker2.answer("refill")
+	_, _ = h2.Update(runeKey('x'))
+
+	if len(h2.steps) != 2 || h2.steps[1] != Step(fakeAfter) {
+		t.Fatalf("refill pass: h2.steps = %v, want [picker2, fakeAfter]", h2.steps)
+	}
+	if !group2.Spliced() {
+		t.Fatalf("refill pass: group2.Spliced() = false, want true")
+	}
+	// Non-empty splice MUST be recorded (unlike the empty-splice case above).
+	if len(h2.splices) != 1 {
+		t.Fatalf("refill pass: len(h2.splices) = %d, want 1 (non-empty splice recorded)", len(h2.splices))
+	}
+}

--- a/internal/tui/harness/steps_test.go
+++ b/internal/tui/harness/steps_test.go
@@ -607,3 +607,123 @@ func TestConditionalLazyBuilderFiresOncePerActivePass(t *testing.T) {
 		t.Fatalf("after Reset+Init: buildCalls = %d, want 2 (one re-fire)", buildCalls)
 	}
 }
+
+// ─── LazyGroup re-splice (Plan 27 §B1) ────────────────────────────────────
+
+// answerableFakeStep is a fakeStep that can be toggled between different
+// result values on demand, and whose Done flag the test flips explicitly.
+// Used to simulate an upstream Select step whose pick drives the LazyGroup
+// branch shape: first "foo", then "bar" after an esc-back re-pick.
+type answerableFakeStep struct {
+	fakeStep
+}
+
+func (f *answerableFakeStep) answer(v any) {
+	f.result = v
+	f.done = true
+}
+
+// TestLazyGroupResplicesOnEscBack is the B1 regression guard. Pre-fix, a
+// LazyGroup was replaced in h.steps by its children on first splice and the
+// original reference was lost — esc-back + re-picking the upstream answer
+// landed the user back on the previously-spliced children with stale data
+// baked in. The fix adds spliceRecord tracking in Harness so esc-back can
+// unsplice (remove children, reinstate the group, Reset it) and the next
+// forward advance invokes Splice with the new prior results.
+//
+// Scenario exercised end-to-end through the harness reducer:
+//
+//  1. Steps: [answerableFakeStep, LazyGroup(fn)]
+//     fn(prev) inspects prev[0] and returns child sets keyed on that value:
+//     "foo" → [fakeFoo]; "bar" → [fakeBar]; anything else → nil.
+//  2. User "picks foo" (step 0 sets Done + result="foo"); harness advances.
+//  3. fn should fire once with prev=["foo"] and splice fakeFoo into h.steps.
+//  4. User hits esc. Cursor pops to step 0. The LazyGroup should be reinstated
+//     at its original slot; h.steps should match the declaration-time shape.
+//  5. User "picks bar" (step 0 Done + result="bar"); harness advances.
+//  6. fn should fire a second time with prev=["bar"] and splice fakeBar —
+//     NOT fakeFoo. Without the B1 fix, the old children stay in place and
+//     fakeBar never appears.
+func TestLazyGroupResplicesOnEscBack(t *testing.T) {
+	picker := &answerableFakeStep{fakeStep: fakeStep{title: "pick"}}
+
+	var buildCalls int
+	var lastPrev []any
+	fakeFoo := newFake("spliced-foo")
+	fakeBar := newFake("spliced-bar")
+
+	group := NewLazyGroup("Branch", func(prev []any) []Step {
+		buildCalls++
+		lastPrev = append([]any(nil), prev...)
+		if len(prev) == 0 {
+			return nil
+		}
+		switch prev[0] {
+		case "foo":
+			return []Step{fakeFoo}
+		case "bar":
+			return []Step{fakeBar}
+		}
+		return nil
+	})
+
+	h := New("BANNER", "TEST", []Step{picker, group})
+	// Prime dimensions so rebroadcastWindowSize no-ops cleanly.
+	_, _ = h.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	// Step 1: pick "foo" and let the harness advance.
+	picker.answer("foo")
+	_, _ = h.Update(runeKey('x'))
+
+	if buildCalls != 1 {
+		t.Fatalf("first advance: build calls = %d, want 1", buildCalls)
+	}
+	if len(lastPrev) != 1 || lastPrev[0] != "foo" {
+		t.Fatalf("first splice prev = %v, want [foo]", lastPrev)
+	}
+	if h.cursor != 1 {
+		t.Fatalf("after first splice: cursor = %d, want 1", h.cursor)
+	}
+	if len(h.steps) != 2 || h.steps[1] != Step(fakeFoo) {
+		t.Fatalf("after first splice: h.steps = %v, want [picker, fakeFoo]", h.steps)
+	}
+
+	// Step 2: user hits esc to go back. The harness should pop the cursor to
+	// 0, unsplice the group (removing fakeFoo, reinstating the group), and
+	// Reset the picker so its form is live again.
+	_, _ = h.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if h.cursor != 0 {
+		t.Fatalf("after esc: cursor = %d, want 0", h.cursor)
+	}
+	if len(h.steps) != 2 {
+		t.Fatalf("after esc: len(h.steps) = %d, want 2 (group reinstated)", len(h.steps))
+	}
+	if _, ok := h.steps[1].(*LazyGroup); !ok {
+		t.Fatalf("after esc: h.steps[1] = %T, want *LazyGroup (unspliced)", h.steps[1])
+	}
+	// Group must be reset so Spliced() reports false for the next advance.
+	if grp, ok := h.steps[1].(*LazyGroup); ok && grp.Spliced() {
+		t.Fatalf("after esc: LazyGroup.Spliced() = true, want false (not reset)")
+	}
+
+	// Step 3: re-pick "bar" on the same picker. The picker is still the same
+	// instance — its done flag needs to flip back to false so the harness
+	// doesn't treat it as already-advanced; the answer helper replaces the
+	// result value and flips done.
+	picker.done = false
+	picker.answer("bar")
+	_, _ = h.Update(runeKey('y'))
+
+	if buildCalls != 2 {
+		t.Fatalf("after re-advance: build calls = %d, want 2 (splice re-fired)", buildCalls)
+	}
+	if len(lastPrev) != 1 || lastPrev[0] != "bar" {
+		t.Fatalf("second splice prev = %v, want [bar]", lastPrev)
+	}
+	if h.cursor != 1 {
+		t.Fatalf("after re-advance: cursor = %d, want 1", h.cursor)
+	}
+	if len(h.steps) != 2 || h.steps[1] != Step(fakeBar) {
+		t.Fatalf("after re-advance: h.steps = %v, want [picker, fakeBar]", h.steps)
+	}
+}

--- a/internal/tui/initflow/stage.go
+++ b/internal/tui/initflow/stage.go
@@ -211,8 +211,14 @@ func (s *Stage) renderFrame(body string, keys []KeyHint) string {
 
 	count := func(s string) int { return strings.Count(s, "\n") + 1 }
 	chromeRows := count(header) + 1 + 1 + count(footer)
+	// Rail is hidden when railHidden is set OR the stage uses a negative
+	// rail index sentinel (addflow.StageIdxOffRail = -1). Off-rail stages
+	// still participate in the harness step list but render without a
+	// visible rail tab — used by the Plan 27 rail-shrink for Ground, Grow,
+	// and Conflicts.
+	railHidden := s.railHidden || s.idx < 0
 	var rail string
-	if !s.railHidden {
+	if !railHidden {
 		rail = RenderEnsoRail(s.idx, s.labels, width, s.ensoSafe)
 		chromeRows += count(rail) + 1
 	}
@@ -229,7 +235,7 @@ func (s *Stage) renderFrame(body string, keys []KeyHint) string {
 		body = strings.Join(lines[:bodyTarget], "\n")
 	}
 
-	if s.railHidden {
+	if railHidden {
 		return header + "\n\n" + body + "\n\n" + footer
 	}
 	return header + "\n\n" + rail + "\n\n" + body + "\n\n" + footer


### PR DESCRIPTION
## Summary
Plan 27 PR1 — foundations + bugs for `bonsai add` cinematic polish.
Rail shrinks to 4 canonical stages, Graft→Branches rename, stale Select-state
bug fix via harness re-splice, cross-agent conflict leak fix scoping add's
generator calls to single agent.

## Changes
- `internal/tui/addflow/addflow.go` — StageLabels shrunk to 4 stages; StageIdxOffRail added
- `internal/tui/addflow/branches.go` (rename from graft.go) — Graft→Branches
- `internal/tui/addflow/branches_test.go` (rename from graft_test.go)
- `internal/tui/addflow/ground.go` — rail index off-rail
- `internal/tui/addflow/grow.go` — rail index off-rail
- `internal/tui/addflow/conflicts.go` — rail index off-rail
- `internal/tui/addflow/observe.go` — body width aligned to PanelWidth
- `internal/tui/initflow/stage.go` — rail render gated on non-negative index
- `internal/tui/harness/steps.go` — LazyGroup.Reset() added
- `internal/tui/harness/harness.go` — spliceRecord tracking + unsplice on esc-back
- `internal/tui/harness/steps_test.go` — TestLazyGroupResplicesOnEscBack
- `internal/generate/generate.go` — *ForAgent variants for PathScopedRules / WorkflowSkills / SettingsJSON
- `internal/generate/generate_test.go` — TestPathScopedRulesForAgentScope
- `cmd/add.go` — call-site swap to *ForAgent; type-scan updated for BranchesResult

## Plan
station/Playbook/Plans/Active/27-add-flow-polish.md (Phase A + B only)

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `gofmt -s -l internal/tui/ cmd/ internal/generate/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)