### PR TITLE
feat(plan-28): P1 cinematic bonsai catalog + RenderHeader extension + hide completion

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -71,13 +71,17 @@ func runAdd(cmd *cobra.Command, args []string) error {
 	// Shared context stamped onto every stage. AgentDisplay is resolved lazily
 	// inside the splicer once the user picks an agent — the initial value
 	// here is empty so the header right-block reads "PLANTING INTO" over the
-	// project path (same convention as initflow).
+	// project path (same convention as initflow). HeaderAction +
+	// HeaderRightLabel preserve the current add-flow presentation verbatim
+	// under the Plan 28 Phase 1 signature extension.
 	ctx := initflow.StageContext{
-		Version:      Version,
-		ProjectDir:   cwd,
-		StationDir:   "station/",
-		AgentDisplay: "",
-		StartedAt:    startedAt,
+		Version:          Version,
+		ProjectDir:       cwd,
+		StationDir:       "station/",
+		AgentDisplay:     "",
+		StartedAt:        startedAt,
+		HeaderAction:     "INIT",
+		HeaderRightLabel: "PLANTING INTO",
 	}
 
 	lock, _ := config.LoadLockFile(cwd)

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -2,10 +2,15 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
+	"github.com/LastStep/Bonsai/internal/catalog"
 	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/catalogflow"
 )
 
 func init() {
@@ -19,10 +24,28 @@ var catalogCmd = &cobra.Command{
 	RunE:  runCatalog,
 }
 
+// runCatalog is the catalog command entry point. TTY invocations open
+// the cinematic BubbleTea browser (catalogflow.BrowserStage);
+// non-TTY invocations (pipes, CI, `> out.txt`) fall back to the
+// static-render path so piped output stays clean and ANSI-free.
 func runCatalog(cmd *cobra.Command, args []string) error {
 	cat := loadCatalog()
 	agentFilter, _ := cmd.Flags().GetString("agent")
 
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		return renderCatalogStatic(cat, agentFilter)
+	}
+
+	stage := catalogflow.NewBrowser(cat, agentFilter)
+	_, err := tea.NewProgram(stage, tea.WithAltScreen()).Run()
+	return err
+}
+
+// renderCatalogStatic renders the seven catalog sections as a flat,
+// one-shot block — the pre-Plan-28 output preserved verbatim for
+// non-TTY invocations (piped output, CI consumers). The TTY path
+// launches the BubbleTea browser instead.
+func renderCatalogStatic(cat *catalog.Catalog, agentFilter string) error {
 	// Agents
 	tui.SectionHeader(fmt.Sprintf("Agents (%d)", len(cat.Agents)))
 	var agentRows [][]string

--- a/cmd/catalog.go
+++ b/cmd/catalog.go
@@ -36,9 +36,15 @@ func runCatalog(cmd *cobra.Command, args []string) error {
 		return renderCatalogStatic(cat, agentFilter)
 	}
 
-	stage := catalogflow.NewBrowser(cat, agentFilter)
-	_, err := tea.NewProgram(stage, tea.WithAltScreen()).Run()
-	return err
+	// cwd feeds the header's right-row-2 so the browser shows where it
+	// was invoked from (catalog is global but the path anchor is still a
+	// useful breadcrumb for multi-terminal users).
+	cwd := mustCwd()
+	stage := catalogflow.NewBrowser(cat, agentFilter, cwd)
+	if _, err := tea.NewProgram(stage, tea.WithAltScreen()).Run(); err != nil {
+		return fmt.Errorf("catalog browser: %w", err)
+	}
+	return nil
 }
 
 // renderCatalogStatic renders the seven catalog sections as a flat,

--- a/cmd/catalog_test.go
+++ b/cmd/catalog_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+)
+
+// fakeCatalogForStatic returns a minimal in-memory catalog covering
+// all 7 sections so renderCatalogStatic exercises every branch.
+func fakeCatalogForStatic() *catalog.Catalog {
+	return &catalog.Catalog{
+		Agents: []catalog.AgentDef{
+			{Name: "tech-lead", DisplayName: "Tech Lead", Description: "orchestrator"},
+		},
+		Skills: []catalog.CatalogItem{
+			{Name: "planning-template", DisplayName: "Planning Template", Description: "tiered plans", Agents: catalog.AgentCompat{All: true}},
+		},
+		Workflows: []catalog.CatalogItem{
+			{Name: "code-review", DisplayName: "Code Review", Description: "review pipeline", Agents: catalog.AgentCompat{All: true}},
+		},
+		Protocols: []catalog.CatalogItem{
+			{Name: "memory", DisplayName: "Memory", Description: "memory protocol", Agents: catalog.AgentCompat{All: true}},
+		},
+		Sensors: []catalog.SensorItem{
+			{Name: "status-bar", DisplayName: "Status Bar", Description: "status line", Event: "Stop", Agents: catalog.AgentCompat{All: true}},
+		},
+		Routines: []catalog.RoutineItem{
+			{Name: "backlog-hygiene", DisplayName: "Backlog Hygiene", Description: "weekly sweep", Frequency: "7 days", Agents: catalog.AgentCompat{All: true}},
+		},
+		Scaffolding: []catalog.ScaffoldingItem{
+			{Name: "playbook", DisplayName: "Playbook", Description: "plans + roadmap", Required: true, Affects: "planning"},
+		},
+	}
+}
+
+// TestRenderCatalogStatic_AllSevenSectionsPresent verifies the non-TTY
+// static render produces a header for each of the 7 catalog sections
+// and embeds the entry count.
+func TestRenderCatalogStatic_AllSevenSectionsPresent(t *testing.T) {
+	cat := fakeCatalogForStatic()
+
+	out := captureStdout(t, func() {
+		if err := renderCatalogStatic(cat, ""); err != nil {
+			t.Fatalf("renderCatalogStatic: %v", err)
+		}
+	})
+
+	// Each section header renders as "<Name> (<count>)" with a trailing
+	// rule. Assert presence of each headline + embedded count.
+	for _, want := range []string{
+		"Agents (1)",
+		"Skills (1)",
+		"Workflows (1)",
+		"Protocols (1)",
+		"Sensors (1)",
+		"Routines (1)",
+		"Scaffolding (1)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("static catalog output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderCatalogStatic_AgentFilterChangesSuffix verifies the
+// agent-filter branch appends the "for <agent>" suffix on filterable
+// sections.
+func TestRenderCatalogStatic_AgentFilterChangesSuffix(t *testing.T) {
+	cat := fakeCatalogForStatic()
+
+	out := captureStdout(t, func() {
+		if err := renderCatalogStatic(cat, "tech-lead"); err != nil {
+			t.Fatalf("renderCatalogStatic: %v", err)
+		}
+	})
+
+	// Skills/Workflows/Protocols/Sensors/Routines show the filter suffix.
+	// Agents and Scaffolding do not (per the existing static-render
+	// contract).
+	for _, want := range []string{
+		"Skills (1 for tech-lead)",
+		"Workflows (1 for tech-lead)",
+		"Protocols (1 for tech-lead)",
+		"Sensors (1 for tech-lead)",
+		"Routines (1 for tech-lead)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("filtered catalog output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/init_flow.go
+++ b/cmd/init_flow.go
@@ -55,13 +55,17 @@ func runInit(cmd *cobra.Command, args []string) error {
 		agentDisplay = catalog.DisplayNameFrom(agentDef.Name)
 	}
 
-	// Shared context stamped on every stage.
+	// Shared context stamped on every stage. HeaderAction + HeaderRightLabel
+	// are passed explicitly so the per-command chrome reads correctly even
+	// as Plan 28's signature extension rolls out across sibling flows.
 	ctx := initflow.StageContext{
-		Version:      Version,
-		ProjectDir:   cwd,
-		StationDir:   "station/",
-		AgentDisplay: agentDisplay,
-		StartedAt:    startedAt,
+		Version:          Version,
+		ProjectDir:       cwd,
+		StationDir:       "station/",
+		AgentDisplay:     agentDisplay,
+		StartedAt:        startedAt,
+		HeaderAction:     "INIT",
+		HeaderRightLabel: "PLANTING INTO",
 	}
 
 	// Lock + WriteResult shared between the Generate action and the conflict

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,6 +37,9 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
+	// Hide Cobra's auto-generated `completion` subcommand from `bonsai --help`.
+	// The command remains functional for users who invoke it directly.
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
 }
 
 func loadCatalog() *catalog.Catalog {

--- a/internal/tui/addflow/branches.go
+++ b/internal/tui/addflow/branches.go
@@ -97,6 +97,7 @@ func newBranches(ctx initflow.StageContext, gctx BranchesContext, filter bool) *
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.ApplyContextHeader(ctx)
 	base.SetRailLabels(StageLabels)
 
 	agentDef := gctx.AgentDef

--- a/internal/tui/addflow/conflicts.go
+++ b/internal/tui/addflow/conflicts.go
@@ -73,6 +73,7 @@ func NewConflictsStage(ctx initflow.StageContext, wr *generate.WriteResult) *Con
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.ApplyContextHeader(ctx)
 	base.SetRailLabels(StageLabels)
 
 	var conflicts []generate.FileResult

--- a/internal/tui/addflow/ground.go
+++ b/internal/tui/addflow/ground.go
@@ -64,6 +64,7 @@ func NewGroundStage(ctx initflow.StageContext, gc GroundContext) *GroundStage {
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.ApplyContextHeader(ctx)
 	base.SetRailLabels(StageLabels)
 
 	ti := textinput.New()

--- a/internal/tui/addflow/observe.go
+++ b/internal/tui/addflow/observe.go
@@ -52,6 +52,7 @@ func NewObserveStage(ctx initflow.StageContext, cat *catalog.Catalog) *ObserveSt
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.ApplyContextHeader(ctx)
 	base.SetRailLabels(StageLabels)
 	return &ObserveStage{
 		Stage:    base,

--- a/internal/tui/addflow/select.go
+++ b/internal/tui/addflow/select.go
@@ -43,6 +43,7 @@ func NewSelectStage(ctx initflow.StageContext, options []AgentOption) *SelectSta
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.ApplyContextHeader(ctx)
 	base.SetRailLabels(StageLabels)
 	return &SelectStage{
 		Stage:   base,

--- a/internal/tui/addflow/yield.go
+++ b/internal/tui/addflow/yield.go
@@ -100,6 +100,7 @@ func newYield(ctx initflow.StageContext, mode yieldMode, tail func(*YieldStage))
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.ApplyContextHeader(ctx)
 	base.SetRailLabels(StageLabels)
 	y := &YieldStage{
 		Stage: base,

--- a/internal/tui/catalogflow/browser.go
+++ b/internal/tui/catalogflow/browser.go
@@ -58,6 +58,38 @@ type BrowserStage struct {
 	quit bool
 }
 
+// shortLabelThreshold is the width (in columns) at or below which the
+// tab strip switches to short-label mode. The seven full tabs plus
+// "(N)" counts plus 2-space separators render at ~96 visible cells;
+// below that they wrap or clip against the 70-col minimum floor. Short
+// labels bring the strip inside a 70-col frame.
+const shortLabelThreshold = 96
+
+// shortLabel returns the compact form of a tab label for use under
+// narrow widths. Target: keep the full 7-tab strip inside the 70-col
+// minimum-width floor. All labels collapse to <=5 chars so the strip
+// + "(N)" counts + 1-space separators fit with margin.
+func shortLabel(full string) string {
+	switch full {
+	case "AGENTS":
+		return "AGENT"
+	case "SKILLS":
+		return "SKILL"
+	case "WORKFLOWS":
+		return "FLOWS"
+	case "PROTOCOLS":
+		return "PROTO"
+	case "SENSORS":
+		return "SENSE"
+	case "ROUTINES":
+		return "RTNES"
+	case "SCAFFOLDING":
+		return "SCAFF"
+	default:
+		return full
+	}
+}
+
 // NewBrowser constructs a BrowserStage from a loaded catalog, applying
 // the optional -a/--agent filter. An empty agentFilter shows every
 // entry in every tab. With a non-empty filter, per-section cat.*For
@@ -65,9 +97,14 @@ type BrowserStage struct {
 // entries render a greyed (0) suffix but are not removed from the
 // tab strip.
 //
+// projectDir is the absolute path to the invoking shell's cwd — passed
+// through so the header's right-row-2 renders a useful path fragment
+// instead of a bare "./". Resolve at the cmd/catalog.go callsite via
+// the existing mustCwd() helper.
+//
 // Called from cmd/catalog.go when stdout is a TTY. Non-TTY invocations
 // stay on the existing static-render path.
-func NewBrowser(cat *catalog.Catalog, agentFilter string) *BrowserStage {
+func NewBrowser(cat *catalog.Catalog, agentFilter string, projectDir string) *BrowserStage {
 	categories := buildCategories(cat, agentFilter)
 
 	itemIdx := make(map[int]int, len(categories))
@@ -79,8 +116,8 @@ func NewBrowser(cat *catalog.Catalog, agentFilter string) *BrowserStage {
 		0,
 		initflow.StageLabel{Kanji: "録", Kana: "ロク", English: "CATALOG"},
 		"CATALOG",
-		"", // version: catalog's header renders no version chip
-		"", // projectDir: catalog is global, no project context
+		"",         // version: catalog's header renders no version chip
+		projectDir, // projectDir: threaded through so header right-row-2 renders the cwd
 		"",
 		"",
 		// Zero time — catalog has no elapsed counter. Matches the
@@ -332,6 +369,14 @@ func (s *BrowserStage) Result() any { return nil }
 
 // View composes the full frame: header + tab strip + list + optional
 // inline-expand detail block + footer. No rail (SetRailHidden(true)).
+//
+// Routing: header/footer go through the embedded Stage.RenderFrame so
+// the stored headerAction / headerRightLabel / projectDir (set in
+// NewBrowser) drive the render. This keeps the catalog's chrome
+// consistent with every other initflow-embedded stage and removes a
+// duplicated copy of the padding/truncation math previously inlined
+// here. The body we hand to RenderFrame is just the tab strip + list +
+// optional details block.
 func (s *BrowserStage) View() string {
 	if s.quit {
 		return ""
@@ -341,18 +386,13 @@ func (s *BrowserStage) View() string {
 	if width <= 0 {
 		width = 80
 	}
-	height := s.Height()
-	if height <= 0 {
-		height = 24
-	}
 
-	// Min-size floor — same 70×20 threshold as init/add.
+	// Min-size floor short-circuit is redundant with RenderFrame's own
+	// guard, but keep it here so View returns the floor panel directly
+	// without constructing a body that would be discarded.
 	if initflow.TerminalTooSmall(s.Width(), s.Height()) {
 		return initflow.RenderMinSizeFloor(s.Width(), s.Height())
 	}
-
-	header := initflow.RenderHeader("", "", "CATALOG", "", width, s.EnsoSafe())
-	footer := initflow.RenderFooter(s.keyHints(), width)
 
 	tabRow := s.renderTabs()
 	list := s.renderList()
@@ -370,28 +410,7 @@ func (s *BrowserStage) View() string {
 	}
 	body := initflow.CenterBlock(strings.Join(bodyParts, "\n"), width)
 
-	// Pad body so footer sits at the bottom of the AltScreen — same
-	// technique initflow.Stage.renderFrame uses.
-	count := func(str string) int {
-		if str == "" {
-			return 0
-		}
-		return strings.Count(str, "\n") + 1
-	}
-	chromeRows := count(header) + 1 + 1 + count(footer)
-	bodyTarget := height - chromeRows
-	if bodyTarget < 1 {
-		bodyTarget = 1
-	}
-	bodyRows := count(body)
-	if bodyRows < bodyTarget {
-		body = body + strings.Repeat("\n", bodyTarget-bodyRows)
-	} else if bodyRows > bodyTarget {
-		lines := strings.Split(body, "\n")
-		body = strings.Join(lines[:bodyTarget], "\n")
-	}
-
-	return header + "\n\n" + body + "\n\n" + footer
+	return s.RenderFrame(body, s.keyHints())
 }
 
 // keyHints returns the footer key row for the browser. Single-stage
@@ -410,14 +429,24 @@ func (s *BrowserStage) keyHints() []initflow.KeyHint {
 // attached to every tab — greyed out when N==0 to signal that an
 // agent filter excluded all entries in that tab (but the tab still
 // renders so the user sees what's being filtered).
+//
+// Narrow-width adaptation: when terminal width is below
+// shortLabelThreshold (96 cols), swaps full labels for compact forms
+// (see shortLabel). The min-size floor is 70×20 — short labels keep
+// the full 7-tab strip inside 70 cols without wrapping or clipping.
 func (s *BrowserStage) renderTabs() string {
 	active := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
 	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
 	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
 
+	useShort := s.Width() > 0 && s.Width() < shortLabelThreshold
+
 	cells := make([]string, 0, len(s.categories))
 	for i, c := range s.categories {
 		label := c.displayName
+		if useShort {
+			label = shortLabel(label)
+		}
 		countSuffix := fmt.Sprintf(" (%d)", len(c.entries))
 		var cell string
 		switch {
@@ -431,7 +460,11 @@ func (s *BrowserStage) renderTabs() string {
 		cells = append(cells, cell)
 	}
 
-	return strings.Join(cells, "  ")
+	sep := "  "
+	if useShort {
+		sep = " "
+	}
+	return strings.Join(cells, sep)
 }
 
 // renderList renders the entries of the current tab. Each row goes

--- a/internal/tui/catalogflow/browser.go
+++ b/internal/tui/catalogflow/browser.go
@@ -1,0 +1,512 @@
+package catalogflow
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// timeZero returns the zero-value time.Time used for stages that have
+// no session-start anchor (catalog is a single-shot browser — no
+// ELAPSED row to render, so any zero-value is safe).
+func timeZero() time.Time { return time.Time{} }
+
+// category is one of the seven catalog section tabs. The tab's header
+// cell renders as "LABEL (N)" where N counts the filtered entries;
+// filterHidZero is the agent-filter's greyed-out suffix signal (tabs
+// with zero filtered items render with a muted (0) suffix but stay in
+// the tab strip so the user sees what their filter excludes).
+type category struct {
+	key         string
+	displayName string
+	entries     []Entry
+}
+
+// BrowserStage is the BubbleTea model for `bonsai catalog`. Seven tabs
+// cover the seven catalog sections; per-tab focus is preserved across
+// tab switches so `← → ↑ ↓ ? q` always reads the current tab's state
+// verbatim.
+//
+// Fields:
+//   - categories: seven tabs, in catalog-section order.
+//   - catIdx: 0..6 — currently-visible tab.
+//   - itemIdx: per-tab focus-row index.
+//   - expanded: global `?` toggle for the inline-expand detail block.
+//   - viewport: scrolls the list when entries overflow body rows.
+//
+// Embeds initflow.Stage with railHidden=true so the shared chrome
+// composer skips the enso rail row (catalog is read-only — it doesn't
+// encode a mutation process, so no rail segments to walk).
+type BrowserStage struct {
+	initflow.Stage
+
+	categories []category
+	catIdx     int
+	itemIdx    map[int]int
+	expanded   bool
+	viewport   initflow.Viewport
+
+	// quit flips to true on any quit key; View returns "" afterwards and
+	// the tea.Program is told to Quit via the Update return cmd.
+	quit bool
+}
+
+// NewBrowser constructs a BrowserStage from a loaded catalog, applying
+// the optional -a/--agent filter. An empty agentFilter shows every
+// entry in every tab. With a non-empty filter, per-section cat.*For
+// accessors drop incompatible items; tabs that end up with zero
+// entries render a greyed (0) suffix but are not removed from the
+// tab strip.
+//
+// Called from cmd/catalog.go when stdout is a TTY. Non-TTY invocations
+// stay on the existing static-render path.
+func NewBrowser(cat *catalog.Catalog, agentFilter string) *BrowserStage {
+	categories := buildCategories(cat, agentFilter)
+
+	itemIdx := make(map[int]int, len(categories))
+	for i := range categories {
+		itemIdx[i] = 0
+	}
+
+	base := initflow.NewStage(
+		0,
+		initflow.StageLabel{Kanji: "録", Kana: "ロク", English: "CATALOG"},
+		"CATALOG",
+		"", // version: catalog's header renders no version chip
+		"", // projectDir: catalog is global, no project context
+		"",
+		"",
+		// Zero time — catalog has no elapsed counter. Matches the
+		// initflow precedent (StageContext.StartedAt zero-value is safe
+		// for stages that never render an ELAPSED row).
+		timeZero(),
+	)
+	base.SetRailHidden(true)
+	base.SetHeaderAction("CATALOG")
+	// Empty rightLabel hides the right-block row 1 — catalog is global,
+	// not scoped to a project path.
+	base.SetHeaderRightLabel("")
+
+	return &BrowserStage{
+		Stage:      base,
+		categories: categories,
+		catIdx:     0,
+		itemIdx:    itemIdx,
+		expanded:   false,
+	}
+}
+
+// buildCategories walks the seven catalog sections and packs each into
+// the per-tab category shape. Per-section Meta packing:
+//
+//   - Agents: Meta = nil.
+//   - Skills / Workflows / Protocols: Meta = nil.
+//   - Sensors: Meta = {"Event": event, "Matcher": matcher} (matcher omitted if empty).
+//   - Routines: Meta = {"Frequency": freq}.
+//   - Scaffolding: Meta = {"If Removed": affects}.
+//
+// agentFilter applies via the catalog's per-section *For accessors.
+// Agents and Scaffolding are unfiltered — Agents has no per-agent
+// compat concept (every agent IS an agent), and Scaffolding is a
+// project-level decision independent of agent choice.
+func buildCategories(cat *catalog.Catalog, agentFilter string) []category {
+	out := make([]category, 0, 7)
+
+	// Agents — always unfiltered.
+	{
+		entries := make([]Entry, 0, len(cat.Agents))
+		for _, a := range cat.Agents {
+			display := a.DisplayName
+			if display == "" {
+				display = catalog.DisplayNameFrom(a.Name)
+			}
+			entries = append(entries, Entry{
+				Name:        a.Name,
+				DisplayName: display,
+				Description: a.Description,
+			})
+		}
+		out = append(out, category{key: "agents", displayName: "AGENTS", entries: entries})
+	}
+
+	// Skills.
+	{
+		items := cat.Skills
+		if agentFilter != "" {
+			items = cat.SkillsFor(agentFilter)
+		}
+		entries := make([]Entry, 0, len(items))
+		for _, it := range items {
+			entries = append(entries, Entry{
+				Name:        it.Name,
+				DisplayName: it.DisplayName,
+				Description: it.Description,
+				Agents:      it.Agents.String(),
+				Required:    it.Required.String(),
+			})
+		}
+		out = append(out, category{key: "skills", displayName: "SKILLS", entries: entries})
+	}
+
+	// Workflows.
+	{
+		items := cat.Workflows
+		if agentFilter != "" {
+			items = cat.WorkflowsFor(agentFilter)
+		}
+		entries := make([]Entry, 0, len(items))
+		for _, it := range items {
+			entries = append(entries, Entry{
+				Name:        it.Name,
+				DisplayName: it.DisplayName,
+				Description: it.Description,
+				Agents:      it.Agents.String(),
+				Required:    it.Required.String(),
+			})
+		}
+		out = append(out, category{key: "workflows", displayName: "WORKFLOWS", entries: entries})
+	}
+
+	// Protocols.
+	{
+		items := cat.Protocols
+		if agentFilter != "" {
+			items = cat.ProtocolsFor(agentFilter)
+		}
+		entries := make([]Entry, 0, len(items))
+		for _, it := range items {
+			entries = append(entries, Entry{
+				Name:        it.Name,
+				DisplayName: it.DisplayName,
+				Description: it.Description,
+				Agents:      it.Agents.String(),
+				Required:    it.Required.String(),
+			})
+		}
+		out = append(out, category{key: "protocols", displayName: "PROTOCOLS", entries: entries})
+	}
+
+	// Sensors — Meta carries Event + Matcher (matcher elided if empty).
+	{
+		items := cat.Sensors
+		if agentFilter != "" {
+			items = cat.SensorsFor(agentFilter)
+		}
+		entries := make([]Entry, 0, len(items))
+		for _, it := range items {
+			meta := map[string]string{"Event": it.Event}
+			if it.Matcher != "" {
+				meta["Matcher"] = it.Matcher
+			}
+			entries = append(entries, Entry{
+				Name:        it.Name,
+				DisplayName: it.DisplayName,
+				Description: it.Description,
+				Meta:        meta,
+				Agents:      it.Agents.String(),
+				Required:    it.Required.String(),
+			})
+		}
+		out = append(out, category{key: "sensors", displayName: "SENSORS", entries: entries})
+	}
+
+	// Routines — Meta carries Frequency.
+	{
+		items := cat.Routines
+		if agentFilter != "" {
+			items = cat.RoutinesFor(agentFilter)
+		}
+		entries := make([]Entry, 0, len(items))
+		for _, it := range items {
+			entries = append(entries, Entry{
+				Name:        it.Name,
+				DisplayName: it.DisplayName,
+				Description: it.Description,
+				Meta:        map[string]string{"Frequency": it.Frequency},
+				Agents:      it.Agents.String(),
+				Required:    it.Required.String(),
+			})
+		}
+		out = append(out, category{key: "routines", displayName: "ROUTINES", entries: entries})
+	}
+
+	// Scaffolding — always unfiltered. Required is a simple bool so
+	// Required renders as "yes" / "" (matching the static-render path).
+	// Meta carries If Removed (Affects).
+	{
+		entries := make([]Entry, 0, len(cat.Scaffolding))
+		for _, s := range cat.Scaffolding {
+			req := ""
+			if s.Required {
+				req = "yes"
+			}
+			meta := map[string]string{}
+			if s.Affects != "" {
+				meta["If Removed"] = s.Affects
+			}
+			entries = append(entries, Entry{
+				Name:        s.Name,
+				DisplayName: s.DisplayName,
+				Description: s.Description,
+				Meta:        meta,
+				Required:    req,
+			})
+		}
+		out = append(out, category{key: "scaffolding", displayName: "SCAFFOLDING", entries: entries})
+	}
+
+	return out
+}
+
+// Init implements tea.Model.
+func (s *BrowserStage) Init() tea.Cmd { return nil }
+
+// Update handles tab cycling, focus movement, expand toggle, and quit.
+// Keys:
+//
+//   - left / h / right / l — tab cycle (wraps both directions).
+//   - up / k / down / j     — focus clamp (no wrap).
+//   - ?                     — inline-expand toggle.
+//   - q / esc / ctrl-c / enter — quit.
+func (s *BrowserStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.SetSize(m.Width, m.Height)
+	case tea.KeyMsg:
+		switch m.String() {
+		case "left", "h":
+			if len(s.categories) == 0 {
+				return s, nil
+			}
+			s.catIdx = (s.catIdx - 1 + len(s.categories)) % len(s.categories)
+		case "right", "l":
+			if len(s.categories) == 0 {
+				return s, nil
+			}
+			s.catIdx = (s.catIdx + 1) % len(s.categories)
+		case "up", "k":
+			cat := s.currentCat()
+			if cat == nil || len(cat.entries) == 0 {
+				return s, nil
+			}
+			cur := s.itemIdx[s.catIdx]
+			cur--
+			if cur < 0 {
+				cur = 0
+			}
+			s.itemIdx[s.catIdx] = cur
+		case "down", "j":
+			cat := s.currentCat()
+			if cat == nil || len(cat.entries) == 0 {
+				return s, nil
+			}
+			cur := s.itemIdx[s.catIdx]
+			cur++
+			if cur >= len(cat.entries) {
+				cur = len(cat.entries) - 1
+			}
+			s.itemIdx[s.catIdx] = cur
+		case "?":
+			s.expanded = !s.expanded
+		case "q", "esc", "ctrl+c", "enter":
+			s.quit = true
+			s.MarkDone()
+			return s, tea.Quit
+		}
+	}
+	return s, nil
+}
+
+// Title implements harness.Step.
+func (s *BrowserStage) Title() string { return "CATALOG" }
+
+// Result implements harness.Step. Catalog is read-only — no payload.
+func (s *BrowserStage) Result() any { return nil }
+
+// View composes the full frame: header + tab strip + list + optional
+// inline-expand detail block + footer. No rail (SetRailHidden(true)).
+func (s *BrowserStage) View() string {
+	if s.quit {
+		return ""
+	}
+
+	width := s.Width()
+	if width <= 0 {
+		width = 80
+	}
+	height := s.Height()
+	if height <= 0 {
+		height = 24
+	}
+
+	// Min-size floor — same 70×20 threshold as init/add.
+	if initflow.TerminalTooSmall(s.Width(), s.Height()) {
+		return initflow.RenderMinSizeFloor(s.Width(), s.Height())
+	}
+
+	header := initflow.RenderHeader("", "", "CATALOG", "", width, s.EnsoSafe())
+	footer := initflow.RenderFooter(s.keyHints(), width)
+
+	tabRow := s.renderTabs()
+	list := s.renderList()
+	details := s.renderDetails()
+
+	// Build body rows — tab strip + list + optional details. centerBlock
+	// matches the visual rhythm of the init-flow stages.
+	bodyParts := []string{
+		tabRow,
+		"",
+		list,
+	}
+	if s.expanded {
+		bodyParts = append(bodyParts, "", details)
+	}
+	body := initflow.CenterBlock(strings.Join(bodyParts, "\n"), width)
+
+	// Pad body so footer sits at the bottom of the AltScreen — same
+	// technique initflow.Stage.renderFrame uses.
+	count := func(str string) int {
+		if str == "" {
+			return 0
+		}
+		return strings.Count(str, "\n") + 1
+	}
+	chromeRows := count(header) + 1 + 1 + count(footer)
+	bodyTarget := height - chromeRows
+	if bodyTarget < 1 {
+		bodyTarget = 1
+	}
+	bodyRows := count(body)
+	if bodyRows < bodyTarget {
+		body = body + strings.Repeat("\n", bodyTarget-bodyRows)
+	} else if bodyRows > bodyTarget {
+		lines := strings.Split(body, "\n")
+		body = strings.Join(lines[:bodyTarget], "\n")
+	}
+
+	return header + "\n\n" + body + "\n\n" + footer
+}
+
+// keyHints returns the footer key row for the browser. Single-stage
+// flow — no back/next, only tab/focus/details/quit.
+func (s *BrowserStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "←→", Desc: "tabs"},
+		{Key: "↑↓", Desc: "focus"},
+		{Key: "?", Desc: "details"},
+		{Key: "q", Desc: "quit"},
+	}
+}
+
+// renderTabs renders the single-row tab header. Active tab is bold
+// ColorPrimary; inactive tabs are ColorMuted. Count suffix `(N)` is
+// attached to every tab — greyed out when N==0 to signal that an
+// agent filter excluded all entries in that tab (but the tab still
+// renders so the user sees what's being filtered).
+func (s *BrowserStage) renderTabs() string {
+	active := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+
+	cells := make([]string, 0, len(s.categories))
+	for i, c := range s.categories {
+		label := c.displayName
+		countSuffix := fmt.Sprintf(" (%d)", len(c.entries))
+		var cell string
+		switch {
+		case i == s.catIdx:
+			cell = active.Render(label) + dim.Render(countSuffix)
+		case len(c.entries) == 0:
+			cell = dim.Render(label + countSuffix)
+		default:
+			cell = muted.Render(label) + dim.Render(countSuffix)
+		}
+		cells = append(cells, cell)
+	}
+
+	return strings.Join(cells, "  ")
+}
+
+// renderList renders the entries of the current tab. Each row goes
+// through the per-entry renderer (renderEntry). Rows that overflow
+// the visible body area are clamped by the embedded viewport — focus
+// stays visible.
+func (s *BrowserStage) renderList() string {
+	cat := s.currentCat()
+	if cat == nil {
+		return ""
+	}
+	if len(cat.entries) == 0 {
+		dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+		return dim.Render("  (no entries in this category)")
+	}
+
+	rows := make([]string, 0, len(cat.entries))
+	for i := range cat.entries {
+		rows = append(rows, renderEntry(cat.entries[i], i == s.itemIdx[s.catIdx]))
+	}
+
+	listH := s.listHeight()
+	if listH <= 0 || listH >= len(rows) {
+		return strings.Join(rows, "\n")
+	}
+	s.viewport.SetLines(rows)
+	s.viewport.SetHeight(listH)
+	s.viewport.Follow(s.itemIdx[s.catIdx])
+	return s.viewport.View()
+}
+
+// renderDetails renders the inline-expand block for the focused
+// entry. Shows Agents, Required, and per-category Meta keys (Event,
+// Matcher, Frequency, If Removed). Entries whose tab carries no
+// focused row (empty tab) render a muted "nothing to show".
+func (s *BrowserStage) renderDetails() string {
+	cat := s.currentCat()
+	if cat == nil || len(cat.entries) == 0 {
+		dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+		return dim.Render("  (nothing to show)")
+	}
+	row := s.itemIdx[s.catIdx]
+	if row < 0 || row >= len(cat.entries) {
+		return ""
+	}
+	return renderDetailsBlock(cat.entries[row], initflow.PanelWidth(s.Width()))
+}
+
+// listHeight computes the visible-row budget for the list. Reserves
+// rows for chrome (header 2 + 2 blanks + footer 2 = 6), tab strip (1
+// + 1 blank), and optional details (5 rows when expanded). Floor at
+// 3 so at least a tiny window is visible on short terminals.
+func (s *BrowserStage) listHeight() int {
+	h := s.Height()
+	if h <= 0 {
+		return 0
+	}
+	const chromeRows = 6
+	const tabRows = 2
+	bodyBelow := 0
+	if s.expanded {
+		bodyBelow = 6 // 1 blank + details block (≈5 rows)
+	}
+	out := h - chromeRows - tabRows - bodyBelow
+	if out < 3 {
+		out = 3
+	}
+	return out
+}
+
+// currentCat returns a pointer to the active category or nil if the
+// index is out of bounds.
+func (s *BrowserStage) currentCat() *category {
+	if s.catIdx < 0 || s.catIdx >= len(s.categories) {
+		return nil
+	}
+	return &s.categories[s.catIdx]
+}

--- a/internal/tui/catalogflow/browser_test.go
+++ b/internal/tui/catalogflow/browser_test.go
@@ -1,0 +1,254 @@
+package catalogflow
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+)
+
+// fakeCatalog returns a minimal Catalog suitable for browser tests. Two
+// skills compatible with "tech-lead", one routine for "all", one agent,
+// one scaffolding item. Every field is populated so downstream
+// renderers see non-empty inputs.
+func fakeCatalog() *catalog.Catalog {
+	return &catalog.Catalog{
+		Agents: []catalog.AgentDef{
+			{Name: "tech-lead", DisplayName: "Tech Lead", Description: "orchestrator"},
+		},
+		Skills: []catalog.CatalogItem{
+			{
+				Name: "planning-template", DisplayName: "Planning Template",
+				Description: "tiered plans", Agents: catalog.AgentCompat{All: true},
+			},
+			{
+				Name: "coding-standards", DisplayName: "Coding Standards",
+				Description: "style guide", Agents: catalog.AgentCompat{Names: []string{"code"}},
+			},
+		},
+		Workflows: []catalog.CatalogItem{
+			{
+				Name: "code-review", DisplayName: "Code Review",
+				Description: "review pipeline", Agents: catalog.AgentCompat{All: true},
+			},
+		},
+		Protocols: []catalog.CatalogItem{
+			{
+				Name: "memory", DisplayName: "Memory",
+				Description: "memory protocol", Agents: catalog.AgentCompat{All: true},
+			},
+		},
+		Sensors: []catalog.SensorItem{
+			{
+				Name: "status-bar", DisplayName: "Status Bar",
+				Description: "status line", Event: "Stop",
+				Agents: catalog.AgentCompat{All: true},
+			},
+		},
+		Routines: []catalog.RoutineItem{
+			{
+				Name: "backlog-hygiene", DisplayName: "Backlog Hygiene",
+				Description: "weekly sweep", Frequency: "7 days",
+				Agents: catalog.AgentCompat{All: true},
+			},
+		},
+		Scaffolding: []catalog.ScaffoldingItem{
+			{Name: "playbook", DisplayName: "Playbook", Description: "plans + roadmap", Required: true, Affects: "planning"},
+		},
+	}
+}
+
+// key builds a tea.KeyMsg for a single named key.
+func key(name string) tea.KeyMsg {
+	switch name {
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)}
+	}
+}
+
+// TestNewBrowser_AllSevenTabsPresent verifies every catalog section is
+// represented in the tab strip, in the canonical order.
+func TestNewBrowser_AllSevenTabsPresent(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	if got, want := len(s.categories), 7; got != want {
+		t.Fatalf("len(categories) = %d, want %d", got, want)
+	}
+	expected := []string{"agents", "skills", "workflows", "protocols", "sensors", "routines", "scaffolding"}
+	for i, key := range expected {
+		if s.categories[i].key != key {
+			t.Fatalf("categories[%d].key = %q, want %q", i, s.categories[i].key, key)
+		}
+	}
+}
+
+// TestBrowser_TabCycleWrapsForward verifies left/right key cycling
+// wraps past the end back to index 0.
+func TestBrowser_TabCycleWrapsForward(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	for range s.categories {
+		s.Update(key("right"))
+	}
+	if s.catIdx != 0 {
+		t.Fatalf("catIdx after full forward cycle = %d, want 0", s.catIdx)
+	}
+}
+
+// TestBrowser_TabCycleWrapsBackward verifies left key cycling from
+// index 0 wraps to the last tab.
+func TestBrowser_TabCycleWrapsBackward(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	s.Update(key("left"))
+	if s.catIdx != len(s.categories)-1 {
+		t.Fatalf("catIdx after one backward = %d, want %d", s.catIdx, len(s.categories)-1)
+	}
+}
+
+// TestBrowser_FocusClampAtTop verifies up key at idx 0 stays at 0.
+func TestBrowser_FocusClampAtTop(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	s.Update(key("up"))
+	if s.itemIdx[s.catIdx] != 0 {
+		t.Fatalf("itemIdx after up at top = %d, want 0", s.itemIdx[s.catIdx])
+	}
+}
+
+// TestBrowser_FocusClampAtBottom verifies down key past the last row
+// clamps to len-1.
+func TestBrowser_FocusClampAtBottom(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	// Move to skills tab (2 entries).
+	s.Update(key("right"))
+	cat := s.currentCat()
+	if cat == nil || len(cat.entries) == 0 {
+		t.Fatalf("expected skills tab to have entries")
+	}
+	last := len(cat.entries) - 1
+	for i := 0; i < 10; i++ {
+		s.Update(key("down"))
+	}
+	if s.itemIdx[s.catIdx] != last {
+		t.Fatalf("itemIdx after down past bottom = %d, want %d", s.itemIdx[s.catIdx], last)
+	}
+}
+
+// TestBrowser_QuestionTogglesExpand verifies the `?` key flips the
+// expanded state each press.
+func TestBrowser_QuestionTogglesExpand(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	if s.expanded {
+		t.Fatalf("expanded starts true, want false")
+	}
+	s.Update(key("?"))
+	if !s.expanded {
+		t.Fatalf("expanded after one ?, got false")
+	}
+	s.Update(key("?"))
+	if s.expanded {
+		t.Fatalf("expanded after two ?, got true")
+	}
+}
+
+// TestBrowser_FilterGreysEmptyTabs verifies that with agent filter
+// "tech-lead", skills with agents=[code] are excluded but the tab
+// strip still shows every category (greyed when empty).
+func TestBrowser_FilterGreysEmptyTabs(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "tech-lead")
+	if len(s.categories) != 7 {
+		t.Fatalf("len(categories) under filter = %d, want 7", len(s.categories))
+	}
+	// Skills: only "planning-template" (All: true) passes — "coding-standards" is code-only.
+	var skills *category
+	for i := range s.categories {
+		if s.categories[i].key == "skills" {
+			skills = &s.categories[i]
+			break
+		}
+	}
+	if skills == nil {
+		t.Fatalf("skills tab missing after filter")
+	}
+	if got, want := len(skills.entries), 1; got != want {
+		t.Fatalf("skills entries under tech-lead filter = %d, want %d", got, want)
+	}
+}
+
+// TestBrowser_EachQuitKey verifies q / esc / ctrl+c / enter all flip
+// the quit flag and issue tea.Quit.
+func TestBrowser_EachQuitKey(t *testing.T) {
+	for _, k := range []string{"q", "esc", "ctrl+c", "enter"} {
+		s := NewBrowser(fakeCatalog(), "")
+		_, cmd := s.Update(key(k))
+		if !s.quit {
+			t.Fatalf("key %q: quit flag = false, want true", k)
+		}
+		if cmd == nil {
+			t.Fatalf("key %q: cmd = nil, want tea.Quit", k)
+		}
+	}
+}
+
+// TestBrowser_ViewUnderMinSizeFloor verifies the browser renders the
+// min-size floor panel (not the tab strip) when terminal dims are
+// below the 70×20 threshold.
+func TestBrowser_ViewUnderMinSizeFloor(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	s.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+
+	out := s.View()
+	if !strings.Contains(out, "please enlarge your terminal") {
+		t.Fatalf("expected min-size floor panel under small terminal, got:\n%s", out)
+	}
+}
+
+// TestBrowser_ViewContainsHeaderAndTabs verifies a normal-sized render
+// contains the BONSAI header brand and every tab label.
+func TestBrowser_ViewContainsHeaderAndTabs(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	out := s.View()
+	if !strings.Contains(out, "BONSAI") {
+		t.Fatalf("expected BONSAI brand in view, got:\n%s", out)
+	}
+	if !strings.Contains(out, "CATALOG") {
+		t.Fatalf("expected CATALOG action in view, got:\n%s", out)
+	}
+	for _, tab := range []string{"AGENTS", "SKILLS", "WORKFLOWS", "PROTOCOLS", "SENSORS", "ROUTINES", "SCAFFOLDING"} {
+		if !strings.Contains(out, tab) {
+			t.Fatalf("expected tab %q in view, got:\n%s", tab, out)
+		}
+	}
+}
+
+// TestBrowser_EmptyCategoriesNoOp ensures focus/tab keys on an empty
+// catalog silently no-op without panicking.
+func TestBrowser_EmptyCategoriesNoOp(t *testing.T) {
+	s := NewBrowser(&catalog.Catalog{}, "")
+	// Even an empty catalog still yields 7 tabs (all empty).
+	if len(s.categories) != 7 {
+		t.Fatalf("empty catalog len(categories) = %d, want 7", len(s.categories))
+	}
+	s.Update(key("down"))
+	s.Update(key("up"))
+	s.Update(key("right"))
+	s.Update(key("left"))
+	if s.itemIdx[s.catIdx] != 0 {
+		t.Fatalf("empty catalog focus drifted to %d, want 0", s.itemIdx[s.catIdx])
+	}
+}

--- a/internal/tui/catalogflow/browser_test.go
+++ b/internal/tui/catalogflow/browser_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/LastStep/Bonsai/internal/catalog"
 )
@@ -85,7 +86,7 @@ func key(name string) tea.KeyMsg {
 // TestNewBrowser_AllSevenTabsPresent verifies every catalog section is
 // represented in the tab strip, in the canonical order.
 func TestNewBrowser_AllSevenTabsPresent(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	if got, want := len(s.categories), 7; got != want {
 		t.Fatalf("len(categories) = %d, want %d", got, want)
 	}
@@ -100,7 +101,7 @@ func TestNewBrowser_AllSevenTabsPresent(t *testing.T) {
 // TestBrowser_TabCycleWrapsForward verifies left/right key cycling
 // wraps past the end back to index 0.
 func TestBrowser_TabCycleWrapsForward(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	for range s.categories {
 		s.Update(key("right"))
 	}
@@ -112,7 +113,7 @@ func TestBrowser_TabCycleWrapsForward(t *testing.T) {
 // TestBrowser_TabCycleWrapsBackward verifies left key cycling from
 // index 0 wraps to the last tab.
 func TestBrowser_TabCycleWrapsBackward(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	s.Update(key("left"))
 	if s.catIdx != len(s.categories)-1 {
 		t.Fatalf("catIdx after one backward = %d, want %d", s.catIdx, len(s.categories)-1)
@@ -121,7 +122,7 @@ func TestBrowser_TabCycleWrapsBackward(t *testing.T) {
 
 // TestBrowser_FocusClampAtTop verifies up key at idx 0 stays at 0.
 func TestBrowser_FocusClampAtTop(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	s.Update(key("up"))
 	if s.itemIdx[s.catIdx] != 0 {
 		t.Fatalf("itemIdx after up at top = %d, want 0", s.itemIdx[s.catIdx])
@@ -131,7 +132,7 @@ func TestBrowser_FocusClampAtTop(t *testing.T) {
 // TestBrowser_FocusClampAtBottom verifies down key past the last row
 // clamps to len-1.
 func TestBrowser_FocusClampAtBottom(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	// Move to skills tab (2 entries).
 	s.Update(key("right"))
 	cat := s.currentCat()
@@ -150,7 +151,7 @@ func TestBrowser_FocusClampAtBottom(t *testing.T) {
 // TestBrowser_QuestionTogglesExpand verifies the `?` key flips the
 // expanded state each press.
 func TestBrowser_QuestionTogglesExpand(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	if s.expanded {
 		t.Fatalf("expanded starts true, want false")
 	}
@@ -168,7 +169,7 @@ func TestBrowser_QuestionTogglesExpand(t *testing.T) {
 // "tech-lead", skills with agents=[code] are excluded but the tab
 // strip still shows every category (greyed when empty).
 func TestBrowser_FilterGreysEmptyTabs(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "tech-lead")
+	s := NewBrowser(fakeCatalog(), "tech-lead", "")
 	if len(s.categories) != 7 {
 		t.Fatalf("len(categories) under filter = %d, want 7", len(s.categories))
 	}
@@ -192,7 +193,7 @@ func TestBrowser_FilterGreysEmptyTabs(t *testing.T) {
 // the quit flag and issue tea.Quit.
 func TestBrowser_EachQuitKey(t *testing.T) {
 	for _, k := range []string{"q", "esc", "ctrl+c", "enter"} {
-		s := NewBrowser(fakeCatalog(), "")
+		s := NewBrowser(fakeCatalog(), "", "")
 		_, cmd := s.Update(key(k))
 		if !s.quit {
 			t.Fatalf("key %q: quit flag = false, want true", k)
@@ -207,7 +208,7 @@ func TestBrowser_EachQuitKey(t *testing.T) {
 // min-size floor panel (not the tab strip) when terminal dims are
 // below the 70×20 threshold.
 func TestBrowser_ViewUnderMinSizeFloor(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	s.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
 
 	out := s.View()
@@ -219,7 +220,7 @@ func TestBrowser_ViewUnderMinSizeFloor(t *testing.T) {
 // TestBrowser_ViewContainsHeaderAndTabs verifies a normal-sized render
 // contains the BONSAI header brand and every tab label.
 func TestBrowser_ViewContainsHeaderAndTabs(t *testing.T) {
-	s := NewBrowser(fakeCatalog(), "")
+	s := NewBrowser(fakeCatalog(), "", "")
 	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 
 	out := s.View()
@@ -239,7 +240,7 @@ func TestBrowser_ViewContainsHeaderAndTabs(t *testing.T) {
 // TestBrowser_EmptyCategoriesNoOp ensures focus/tab keys on an empty
 // catalog silently no-op without panicking.
 func TestBrowser_EmptyCategoriesNoOp(t *testing.T) {
-	s := NewBrowser(&catalog.Catalog{}, "")
+	s := NewBrowser(&catalog.Catalog{}, "", "")
 	// Even an empty catalog still yields 7 tabs (all empty).
 	if len(s.categories) != 7 {
 		t.Fatalf("empty catalog len(categories) = %d, want 7", len(s.categories))
@@ -250,5 +251,65 @@ func TestBrowser_EmptyCategoriesNoOp(t *testing.T) {
 	s.Update(key("left"))
 	if s.itemIdx[s.catIdx] != 0 {
 		t.Fatalf("empty catalog focus drifted to %d, want 0", s.itemIdx[s.catIdx])
+	}
+}
+
+// TestRenderTabs_ShortLabelsAtNarrowWidth verifies the tab strip
+// switches to compact labels below the 96-col threshold so the full
+// 7-tab row fits inside the 70-col minimum-width floor. All seven
+// tabs must still be present (by their short form), the active tab
+// must still render bold, and the rendered strip must fit in 70 cols.
+func TestRenderTabs_ShortLabelsAtNarrowWidth(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "", "")
+	s.Update(tea.WindowSizeMsg{Width: 70, Height: 20})
+
+	strip := s.renderTabs()
+	// Visible width — lipgloss.Width strips ANSI escapes, giving the
+	// true on-screen cell count.
+	if w := lipgloss.Width(strip); w > 70 {
+		t.Fatalf("tab strip width at 70 cols = %d, want <= 70\nstrip: %q", w, strip)
+	}
+
+	// Every tab still present (by short label). All seven collapse to
+	// 5-char forms under narrow widths.
+	shortLabels := []string{"AGENT", "SKILL", "FLOWS", "PROTO", "SENSE", "RTNES", "SCAFF"}
+	for _, lab := range shortLabels {
+		if !strings.Contains(strip, lab) {
+			t.Fatalf("short label %q missing from strip at 70 cols:\n%s", lab, strip)
+		}
+	}
+
+	// Full labels that should have been compressed must NOT appear as
+	// whole words — checking boundary chars via a space suffix is
+	// sufficient because the strip only has labels + "(N)" suffixes.
+	for _, full := range []string{"AGENTS ", "SKILLS ", "WORKFLOWS ", "PROTOCOLS ", "SENSORS ", "ROUTINES ", "SCAFFOLDING "} {
+		if strings.Contains(strip, full) {
+			t.Fatalf("expected full label %q compressed at 70 cols, still present:\n%s", full, strip)
+		}
+	}
+
+	// Active tab is catIdx=0 (AGENT). In a color-capable terminal the
+	// active cell carries a bold SGR escape; under Go's test environment
+	// lipgloss auto-disables colour so we only assert the active label
+	// is present. The key visual invariant is that AGENT appears first
+	// (catIdx 0) — which is covered by the width + presence checks
+	// above.
+	if idx := strings.Index(strip, "AGENT"); idx != 0 {
+		t.Fatalf("active tab AGENT should render first in strip, got index %d:\n%s", idx, strip)
+	}
+}
+
+// TestRenderTabs_FullLabelsAtWideWidth verifies that at widths >= 96
+// cols the tab strip uses the full labels (regression guard against
+// the short-label mode leaking into normal terminals).
+func TestRenderTabs_FullLabelsAtWideWidth(t *testing.T) {
+	s := NewBrowser(fakeCatalog(), "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	strip := s.renderTabs()
+	for _, full := range []string{"AGENTS", "WORKFLOWS", "PROTOCOLS", "SCAFFOLDING"} {
+		if !strings.Contains(strip, full) {
+			t.Fatalf("expected full label %q at 120 cols:\n%s", full, strip)
+		}
 	}
 }

--- a/internal/tui/catalogflow/catalogflow.go
+++ b/internal/tui/catalogflow/catalogflow.go
@@ -1,0 +1,35 @@
+// Package catalogflow implements the cinematic tabbed browser for
+// `bonsai catalog`. The package mirrors internal/tui/initflow's chrome
+// shape (header + footer, rail hidden) around a single BubbleTea stage
+// that cycles seven tabs over the seven catalog sections (Agents,
+// Skills, Workflows, Protocols, Sensors, Routines, Scaffolding).
+//
+// Every chrome primitive (RenderHeader, RenderFooter,
+// RenderMinSizeFloor, Viewport, PanelContentWidth, design tokens,
+// WideCharSafe, TerminalTooSmall) is imported from initflow —
+// catalogflow does not reimplement any of them. The package's single
+// public entry is NewBrowser, consumed by cmd/catalog.go when stdout
+// is a TTY; non-TTY invocations fall back to the static-render path
+// already in cmd/catalog.go.
+//
+// Plan 28 reference: station/Playbook/Plans/Active/28-view-cmds-cinematic.md.
+package catalogflow
+
+// Entry is the per-row shape rendered in a single tab. Every catalog
+// section (Agents, Skills, Workflows, Protocols, Sensors, Routines,
+// Scaffolding) packs its items into this shape — per-category extras
+// (Event, Matcher, Frequency, If Removed) go into the Meta dict keyed
+// by their labelled form so the inline-expand renderer can surface
+// them as `LABEL  value` rows.
+//
+// Agents is the AgentCompat.String() form (e.g. "all" or "tech-lead,
+// code"). Required is the same format — empty string signals "not
+// required for any agent".
+type Entry struct {
+	Name        string
+	DisplayName string
+	Description string
+	Meta        map[string]string
+	Agents      string
+	Required    string
+}

--- a/internal/tui/catalogflow/entry.go
+++ b/internal/tui/catalogflow/entry.go
@@ -1,0 +1,150 @@
+package catalogflow
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// renderEntry renders a single catalog row. Focused rows receive the
+// leaf-coloured `│ ` left border (same pattern as initflow's
+// BranchesStage.renderRow) and white-bold name styling;
+// unfocused rows render muted.
+//
+// The row shape:
+//
+//	<border> <name>  <description>
+//
+// Required entries (Required != "") get a trailing gold "*" glyph
+// after the name — matches the required-marker convention used by
+// Soil and Branches in the init flow.
+func renderEntry(e Entry, focused bool) string {
+	dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+
+	border := initflow.UnfocusBorder()
+	if focused {
+		border = initflow.FocusBorder()
+	}
+
+	name := e.DisplayName
+	if name == "" {
+		name = e.Name
+	}
+
+	// Name style: white-bold on focus, subtle otherwise. Description
+	// lifts from dim to accent-white on focus so the whole row reads as
+	// a single bright block under the cursor.
+	var nameStyle lipgloss.Style
+	var descStyle lipgloss.Style
+	if focused {
+		nameStyle = initflow.FocusedNameStyle()
+		descStyle = initflow.FocusedDescStyle()
+	} else {
+		nameStyle = initflow.UnfocusedNameStyle()
+		descStyle = dim
+	}
+
+	nameText := nameStyle.Render(name)
+	if e.Required != "" {
+		nameText += " " + initflow.RequiredGlyph()
+	}
+
+	// Description clamped to a soft budget — browser rows are wider than
+	// the Branches list (no tag column), so we allow up to 60 cells of
+	// description before truncating.
+	const descBudget = 60
+	desc := e.Description
+	if lipgloss.Width(desc) > descBudget {
+		rr := []rune(desc)
+		if len(rr) > descBudget-1 {
+			desc = string(rr[:descBudget-1]) + "…"
+		}
+	}
+
+	row := border + nameText
+	if desc != "" {
+		row += "  " + descStyle.Render(desc)
+	}
+	return row
+}
+
+// renderDetailsBlock renders the inline-expand block shown when `?`
+// is toggled on. Labels render bark-gold bold (LabelStyle); values
+// render accent-white (ValueStyle). Rendered fields, in order:
+//
+//   - Agents      — always shown when set.
+//   - Required    — shown when non-empty.
+//   - Meta keys   — rendered in sorted order so the output is stable
+//     across runs (map iteration is unordered in Go).
+//
+// panelW is the effective width of the details panel. Rows are
+// tail-truncated with an ellipsis to keep the block from wrapping.
+func renderDetailsBlock(e Entry, panelW int) string {
+	label := initflow.LabelStyle()
+	value := lipgloss.NewStyle().Foreground(tui.ColorAccent)
+
+	header := initflow.RenderSectionHeader("DETAILS", panelW)
+
+	const labelW = 12
+	const indent = "  "
+
+	rows := []string{header}
+	add := func(key, val string) {
+		if val == "" {
+			return
+		}
+		// Tail-truncate long values so the DETAILS block never wraps.
+		budget := panelW - labelW - len(indent) - 2
+		if budget < 10 {
+			budget = 10
+		}
+		if lipgloss.Width(val) > budget {
+			rr := []rune(val)
+			if len(rr) > budget-1 {
+				val = string(rr[:budget-1]) + "…"
+			}
+		}
+		rows = append(rows,
+			indent+label.Render(padRight(key, labelW))+value.Render(val))
+	}
+
+	if e.Agents != "" {
+		add("AGENTS", e.Agents)
+	}
+	if e.Required != "" {
+		add("REQUIRED", e.Required)
+	}
+
+	// Sort Meta keys so output is deterministic.
+	metaKeys := make([]string, 0, len(e.Meta))
+	for k := range e.Meta {
+		metaKeys = append(metaKeys, k)
+	}
+	sort.Strings(metaKeys)
+	for _, k := range metaKeys {
+		add(strings.ToUpper(k), e.Meta[k])
+	}
+
+	if len(rows) == 1 {
+		// Nothing to show beyond the header.
+		dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+		rows = append(rows, indent+dim.Render("(no extra metadata)"))
+	}
+
+	return strings.Join(rows, "\n")
+}
+
+// padRight right-pads s with spaces so its visible width reaches w.
+// Kept local to catalogflow so the package stays self-contained without
+// leaking into initflow's internal helper namespace.
+func padRight(s string, w int) string {
+	cur := lipgloss.Width(s)
+	if cur >= w {
+		return s
+	}
+	return s + strings.Repeat(" ", w-cur)
+}

--- a/internal/tui/catalogflow/entry_test.go
+++ b/internal/tui/catalogflow/entry_test.go
@@ -1,0 +1,82 @@
+package catalogflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRenderEntry_NameAppears verifies the display name is rendered in
+// both focused and unfocused states.
+func TestRenderEntry_NameAppears(t *testing.T) {
+	e := Entry{Name: "foo", DisplayName: "Foo Bar", Description: "a thing"}
+	for _, focused := range []bool{true, false} {
+		out := renderEntry(e, focused)
+		if !strings.Contains(out, "Foo Bar") {
+			t.Fatalf("focused=%v: display name missing, got:\n%s", focused, out)
+		}
+	}
+}
+
+// TestRenderEntry_FallsBackToName verifies an empty DisplayName falls
+// back to the machine Name field.
+func TestRenderEntry_FallsBackToName(t *testing.T) {
+	e := Entry{Name: "foo-bar", Description: "a thing"}
+	out := renderEntry(e, false)
+	if !strings.Contains(out, "foo-bar") {
+		t.Fatalf("expected machine name fallback, got:\n%s", out)
+	}
+}
+
+// TestRenderEntry_RequiredGlyph verifies entries with a non-empty
+// Required field get a trailing "*" after the name.
+func TestRenderEntry_RequiredGlyph(t *testing.T) {
+	e := Entry{Name: "foo", DisplayName: "Foo", Required: "all"}
+	out := renderEntry(e, false)
+	if !strings.Contains(out, "*") {
+		t.Fatalf("expected required glyph after name, got:\n%s", out)
+	}
+}
+
+// TestRenderEntry_FocusBorder verifies the focused row carries the
+// leaf `│ ` border prefix while the unfocused row is plain-padded.
+func TestRenderEntry_FocusBorder(t *testing.T) {
+	e := Entry{Name: "foo", DisplayName: "Foo", Description: "thing"}
+	focused := renderEntry(e, true)
+	unfocused := renderEntry(e, false)
+	if !strings.Contains(focused, "│") {
+		t.Fatalf("focused row missing leaf border, got:\n%s", focused)
+	}
+	if strings.Contains(unfocused, "│") {
+		t.Fatalf("unfocused row must not carry leaf border, got:\n%s", unfocused)
+	}
+}
+
+// TestRenderDetailsBlock_RendersMetaKeys verifies that Meta entries
+// appear as labelled rows in sorted order.
+func TestRenderDetailsBlock_RendersMetaKeys(t *testing.T) {
+	e := Entry{
+		Name: "foo", DisplayName: "Foo", Description: "thing",
+		Agents: "all", Required: "all",
+		Meta: map[string]string{"Event": "Stop", "Matcher": "Edit"},
+	}
+	out := renderDetailsBlock(e, 80)
+	for _, want := range []string{"AGENTS", "REQUIRED", "EVENT", "MATCHER", "Stop", "Edit"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("details block missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderDetailsBlock_MinRowsWithoutMeta verifies that an entry
+// with no metadata renders the header + the "(no extra metadata)"
+// placeholder so the block always reads as a labelled section.
+func TestRenderDetailsBlock_MinRowsWithoutMeta(t *testing.T) {
+	e := Entry{Name: "bare", DisplayName: "Bare"}
+	out := renderDetailsBlock(e, 80)
+	if !strings.Contains(out, "DETAILS") {
+		t.Fatalf("header missing, got:\n%s", out)
+	}
+	if !strings.Contains(out, "no extra metadata") {
+		t.Fatalf("expected fallback copy for bare entry, got:\n%s", out)
+	}
+}

--- a/internal/tui/initflow/branches.go
+++ b/internal/tui/initflow/branches.go
@@ -97,6 +97,7 @@ func NewBranchesStage(ctx StageContext, cat *catalog.Catalog, agentDef *catalog.
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.applyContextHeader(ctx)
 
 	const agentType = "tech-lead"
 

--- a/internal/tui/initflow/chrome.go
+++ b/internal/tui/initflow/chrome.go
@@ -20,13 +20,18 @@ type KeyHint struct {
 // RenderHeader renders the two-column, two-row top banner shown above every
 // stage. Both columns are two rows — left stacks the service badge above the
 // process label so the brand and the action sit on distinct lines; right
-// stacks "PLANTING INTO" above the project path so the destination reads as
-// its own block.
+// stacks the destination label above the project path so the destination
+// reads as its own block.
 //
-//	Left row 1:  盆  BONSAI
-//	Left row 2:  ◇ INIT · v<version>
-//	Right row 1: PLANTING INTO
+//	Left row 1:  ◇  BONSAI
+//	Left row 2:  <action> · v<version>
+//	Right row 1: <rightLabel>
 //	Right row 2: ~/.../<project>/
+//
+// action is the uppercase command label shown on row 2 (e.g. "INIT",
+// "CATALOG"); rightLabel is the destination-context label (e.g.
+// "PLANTING INTO", "IN"). An empty rightLabel hides the right-block row 1
+// entirely — useful for commands that don't have a "destination".
 //
 // version "dev" / "" hides the version segment on row 2. projectDir is the
 // absolute path to the project root — the only path segment rendered in the
@@ -38,7 +43,7 @@ type KeyHint struct {
 // A sidePad (2 cells) is applied to both edges so the header's content
 // sits inside the same inset as the enso rail below — keeps the chrome's
 // left/right margins visually consistent across rows.
-func RenderHeader(version, projectDir string, width int, safe bool) string {
+func RenderHeader(version, projectDir, action, rightLabel string, width int, safe bool) string {
 	if width <= 0 {
 		width = 80
 	}
@@ -59,14 +64,19 @@ func RenderHeader(version, projectDir string, width int, safe bool) string {
 	}
 	leftRow1 := dot.Render(glyph) + "  " + primary.Render("BONSAI")
 
-	// Row 2 — muted "INIT · v…" subtitle. No leading glyph — row 1 carries
-	// the only decorative mark so the two rows read as brand / state.
-	leftRow2Parts := []string{muted.Render("INIT")}
+	// Row 2 — muted "<action> · v…" subtitle. No leading glyph — row 1
+	// carries the only decorative mark so the two rows read as brand /
+	// state. A blank action collapses the subtitle to just the version
+	// chip (or disappears entirely when version is dev/empty).
+	var leftRow2Parts []string
+	if action != "" {
+		leftRow2Parts = append(leftRow2Parts, muted.Render(action))
+	}
 	if version != "" && version != "dev" {
-		leftRow2Parts = append(leftRow2Parts,
-			muted.Render("·"),
-			muted.Render("v"+version),
-		)
+		if len(leftRow2Parts) > 0 {
+			leftRow2Parts = append(leftRow2Parts, muted.Render("·"))
+		}
+		leftRow2Parts = append(leftRow2Parts, muted.Render("v"+version))
 	}
 	leftRow2 := strings.Join(leftRow2Parts, " ")
 
@@ -79,7 +89,13 @@ func RenderHeader(version, projectDir string, width int, safe bool) string {
 	} else if !strings.HasSuffix(parent, "/") {
 		parent += "/"
 	}
-	rightRow1 := muted.Render("PLANTING INTO")
+	// Empty rightLabel hides row 1 of the right block entirely — the
+	// project path still renders on row 2 but the destination preamble
+	// is omitted for commands with no destination context.
+	var rightRow1 string
+	if rightLabel != "" {
+		rightRow1 = muted.Render(rightLabel)
+	}
 	rightRow2 := muted.Render(parent) + bark.Render(projectName) + muted.Render("/")
 
 	// ── Compose ─────────────────────────────────────────────────────

--- a/internal/tui/initflow/chrome_test.go
+++ b/internal/tui/initflow/chrome_test.go
@@ -11,7 +11,7 @@ import (
 func TestRenderHeader_CollapsesHome(t *testing.T) {
 	t.Setenv("HOME", "/home/alice")
 
-	out := RenderHeader("0.1.2", "/home/alice/voyager-api", 120, true)
+	out := RenderHeader("0.1.2", "/home/alice/voyager-api", "INIT", "PLANTING INTO", 120, true)
 
 	if !strings.Contains(out, "~/voyager-api") {
 		t.Fatalf("expected tilde-collapsed project path in header, got:\n%s", out)
@@ -27,7 +27,7 @@ func TestRenderHeader_CollapsesHome(t *testing.T) {
 func TestRenderHeader_AbsolutePathOutsideHome(t *testing.T) {
 	t.Setenv("HOME", "/home/bob")
 
-	out := RenderHeader("0.1.2", "/tmp/p", 120, true)
+	out := RenderHeader("0.1.2", "/tmp/p", "INIT", "PLANTING INTO", 120, true)
 
 	if !strings.Contains(out, "/tmp/p") {
 		t.Fatalf("expected absolute project path in header, got:\n%s", out)
@@ -45,7 +45,7 @@ func TestRenderHeader_NoStationSegment(t *testing.T) {
 	t.Setenv("HOME", "/home/alice")
 
 	for _, safe := range []bool{true, false} {
-		out := RenderHeader("0.1.2", "/home/alice/voyager-api", 120, safe)
+		out := RenderHeader("0.1.2", "/home/alice/voyager-api", "INIT", "PLANTING INTO", 120, safe)
 		if strings.Contains(out, "station") {
 			t.Fatalf("safe=%v: header must not contain \"station\" substring, got:\n%s", safe, out)
 		}
@@ -57,9 +57,43 @@ func TestRenderHeader_NoStationSegment(t *testing.T) {
 func TestRenderHeader_TrailingSlash(t *testing.T) {
 	t.Setenv("HOME", "/home/alice")
 
-	out := RenderHeader("0.1.2", "/home/alice/voyager-api", 120, true)
+	out := RenderHeader("0.1.2", "/home/alice/voyager-api", "INIT", "PLANTING INTO", 120, true)
 
 	if !strings.Contains(out, "voyager-api/") {
 		t.Fatalf("expected trailing slash after project name, got:\n%s", out)
+	}
+}
+
+// TestRenderHeader_CustomAction covers the Plan 28 Phase 1 signature
+// extension — the `action` parameter is rendered on the left block row 2
+// instead of the hardcoded "INIT" literal.
+func TestRenderHeader_CustomAction(t *testing.T) {
+	t.Setenv("HOME", "/home/alice")
+
+	out := RenderHeader("0.1.2", "/home/alice/voyager-api", "CATALOG", "PLANTING INTO", 120, true)
+
+	if !strings.Contains(out, "CATALOG") {
+		t.Fatalf("expected custom action label in header, got:\n%s", out)
+	}
+	// INIT must not leak in when a different action is supplied.
+	if strings.Contains(out, "INIT") {
+		t.Fatalf("custom action did not replace default INIT, got:\n%s", out)
+	}
+}
+
+// TestRenderHeader_EmptyRightLabelHidesRow1 verifies that an empty rightLabel
+// hides the right-block row 1 entirely. The project path still renders on
+// row 2, but the destination preamble (e.g. "PLANTING INTO") is omitted.
+func TestRenderHeader_EmptyRightLabelHidesRow1(t *testing.T) {
+	t.Setenv("HOME", "/home/alice")
+
+	out := RenderHeader("0.1.2", "/home/alice/voyager-api", "CATALOG", "", 120, true)
+
+	if strings.Contains(out, "PLANTING INTO") {
+		t.Fatalf("expected right-block row 1 to be hidden, got:\n%s", out)
+	}
+	// Project path must still render.
+	if !strings.Contains(out, "voyager-api") {
+		t.Fatalf("expected project name to still render on row 2, got:\n%s", out)
 	}
 }

--- a/internal/tui/initflow/generate.go
+++ b/internal/tui/initflow/generate.go
@@ -107,6 +107,7 @@ func NewGenerateStage(ctx StageContext, action GenerateAction) *GenerateStage {
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.applyContextHeader(ctx)
 	return &GenerateStage{
 		Stage:  base,
 		action: action,

--- a/internal/tui/initflow/observe.go
+++ b/internal/tui/initflow/observe.go
@@ -65,6 +65,7 @@ func NewObserveStage(ctx StageContext, cat *catalog.Catalog, agentDef *catalog.A
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.applyContextHeader(ctx)
 	return &ObserveStage{
 		Stage:    base,
 		cat:      cat,

--- a/internal/tui/initflow/planted.go
+++ b/internal/tui/initflow/planted.go
@@ -63,6 +63,7 @@ func NewPlantedStage(ctx StageContext, wr *generate.WriteResult, summary Planted
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.applyContextHeader(ctx)
 	return &PlantedStage{
 		Stage:         base,
 		wr:            wr,

--- a/internal/tui/initflow/soil.go
+++ b/internal/tui/initflow/soil.go
@@ -49,6 +49,7 @@ func NewSoilStage(ctx StageContext, options []ScaffoldingOption) *SoilStage {
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.applyContextHeader(ctx)
 
 	selected := make([]bool, len(options))
 	for i, opt := range options {

--- a/internal/tui/initflow/stage.go
+++ b/internal/tui/initflow/stage.go
@@ -38,13 +38,24 @@ type Stage struct {
 	agentDisplay string    // agentDef.DisplayName — rendered by Observe's AGENT row
 	startedAt    time.Time // captured at cmd.runInit entry for Planted's ELAPSED
 
+	// Header chrome labels — passed to RenderHeader on every frame. Defaults
+	// ("INIT" / "PLANTING INTO") preserve the init-flow presentation so
+	// callers that predate the Plan 28 Phase 1 signature extension don't
+	// need any changes. Sibling packages override via SetHeaderAction /
+	// SetHeaderRightLabel — or stamp the values via StageContext.
+	headerAction     string
+	headerRightLabel string
+
 	// State.
 	done bool // set by subclass when Enter advances
 }
 
 // NewStage constructs the shared Stage bundle used by every subclass. idx is
 // the 0-based rail position; label is typically StageLabels[idx]. Remaining
-// fields are the project context captured by cmd.runInit.
+// fields are the project context captured by cmd.runInit. Header chrome
+// labels default to "INIT" / "PLANTING INTO" — overridable via
+// SetHeaderAction / SetHeaderRightLabel or via StageContext.HeaderAction /
+// StageContext.HeaderRightLabel at the caller.
 func NewStage(
 	idx int,
 	label StageLabel,
@@ -56,15 +67,17 @@ func NewStage(
 	startedAt time.Time,
 ) Stage {
 	return Stage{
-		idx:          idx,
-		label:        label,
-		title:        title,
-		version:      version,
-		projectDir:   projectDir,
-		stationDir:   stationDir,
-		agentDisplay: agentDisplay,
-		startedAt:    startedAt,
-		ensoSafe:     WideCharSafe(),
+		idx:              idx,
+		label:            label,
+		title:            title,
+		version:          version,
+		projectDir:       projectDir,
+		stationDir:       stationDir,
+		agentDisplay:     agentDisplay,
+		startedAt:        startedAt,
+		ensoSafe:         WideCharSafe(),
+		headerAction:     "INIT",
+		headerRightLabel: "PLANTING INTO",
 	}
 }
 
@@ -89,6 +102,39 @@ func (s *Stage) SetRailIndex(idx int) { s.idx = idx }
 // transition-art stages (spinners) and terminal completion cards that
 // render their own chromeless hero layout instead of the standard rail.
 func (s *Stage) SetRailHidden(h bool) { s.railHidden = h }
+
+// SetHeaderAction overrides the uppercase command label rendered on header
+// row 2 ("INIT", "CATALOG", etc.). Defaults to "INIT" so existing init-flow
+// callers need no change. Empty string collapses row 2 to the version chip
+// (or removes it entirely when version is dev/empty).
+func (s *Stage) SetHeaderAction(a string) { s.headerAction = a }
+
+// SetHeaderRightLabel overrides the destination-context label on header
+// right-block row 1 ("PLANTING INTO", "IN", etc.). Defaults to
+// "PLANTING INTO". Empty string hides right-block row 1 entirely — the
+// project path still renders on row 2.
+func (s *Stage) SetHeaderRightLabel(l string) { s.headerRightLabel = l }
+
+// applyContextHeader installs header labels from ctx when set. An empty
+// field on ctx preserves the NewStage default so callers that don't care
+// about per-command chrome don't have to restamp it. Used by every stage
+// ctor that accepts a StageContext so the cmd-layer caller can configure
+// the header labels once (at StageContext construction) and have every
+// downstream stage render with the same chrome.
+func (s *Stage) applyContextHeader(ctx StageContext) {
+	if ctx.HeaderAction != "" {
+		s.headerAction = ctx.HeaderAction
+	}
+	if ctx.HeaderRightLabel != "" {
+		s.headerRightLabel = ctx.HeaderRightLabel
+	}
+}
+
+// ApplyContextHeader is the exported wrapper for applyContextHeader. Used
+// by sibling flow packages (addflow, etc.) so their per-stage ctors can
+// install the header labels from StageContext without reimplementing the
+// "empty-preserves-default" rule.
+func (s *Stage) ApplyContextHeader(ctx StageContext) { s.applyContextHeader(ctx) }
 
 // SetLabel overrides the stage's rendered kanji/kana/English triple. Used
 // in tandem with SetRailIndex when a sibling package reuses an initflow
@@ -206,7 +252,7 @@ func (s *Stage) renderFrame(body string, keys []KeyHint) string {
 		return RenderMinSizeFloor(s.width, s.height)
 	}
 
-	header := RenderHeader(s.version, s.projectDir, width, s.ensoSafe)
+	header := RenderHeader(s.version, s.projectDir, s.headerAction, s.headerRightLabel, width, s.ensoSafe)
 	footer := RenderFooter(keys, width)
 
 	count := func(s string) int { return strings.Count(s, "\n") + 1 }
@@ -261,12 +307,20 @@ func DefaultKeys(canGoBack bool) []KeyHint {
 // StageContext is a small record used by cmd.runInit to stamp each stage
 // with the shared project context at construction time. Keeps the call-site
 // symmetric and obvious across all stage constructors.
+//
+// HeaderAction / HeaderRightLabel override the header chrome labels
+// ("INIT" / "PLANTING INTO" by default). Sibling packages (addflow, etc.)
+// stamp their own values here so each command's header reads with its own
+// action label. Empty values on both fields preserve the NewStage defaults;
+// explicit empty-string HeaderRightLabel hides the right-block row 1.
 type StageContext struct {
-	Version      string
-	ProjectDir   string
-	StationDir   string
-	AgentDisplay string
-	StartedAt    time.Time
+	Version          string
+	ProjectDir       string
+	StationDir       string
+	AgentDisplay     string
+	StartedAt        time.Time
+	HeaderAction     string
+	HeaderRightLabel string
 }
 
 // homeDir returns $HOME via os.UserHomeDir. Kept wrapped so chrome.go can

--- a/internal/tui/initflow/vessel.go
+++ b/internal/tui/initflow/vessel.go
@@ -57,6 +57,7 @@ func NewVesselStage(ctx StageContext) *VesselStage {
 		ctx.AgentDisplay,
 		ctx.StartedAt,
 	)
+	base.applyContextHeader(ctx)
 
 	inputs := [3]textinput.Model{}
 	for i := range inputs {


### PR DESCRIPTION
## Summary
Plan 28 Phase 1 — cinematic `bonsai catalog` (tabbed BubbleTea browser) + `initflow.RenderHeader` signature extension (action + rightLabel params) + hide auto-generated `completion` subcommand from `bonsai --help`.

## Changes
- `internal/tui/catalogflow/` — new package: `BrowserStage` BubbleTea model, 7 tabs, inline-expand details, `-a` filter greys empty tabs.
- `internal/tui/initflow/chrome.go` — `RenderHeader` accepts `action` and `rightLabel` params; empty rightLabel hides right-row-1.
- `internal/tui/initflow/stage.go` — Stage carries header labels with "INIT"/"PLANTING INTO" defaults + setters + `applyContextHeader` helper; `StageContext` gains `HeaderAction` / `HeaderRightLabel`.
- `internal/tui/addflow/*` + `internal/tui/initflow/*` + `cmd/init_flow.go` + `cmd/add.go` — updated RenderHeader call-sites; add/init stamp "INIT" / "PLANTING INTO" explicitly.
- `cmd/catalog.go` — rewire to TTY-gated BubbleTea launch; non-TTY falls back to existing static render (factored into `renderCatalogStatic`).
- `cmd/root.go` — `rootCmd.CompletionOptions.HiddenDefaultCmd = true`.

## Plan
station/Playbook/Plans/Active/28-view-cmds-cinematic.md (Phase 1)

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `gofmt -l .` — clean
- [x] `go vet ./...` — clean
- [x] `./bonsai --help` — `completion` no longer listed
- [x] `./bonsai completion zsh | head` — emits completion script
- [x] `./bonsai catalog` AltScreen launches (manual probe: when stdout is a TTY; probed via pipe to verify non-TTY branch falls back correctly)
- [x] `./bonsai catalog > out.txt` — static fallback produces 7 sections

## Test plan
- [ ] Manually run `./bonsai catalog` in a TTY — confirm tab cycle with arrows, `?` toggles details, `q` exits cleanly
- [ ] `./bonsai catalog -a tech-lead` — confirm greyed tabs for categories with zero tech-lead-compat items
- [ ] Resize terminal below 70×20 — confirm min-size floor panel renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)