### PR TITLE
Plan 27 PR2 — add-flow Phase C polish + Phase D verification

### DIFF
--- a/internal/tui/addflow/conflicts.go
+++ b/internal/tui/addflow/conflicts.go
@@ -13,43 +13,47 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
 
-// ConflictsStage is the tabbed conflict-resolution picker at rail position 5
-// (衝 CONFLICT). Rendered only when the Grow action produced at least one
-// ActionConflict file — the harness gates construction on
+// ConflictsStage is the chromeless full-screen conflict-resolution surface
+// (Plan 27 PR2 §C1-C5). Rendered only when the Grow action produced at least
+// one ActionConflict file — the harness gates construction on
 // wr.HasConflicts(), so this stage never instantiates for clean writes.
 //
-// Layout: one tab per conflict file. Each tab shows:
-//   - Header  : the conflict file's relative path
-//   - Summary : a short "local has edits · source has changes" line (until the
-//     generator surfaces an inline diff field, this is a placeholder — see
-//     the TODO next to diffSummary below)
-//   - Radio   : three rows — Keep local · Overwrite with source · Backup
-//     then overwrite. Default Keep.
+// Layout: one row per conflict file in a vertical list. Each row carries:
 //
-// Keystrokes match the addflow house style:
-//   - ← → / h l     cycle tabs (wrap)
-//   - ↑ ↓ / j k     cycle radio (no-wrap)
-//   - ␣ / ↵         advance (to next tab, or complete if last)
-//   - shift+tab / esc   back to prior stage (Grow; harness handles the pop)
+//	[focus glyph] [action glyph · coloured by pick] [relative path] [action label]
+//
+// Below the list a batch-resolve row renders three cells (Keep all /
+// Overwrite all / Backup all) that apply the chosen action to every row via
+// uppercase K/O/B.
+//
+// The stage is chromeless — View() returns the full AltScreen frame without
+// the header/enso-rail/footer chrome used by the four on-rail stages. The
+// rail visible to the user (anchored on OBSERVE) stays unchanged while the
+// conflict picker runs — no rail churn between Observe and Conflict.
+//
+// Keystrokes (plan-27 PR2 §C2 + §C4):
+//
+//   - ↑ ↓ / j k         move focus row (no wrap)
+//   - 1 / 2 / 3         set focused row's action to Keep / Overwrite / Backup
+//   - ␣                 cycle focused row's action (Keep → Overwrite → Backup → Keep)
+//   - K / O / B         batch-resolve — apply action to every row
+//   - ↵                 advance (complete stage)
+//   - shift+tab / esc   back to Observe (harness pops cursor)
 //
 // Result: map[string]config.ConflictAction keyed by FileResult.RelPath — one
-// entry per conflict file. applyCinematicConflictPicks in cmd/add.go
-// reads the map and dispatches per-file mutations.
+// entry per conflict file. applyCinematicConflictPicks in cmd/add.go reads
+// the map and dispatches per-file mutations.
 type ConflictsStage struct {
 	initflow.Stage
 
 	files   []generate.FileResult
-	catIdx  int                              // focused tab
+	focus   int                              // focused row (0..len(files)-1)
 	action  map[string]config.ConflictAction // per-file pick
-	radio   map[string]int                   // per-file radio focus row
-	toneOrd []config.ConflictAction          // index → action for radio rows
+	toneOrd []config.ConflictAction          // cycle order for ␣ keypress
+
+	viewport initflow.Viewport // used when conflict count exceeds visible rows
 }
 
-// NewConflictsStage constructs the stage over the conflict entries present
-// in wr. When wr has zero conflicts the ctor still returns a usable stage —
-// it simply renders an empty body with a single "nothing to reconcile" line
-// and completes on Enter. Callers should gate on wr.HasConflicts() before
-// splicing.
 // conflictsLabel is the kanji/kana/English triple shown in the Conflicts
 // stage body title. Plan 27 shrunk the rail to four visible stages so the
 // Conflicts stage renders off-rail; its rail index is StageIdxOffRail and
@@ -57,10 +61,11 @@ type ConflictsStage struct {
 // Bonsai-metaphor identity is retained.
 var conflictsLabel = initflow.StageLabel{Kanji: "衝", Kana: "しょう", English: "CONFLICT"}
 
-// Rail suppression is implicit: passing StageIdxOffRail (-1) into the base
-// ctor trips the negative-index branch in internal/tui/initflow/stage.go
-// (railHidden := s.railHidden || s.idx < 0), so no SetRailIndex call is
-// needed here.
+// NewConflictsStage constructs the stage over the conflict entries present
+// in wr. When wr has zero conflicts the ctor still returns a usable stage —
+// it simply renders an empty body with a single "nothing to reconcile" line
+// and completes on Enter. Callers should gate on wr.HasConflicts() before
+// splicing.
 func NewConflictsStage(ctx initflow.StageContext, wr *generate.WriteResult) *ConflictsStage {
 	label := conflictsLabel
 	base := initflow.NewStage(
@@ -82,18 +87,15 @@ func NewConflictsStage(ctx initflow.StageContext, wr *generate.WriteResult) *Con
 	}
 
 	action := make(map[string]config.ConflictAction, len(conflicts))
-	radio := make(map[string]int, len(conflicts))
 	for _, f := range conflicts {
 		action[f.RelPath] = config.ConflictActionKeep
-		radio[f.RelPath] = 0
 	}
 
 	return &ConflictsStage{
 		Stage:  base,
 		files:  conflicts,
-		catIdx: 0,
+		focus:  0,
 		action: action,
-		radio:  radio,
 		toneOrd: []config.ConflictAction{
 			config.ConflictActionKeep,
 			config.ConflictActionOverwrite,
@@ -102,10 +104,17 @@ func NewConflictsStage(ctx initflow.StageContext, wr *generate.WriteResult) *Con
 	}
 }
 
+// Chromeless reports true so the harness yields View() verbatim without its
+// default header/footer. Embedded initflow.Stage.Chromeless() already
+// returns true, but ConflictsStage declares the method explicitly so the
+// contract is obvious at call-sites that type-scan for Chromeless.
+func (s *ConflictsStage) Chromeless() bool { return true }
+
 // Init implements tea.Model — no cmd on entry.
 func (s *ConflictsStage) Init() tea.Cmd { return nil }
 
-// Update handles tab cycle + radio cycle + advance + back.
+// Update handles focus movement + per-row action + batch-resolve + advance +
+// back.
 func (s *ConflictsStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -120,38 +129,36 @@ func (s *ConflictsStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return s, nil
 		}
 		switch m.String() {
-		case "left", "h":
-			s.catIdx = (s.catIdx - 1 + len(s.files)) % len(s.files)
-		case "right", "l":
-			s.catIdx = (s.catIdx + 1) % len(s.files)
 		case "up", "k":
-			key := s.currentKey()
-			if key == "" {
-				return s, nil
+			if s.focus > 0 {
+				s.focus--
 			}
-			cur := s.radio[key] - 1
-			if cur < 0 {
-				cur = 0
-			}
-			s.radio[key] = cur
-			s.action[key] = s.toneOrd[cur]
 		case "down", "j":
+			if s.focus+1 < len(s.files) {
+				s.focus++
+			}
+		case "1":
+			s.setFocusedAction(config.ConflictActionKeep)
+		case "2":
+			s.setFocusedAction(config.ConflictActionOverwrite)
+		case "3":
+			s.setFocusedAction(config.ConflictActionBackup)
+		case " ":
+			// Cycle focused row: Keep → Overwrite → Backup → Keep.
 			key := s.currentKey()
 			if key == "" {
 				return s, nil
 			}
-			cur := s.radio[key] + 1
-			if cur >= len(s.toneOrd) {
-				cur = len(s.toneOrd) - 1
-			}
-			s.radio[key] = cur
-			s.action[key] = s.toneOrd[cur]
-		case " ", "enter":
-			// Advance to the next tab; complete on the last.
-			if s.catIdx+1 < len(s.files) {
-				s.catIdx++
-				return s, nil
-			}
+			cur := s.action[key]
+			next := cycleAction(cur, s.toneOrd)
+			s.action[key] = next
+		case "K":
+			s.setAllActions(config.ConflictActionKeep)
+		case "O":
+			s.setAllActions(config.ConflictActionOverwrite)
+		case "B":
+			s.setAllActions(config.ConflictActionBackup)
+		case "enter":
 			s.MarkDone()
 			return s, nil
 		}
@@ -159,61 +166,107 @@ func (s *ConflictsStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return s, nil
 }
 
-// currentKey returns the RelPath of the focused tab's file, or "" if no tabs.
+// cycleAction returns the next action in order, wrapping around.
+func cycleAction(cur config.ConflictAction, order []config.ConflictAction) config.ConflictAction {
+	for i, a := range order {
+		if a == cur {
+			return order[(i+1)%len(order)]
+		}
+	}
+	return order[0]
+}
+
+func (s *ConflictsStage) setFocusedAction(a config.ConflictAction) {
+	key := s.currentKey()
+	if key == "" {
+		return
+	}
+	s.action[key] = a
+}
+
+func (s *ConflictsStage) setAllActions(a config.ConflictAction) {
+	for _, f := range s.files {
+		s.action[f.RelPath] = a
+	}
+}
+
+// currentKey returns the RelPath of the focused row's file, or "" if no rows.
 func (s *ConflictsStage) currentKey() string {
-	if s.catIdx < 0 || s.catIdx >= len(s.files) {
+	if s.focus < 0 || s.focus >= len(s.files) {
 		return ""
 	}
-	return s.files[s.catIdx].RelPath
+	return s.files[s.focus].RelPath
 }
 
-// View composes the body inside the shared frame.
+// View returns the full AltScreen frame. Chromeless — no header/rail/footer.
+// Mirrors initflow.PlantedStage.View for layout parity: centre vertically,
+// compose title + divider + list + batch row + inline key hints.
 func (s *ConflictsStage) View() string {
-	return s.RenderFrame(s.renderBody(), s.keyHints())
-}
-
-func (s *ConflictsStage) keyHints() []initflow.KeyHint {
-	return []initflow.KeyHint{
-		{Key: "←→", Desc: "file"},
-		{Key: "↑↓", Desc: "action"},
-		{Key: "↵", Desc: "next"},
-		{Key: "esc", Desc: "back"},
-		{Key: "ctrl-c", Desc: "quit"},
+	w := s.Width()
+	h := s.Height()
+	if w <= 0 {
+		w = 80
 	}
+	if h <= 0 {
+		h = 24
+	}
+	if initflow.TerminalTooSmall(s.Width(), s.Height()) {
+		return initflow.RenderMinSizeFloor(s.Width(), s.Height())
+	}
+
+	body := s.renderBody()
+
+	// Vertically centre inside the AltScreen.
+	rows := strings.Count(body, "\n") + 1
+	topPad := (h - rows) / 2
+	if topPad < 1 {
+		topPad = 1
+	}
+	bottomPad := h - rows - topPad
+	if bottomPad < 0 {
+		bottomPad = 0
+	}
+	return strings.Repeat("\n", topPad) + body + strings.Repeat("\n", bottomPad)
 }
 
+// renderBody composes title row + divider + list + batch-resolve row +
+// inline key-hint footer. No surrounding chrome — the stage owns the frame.
 func (s *ConflictsStage) renderBody() string {
 	dim := initflow.DimStyle()
 	bark := initflow.LabelStyle()
 	white := lipgloss.NewStyle().Foreground(tui.ColorAccent).Bold(true)
+	danger := lipgloss.NewStyle().Foreground(tui.ColorDanger).Bold(true)
 
-	var title string
+	// Dedicated title row (replaces RenderHeader chrome). Title mixes the
+	// kanji + English so ASCII fallback still reads "CONFLICT".
+	var titleRow string
 	if s.EnsoSafe() {
-		title = bark.Render(s.Label().Kanji) + " " + white.Render(s.Label().English)
+		titleRow = danger.Render(s.Label().Kanji + " · CONFLICT")
 	} else {
-		title = white.Render(s.Label().English)
+		titleRow = danger.Render("CONFLICT")
 	}
 
+	panelW := initflow.PanelWidth(s.Width())
+	divider := initflow.RenderSectionHeader("RECONCILE", panelW)
+
 	intro := strings.Join([]string{
-		title,
+		titleRow,
 		white.Render("Reconcile edited files."),
 		dim.Render("Pick an action per file — nothing overwritten silently."),
 	}, "\n")
 
-	panelW := initflow.PanelWidth(s.Width())
-	divider := initflow.RenderSectionHeader("CONFLICTS", panelW)
-
 	if len(s.files) == 0 {
 		empty := dim.Render("  (nothing to reconcile)")
-		body := []string{intro, "", "", divider, "", empty}
+		hint := s.renderKeyHints()
+		body := []string{intro, "", "", divider, "", empty, "", "", hint}
 		return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
 	}
 
-	tabRow := s.renderTabs()
-	header := s.renderFileHeader()
-	summary := s.renderDiffSummary()
-	radio := s.renderRadio()
+	list := s.renderList()
+	batchCaption := "  " + dim.Render("batch resolve:")
+	batchRow := s.renderBatchRow()
 	counter := s.renderCounter()
+	hint := s.renderKeyHints()
 
 	body := []string{
 		intro,
@@ -221,182 +274,158 @@ func (s *ConflictsStage) renderBody() string {
 		"",
 		divider,
 		"",
-		tabRow,
+		list,
 		"",
-		header,
+		batchCaption,
+		batchRow,
 		"",
-		summary,
+		"  " + bark.Render(counter),
 		"",
-		radio,
-		"",
-		dim.Render(counter),
+		hint,
 	}
 	return initflow.CenterBlock(strings.Join(body, "\n"), s.Width())
 }
 
-// renderTabs draws a compact tab strip — one cell per conflict file, keyed
-// by file index. File paths are truncated to fit.
-func (s *ConflictsStage) renderTabs() string {
-	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
-	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
-	bracket := lipgloss.NewStyle().Foreground(tui.ColorPrimary)
-	chevron := lipgloss.NewStyle().Foreground(tui.ColorSecondary).Bold(true)
-
-	cells := make([]string, 0, len(s.files))
-	// Use a compact label — index + short basename — so the tab strip does
-	// not wrap on terminals with many conflicts. Full path is shown in the
-	// header block below.
-	for i, f := range s.files {
-		label := fmt.Sprintf("%d · %s", i+1, basename(f.RelPath))
-		// Clamp label to a conservative width so many conflicts still fit.
-		if lipgloss.Width(label) > 20 {
-			rr := []rune(label)
-			if len(rr) > 19 {
-				label = string(rr[:19]) + "…"
-			}
-		}
-		var cell string
-		if i == s.catIdx {
-			cell = bracket.Render("[ ") + leaf.Render(label) + bracket.Render(" ]")
-		} else {
-			cell = "  " + muted.Render(label) + "  "
-		}
-		cells = append(cells, cell)
+// renderList renders one row per conflict file in a vertical list. When the
+// row count exceeds the available budget the list is rendered through a
+// Viewport that follows the focus.
+func (s *ConflictsStage) renderList() string {
+	rows := make([]string, len(s.files))
+	for i := range s.files {
+		rows[i] = s.renderRow(i)
 	}
 
-	row := strings.Join(cells, " ")
-	return chevron.Render("‹") + " " + row + " " + chevron.Render("›")
+	listH := s.listHeight()
+	if listH > 0 && listH < len(rows) {
+		s.viewport.SetLines(rows)
+		s.viewport.SetHeight(listH)
+		s.viewport.Follow(s.focus)
+		return s.viewport.View()
+	}
+	return strings.Join(rows, "\n")
 }
 
-// renderFileHeader shows the focused file's full relative path, truncated to
-// the panel width if needed.
-func (s *ConflictsStage) renderFileHeader() string {
-	bark := initflow.LabelStyle()
-	value := initflow.ValueStyle()
-
-	key := s.currentKey()
-	if key == "" {
-		return ""
+// listHeight returns the visible row budget for the conflict list. Fixed
+// body rows: title (3) + blanks (2) + divider (1) + blank (1) + blank (1) +
+// batch caption (1) + batch row (1) + blank (1) + counter (1) + blank (1) +
+// key hint (1) = ~14 rows. Leaves at least 3 rows for the list on 20-row
+// terminals.
+func (s *ConflictsStage) listHeight() int {
+	h := s.Height()
+	if h <= 0 {
+		return 0
 	}
+	const fixedRows = 15
+	v := h - fixedRows
+	if v < 3 {
+		v = 3
+	}
+	return v
+}
+
+// renderRow renders a single conflict entry. Layout:
+//
+//	[border 2] [focus glyph 1] [sp 1] [action glyph 1] [sp 1] [relative path] [sp 2] [action label]
+//
+// Colour family is driven by the CURRENT action for the row — Keep green,
+// Overwrite red, Backup amber — so the palette updates live as the user
+// cycles ␣ / 1 / 2 / 3 / K / O / B. The focused row uses FocusBorder + bold
+// emphasis; unfocused rows are dim.
+func (s *ConflictsStage) renderRow(idx int) string {
+	f := s.files[idx]
+	focused := idx == s.focus
+
+	act := s.action[f.RelPath]
+	tone := toneFor(act)
+	rowStyle := initflow.ConflictRowStyle(tone)
+	glyph := initflow.ConflictActionGlyph(tone)
+
+	border := initflow.UnfocusBorder()
+	if focused {
+		border = initflow.FocusBorder()
+	}
+
+	focusGlyph := " "
+	leaf := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	if focused {
+		focusGlyph = leaf.Render("▸")
+	}
+
+	// Path column — budget = panelW - (border 2 + focusGlyph 1 + sp 1 +
+	// actionGlyph 1 + sp 1 + actionLabel ~18 + sp 2) ≈ panelW - 26.
 	panelW := initflow.PanelWidth(s.Width())
-	// Reserve space for the "FILE " label prefix (4 + 2 gap).
-	labelW := 6
-	pathBudget := panelW - labelW - 2
+	labelText := actionLabel(act)
+	labelW := 18 // generous budget so "backup + overwrite" fits
+	pathBudget := panelW - 2 - 1 - 1 - 1 - 1 - labelW - 2
 	if pathBudget < 10 {
 		pathBudget = 10
 	}
-	path := key
+	path := f.RelPath
 	if lipgloss.Width(path) > pathBudget {
 		rr := []rune(path)
 		if len(rr) > pathBudget-1 {
-			// Head-truncate paths so the distinctive basename survives.
 			path = "…" + string(rr[len(rr)-pathBudget+1:])
 		}
 	}
-	return "  " + bark.Render(initflow.PadRight("FILE", labelW)) + value.Render(path)
+
+	pathStyle := initflow.UnfocusedNameStyle()
+	if focused {
+		pathStyle = initflow.FocusedNameStyle()
+	}
+
+	actionCell := rowStyle.Render(glyph) + " " + rowStyle.Render(labelText)
+	return border + focusGlyph + " " + pathStyle.Render(initflow.PadRight(path, pathBudget)) + "  " + actionCell
 }
 
-// renderDiffSummary emits a short status line describing the conflict. TODO:
-// surface a real inline diff once FileResult carries one. Until then we read
-// Source (the catalog path the file came from) and the RelPath to compose a
-// one-line provenance summary — no partial diff leaks, no placeholder data
-// masquerades as content.
-func (s *ConflictsStage) renderDiffSummary() string {
-	dim := initflow.DimStyle()
+// renderBatchRow draws the three labelled cells below the list. Uppercase
+// K/O/B trigger each cell; lowercase k/o/b are no-ops (Plan 27 §C4).
+func (s *ConflictsStage) renderBatchRow() string {
+	keepStyle := initflow.ConflictRowStyle(initflow.ConflictToneKeep)
+	overStyle := initflow.ConflictRowStyle(initflow.ConflictToneOverwrite)
+	backStyle := initflow.ConflictRowStyle(initflow.ConflictToneBackup)
 	bark := initflow.LabelStyle()
-	value := initflow.ValueStyle()
 
-	if s.catIdx < 0 || s.catIdx >= len(s.files) {
-		return ""
-	}
-	f := s.files[s.catIdx]
-
-	labelW := 6
-	source := f.Source
-	if source == "" {
-		source = "—"
+	cell := func(key string, style lipgloss.Style, label string) string {
+		return style.Render("[ ") + bark.Render(key) + style.Render(" "+label+" ]")
 	}
 
-	panelW := initflow.PanelWidth(s.Width())
-	srcBudget := panelW - labelW - 2
-	if srcBudget < 10 {
-		srcBudget = 10
-	}
-	if lipgloss.Width(source) > srcBudget {
-		rr := []rune(source)
-		if len(rr) > srcBudget-1 {
-			source = string(rr[:srcBudget-1]) + "…"
-		}
-	}
-
-	// TODO(plan-23-phase2): replace the placeholder status with a real inline
-	// diff summary once generate.FileResult exposes one. Today the write
-	// pipeline only records Action=ActionConflict, not a per-file diff — so
-	// we surface provenance (source) + a stable status instead of mocking
-	// content deltas.
-	statusLine := dim.Render("local has edits · source has changes")
-	srcLine := "  " + bark.Render(initflow.PadRight("SOURCE", labelW)) + value.Render(source)
-	return "  " + bark.Render(initflow.PadRight("WHAT", labelW)) + statusLine + "\n" + srcLine
+	row := cell("K", keepStyle, "Keep all") + "  " +
+		cell("O", overStyle, "Overwrite all") + "  " +
+		cell("B", backStyle, "Backup all")
+	return "  " + row
 }
 
-// renderRadio draws the three Keep / Overwrite / Backup rows for the focused
-// tab, using the colour-coded ConflictRowStyle tokens from initflow/design.
-func (s *ConflictsStage) renderRadio() string {
-	key := s.currentKey()
-	if key == "" {
-		return ""
-	}
-
-	rowFocus := s.radio[key]
-	rows := []struct {
-		tone  initflow.ConflictActionTone
-		label string
-		desc  string
-	}{
-		{initflow.ConflictToneKeep, "Keep local", "skip this file — your edits win"},
-		{initflow.ConflictToneOverwrite, "Overwrite with source", "discard edits and pull new content"},
-		{initflow.ConflictToneBackup, "Backup then overwrite", "save .bak and pull new content"},
-	}
-
-	out := make([]string, 0, len(rows))
-	for i, r := range rows {
-		style := initflow.ConflictRowStyle(r.tone)
-		glyph := initflow.ConflictActionGlyph(r.tone)
-
-		focused := i == rowFocus
-		border := initflow.UnfocusBorder()
-		if focused {
-			border = initflow.FocusBorder()
-		}
-
-		nameStyle := style
-		if focused {
-			nameStyle = nameStyle.Bold(true)
-		}
-
-		desc := initflow.UnfocusedDescStyle().Render(r.desc)
-		if focused {
-			desc = initflow.FocusedDescStyle().Render(r.desc)
-		}
-		line := border + style.Render(glyph) + " " + nameStyle.Render(r.label) + "  " + desc
-		out = append(out, line)
-	}
-	return strings.Join(out, "\n")
-}
-
-// renderCounter emits "file N of M — action: <label>" so the user always has
-// a sticky summary of where they are in the picker and what they picked.
+// renderCounter emits a sticky summary: "file N of M · focus: <action>".
 func (s *ConflictsStage) renderCounter() string {
 	if len(s.files) == 0 {
 		return ""
 	}
 	key := s.currentKey()
 	act := s.action[key]
-	return fmt.Sprintf("file %d of %d · action: %s", s.catIdx+1, len(s.files), actionLabel(act))
+	return fmt.Sprintf("file %d of %d · focus: %s", s.focus+1, len(s.files), actionLabel(act))
 }
 
-// actionLabel renders a ConflictAction as its user-facing label. Centralised
-// here so the counter + (future) confirm lines read from a single source.
+// renderKeyHints renders the inline key hint row (since the stage is
+// chromeless there is no RenderFooter). Keeps the hint set compact.
+func (s *ConflictsStage) renderKeyHints() string {
+	dim := initflow.DimStyle()
+	hint := "↑↓ focus  ·  1/2/3 action  ·  ␣ cycle  ·  K/O/B batch  ·  ↵ next  ·  esc back"
+	return dim.Render(hint)
+}
+
+// toneFor maps a ConflictAction to its visual tone.
+func toneFor(a config.ConflictAction) initflow.ConflictActionTone {
+	switch a {
+	case config.ConflictActionOverwrite:
+		return initflow.ConflictToneOverwrite
+	case config.ConflictActionBackup:
+		return initflow.ConflictToneBackup
+	default:
+		return initflow.ConflictToneKeep
+	}
+}
+
+// actionLabel renders a ConflictAction as its user-facing label.
 func actionLabel(a config.ConflictAction) string {
 	switch a {
 	case config.ConflictActionKeep:
@@ -410,27 +439,10 @@ func actionLabel(a config.ConflictAction) string {
 	}
 }
 
-// basename returns the last path segment of a forward-slash path. Kept local
-// so conflicts.go has no dependency on path/filepath on the hot render path.
-func basename(p string) string {
-	if p == "" {
-		return ""
-	}
-	idx := strings.LastIndex(p, "/")
-	if idx < 0 {
-		return p
-	}
-	return p[idx+1:]
-}
-
 // Result returns the per-file ConflictAction map. Keys are RelPath values;
 // every conflict entry is guaranteed to appear in the map (default Keep if
-// untouched). When the stage was aborted via esc the harness calls Reset and
-// discards the result — callers receiving a nil map on the read path should
-// fall through to a no-op.
+// untouched).
 func (s *ConflictsStage) Result() any {
-	// Return a copy so later mutations on the stage (shouldn't happen, but
-	// defensive) cannot mutate the harness-held snapshot.
 	if len(s.action) == 0 {
 		return map[string]config.ConflictAction{}
 	}
@@ -441,9 +453,8 @@ func (s *ConflictsStage) Result() any {
 	return out
 }
 
-// Reset clears the completion flag but preserves per-file picks, tab focus,
-// and radio focus so Esc-back → re-entry reads exactly where the user left
-// off. Mirrors the Graft stage's preserve-everything-but-done policy.
+// Reset clears the completion flag but preserves per-file picks and focus so
+// Esc-back → re-entry reads exactly where the user left off.
 func (s *ConflictsStage) Reset() tea.Cmd {
 	s.ClearDone()
 	return nil

--- a/internal/tui/addflow/conflicts_test.go
+++ b/internal/tui/addflow/conflicts_test.go
@@ -31,12 +31,20 @@ func conflictsPressKey(s *ConflictsStage, k tea.KeyType) {
 	}
 }
 
-// TestConflicts_TabCount verifies the stage surfaces one tab per conflict
+// conflictsPressRune dispatches a rune-based KeyMsg (digits, letters, space).
+func conflictsPressRune(s *ConflictsStage, r rune) {
+	m, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	if cs, ok := m.(*ConflictsStage); ok {
+		*s = *cs
+	}
+}
+
+// TestConflicts_RowCount verifies the stage surfaces one row per conflict
 // file.
-func TestConflicts_TabCount(t *testing.T) {
+func TestConflicts_RowCount(t *testing.T) {
 	s := newTestConflicts()
 	if len(s.files) != 3 {
-		t.Fatalf("tabs = %d, want 3 (one per conflict file)", len(s.files))
+		t.Fatalf("rows = %d, want 3 (one per conflict file)", len(s.files))
 	}
 }
 
@@ -55,77 +63,154 @@ func TestConflicts_DefaultIsKeep(t *testing.T) {
 	}
 }
 
-// TestConflicts_TabCycleWraps verifies ← / → wraps around the end of the
-// tab list.
-func TestConflicts_TabCycleWraps(t *testing.T) {
+// TestConflicts_FocusMoveClamps verifies ↑/↓ move focus without wrapping.
+func TestConflicts_FocusMoveClamps(t *testing.T) {
 	s := newTestConflicts()
-	if s.catIdx != 0 {
-		t.Fatalf("initial catIdx = %d, want 0", s.catIdx)
+	if s.focus != 0 {
+		t.Fatalf("initial focus = %d, want 0", s.focus)
 	}
-	// Right across the end: 0 → 1 → 2 → 0.
-	for i := 0; i < len(s.files); i++ {
-		conflictsPressKey(s, tea.KeyRight)
+	// Up from 0 clamps at 0.
+	conflictsPressKey(s, tea.KeyUp)
+	if s.focus != 0 {
+		t.Fatalf("up from 0 focus = %d, want 0 (clamp)", s.focus)
 	}
-	if s.catIdx != 0 {
-		t.Fatalf("after full cycle, catIdx = %d, want 0 (wrap)", s.catIdx)
+	// Down → 1 → 2 → 2 (clamp at last).
+	conflictsPressKey(s, tea.KeyDown)
+	if s.focus != 1 {
+		t.Fatalf("after 1x down focus = %d, want 1", s.focus)
 	}
-	// Left from 0 wraps to the last tab.
-	conflictsPressKey(s, tea.KeyLeft)
-	if s.catIdx != len(s.files)-1 {
-		t.Fatalf("after left from 0, catIdx = %d, want %d", s.catIdx, len(s.files)-1)
+	conflictsPressKey(s, tea.KeyDown)
+	if s.focus != 2 {
+		t.Fatalf("after 2x down focus = %d, want 2", s.focus)
+	}
+	conflictsPressKey(s, tea.KeyDown)
+	if s.focus != 2 {
+		t.Fatalf("down from last focus = %d, want 2 (clamp)", s.focus)
 	}
 }
 
-// TestConflicts_RadioCycleClamps verifies ↑/↓ cycles the radio focus without
-// wrapping.
-func TestConflicts_RadioCycleClamps(t *testing.T) {
+// TestConflicts_DigitKeysSetAction verifies 1/2/3 set the focused row's
+// action without moving focus.
+func TestConflicts_DigitKeysSetAction(t *testing.T) {
 	s := newTestConflicts()
 	key := s.currentKey()
-	// Start at row 0 (Keep).
-	if s.radio[key] != 0 {
-		t.Fatalf("initial radio = %d, want 0", s.radio[key])
+
+	conflictsPressRune(s, '2')
+	if s.action[key] != config.ConflictActionOverwrite {
+		t.Fatalf("after '2' action = %v, want Overwrite", s.action[key])
 	}
-	// Up from 0 clamps.
-	conflictsPressKey(s, tea.KeyUp)
-	if s.radio[key] != 0 {
-		t.Fatalf("up from 0 radio = %d, want 0", s.radio[key])
+	conflictsPressRune(s, '3')
+	if s.action[key] != config.ConflictActionBackup {
+		t.Fatalf("after '3' action = %v, want Backup", s.action[key])
 	}
-	// Down → 1 (Overwrite) → 2 (Backup) → 2 (clamp).
-	conflictsPressKey(s, tea.KeyDown)
-	if s.radio[key] != 1 || s.action[key] != config.ConflictActionOverwrite {
-		t.Fatalf("after 1x down radio=%d action=%v, want 1 + Overwrite", s.radio[key], s.action[key])
+	conflictsPressRune(s, '1')
+	if s.action[key] != config.ConflictActionKeep {
+		t.Fatalf("after '1' action = %v, want Keep", s.action[key])
 	}
-	conflictsPressKey(s, tea.KeyDown)
-	if s.radio[key] != 2 || s.action[key] != config.ConflictActionBackup {
-		t.Fatalf("after 2x down radio=%d action=%v, want 2 + Backup", s.radio[key], s.action[key])
-	}
-	conflictsPressKey(s, tea.KeyDown)
-	if s.radio[key] != 2 {
-		t.Fatalf("down from last radio=%d, want clamp at 2", s.radio[key])
+	// Focus should be unchanged.
+	if s.focus != 0 {
+		t.Fatalf("digit keys moved focus to %d, want 0", s.focus)
 	}
 }
 
-// TestConflicts_EnterAdvancesTabsThenCompletes verifies Enter cycles through
-// the tabs in order and flips Done only on the last tab.
-func TestConflicts_EnterAdvancesTabsThenCompletes(t *testing.T) {
+// TestConflicts_SpaceCyclesAction verifies ␣ cycles Keep → Overwrite →
+// Backup → Keep on the focused row.
+func TestConflicts_SpaceCyclesAction(t *testing.T) {
 	s := newTestConflicts()
-	// First Enter: tab 0 → tab 1, not done.
-	conflictsPressKey(s, tea.KeyEnter)
-	if s.catIdx != 1 {
-		t.Fatalf("after 1st Enter catIdx = %d, want 1", s.catIdx)
+	key := s.currentKey()
+
+	// Start: Keep.
+	if s.action[key] != config.ConflictActionKeep {
+		t.Fatalf("initial action = %v, want Keep", s.action[key])
 	}
-	if s.Done() {
-		t.Fatal("Done flipped on intermediate Enter")
+	conflictsPressRune(s, ' ')
+	if s.action[key] != config.ConflictActionOverwrite {
+		t.Fatalf("after 1x space action = %v, want Overwrite", s.action[key])
 	}
-	// Second Enter: tab 1 → tab 2, not done.
-	conflictsPressKey(s, tea.KeyEnter)
-	if s.catIdx != 2 || s.Done() {
-		t.Fatalf("after 2nd Enter catIdx=%d done=%v, want 2 + !done", s.catIdx, s.Done())
+	conflictsPressRune(s, ' ')
+	if s.action[key] != config.ConflictActionBackup {
+		t.Fatalf("after 2x space action = %v, want Backup", s.action[key])
 	}
-	// Third Enter (from last tab): stays at 2, flips Done.
+	conflictsPressRune(s, ' ')
+	if s.action[key] != config.ConflictActionKeep {
+		t.Fatalf("after 3x space action = %v, want Keep (wrap)", s.action[key])
+	}
+}
+
+// TestConflicts_BatchKeyAppliesToAll verifies uppercase K / O / B apply the
+// action to every row.
+func TestConflicts_BatchKeyAppliesToAll(t *testing.T) {
+	s := newTestConflicts()
+
+	// Seed row 1 with a different action so we can prove K overwrites it.
+	conflictsPressKey(s, tea.KeyDown)
+	conflictsPressRune(s, '2') // row 1 → Overwrite
+	conflictsPressKey(s, tea.KeyUp)
+
+	// Batch overwrite — every row becomes Overwrite.
+	conflictsPressRune(s, 'O')
+	for _, f := range s.files {
+		if s.action[f.RelPath] != config.ConflictActionOverwrite {
+			t.Fatalf("after 'O' action[%q] = %v, want Overwrite", f.RelPath, s.action[f.RelPath])
+		}
+	}
+
+	// Batch backup.
+	conflictsPressRune(s, 'B')
+	for _, f := range s.files {
+		if s.action[f.RelPath] != config.ConflictActionBackup {
+			t.Fatalf("after 'B' action[%q] = %v, want Backup", f.RelPath, s.action[f.RelPath])
+		}
+	}
+
+	// Batch keep.
+	conflictsPressRune(s, 'K')
+	for _, f := range s.files {
+		if s.action[f.RelPath] != config.ConflictActionKeep {
+			t.Fatalf("after 'K' action[%q] = %v, want Keep", f.RelPath, s.action[f.RelPath])
+		}
+	}
+}
+
+// TestConflicts_LowercaseBatchKeysNoOp verifies lowercase k/o/b do not
+// trigger batch-resolve (k maps to focus-up, o/b are unassigned no-ops).
+// The Plan 27 §C4 contract: uppercase keys only trigger batch.
+func TestConflicts_LowercaseBatchKeysNoOp(t *testing.T) {
+	s := newTestConflicts()
+
+	// Seed row 0 with Backup so we can prove lowercase 'o' doesn't
+	// overwrite it.
+	conflictsPressRune(s, '3')
+	key0 := s.files[0].RelPath
+	if s.action[key0] != config.ConflictActionBackup {
+		t.Fatalf("setup action = %v, want Backup", s.action[key0])
+	}
+
+	// Lowercase 'o' — no batch, row 0's action must stay at Backup.
+	conflictsPressRune(s, 'o')
+	if s.action[key0] != config.ConflictActionBackup {
+		t.Fatalf("after lowercase 'o' action[0] = %v, want Backup (unchanged)", s.action[key0])
+	}
+	// Row 1 should still be Keep (default).
+	key1 := s.files[1].RelPath
+	if s.action[key1] != config.ConflictActionKeep {
+		t.Fatalf("after lowercase 'o' action[1] = %v, want Keep (unchanged)", s.action[key1])
+	}
+
+	// Lowercase 'b' — same expectation.
+	conflictsPressRune(s, 'b')
+	if s.action[key1] != config.ConflictActionKeep {
+		t.Fatalf("after lowercase 'b' action[1] = %v, want Keep", s.action[key1])
+	}
+}
+
+// TestConflicts_EnterCompletes verifies Enter flips Done on the single-screen
+// vertical list (no per-tab cycling).
+func TestConflicts_EnterCompletes(t *testing.T) {
+	s := newTestConflicts()
 	conflictsPressKey(s, tea.KeyEnter)
 	if !s.Done() {
-		t.Fatal("3rd Enter on last tab should flip Done")
+		t.Fatal("Enter should flip Done")
 	}
 }
 
@@ -133,11 +218,10 @@ func TestConflicts_EnterAdvancesTabsThenCompletes(t *testing.T) {
 // entry per conflict file carrying the user's current pick.
 func TestConflicts_ResultMapPopulated(t *testing.T) {
 	s := newTestConflicts()
-	// Pick Overwrite on tab 0 + Backup on tab 1.
-	conflictsPressKey(s, tea.KeyDown) // tab 0 → Overwrite
-	conflictsPressKey(s, tea.KeyRight)
-	conflictsPressKey(s, tea.KeyDown) // tab 1 → Overwrite
-	conflictsPressKey(s, tea.KeyDown) // tab 1 → Backup
+	// Pick Overwrite on row 0, Backup on row 1, leave row 2 as Keep.
+	conflictsPressRune(s, '2') // row 0 → Overwrite
+	conflictsPressKey(s, tea.KeyDown)
+	conflictsPressRune(s, '3') // row 1 → Backup
 
 	res, ok := s.Result().(map[string]config.ConflictAction)
 	if !ok {
@@ -147,13 +231,13 @@ func TestConflicts_ResultMapPopulated(t *testing.T) {
 		t.Fatalf("result size = %d, want 3", len(res))
 	}
 	if res[s.files[0].RelPath] != config.ConflictActionOverwrite {
-		t.Fatalf("tab 0 action = %v, want Overwrite", res[s.files[0].RelPath])
+		t.Fatalf("row 0 action = %v, want Overwrite", res[s.files[0].RelPath])
 	}
 	if res[s.files[1].RelPath] != config.ConflictActionBackup {
-		t.Fatalf("tab 1 action = %v, want Backup", res[s.files[1].RelPath])
+		t.Fatalf("row 1 action = %v, want Backup", res[s.files[1].RelPath])
 	}
 	if res[s.files[2].RelPath] != config.ConflictActionKeep {
-		t.Fatalf("tab 2 action = %v, want Keep (untouched)", res[s.files[2].RelPath])
+		t.Fatalf("row 2 action = %v, want Keep (untouched)", res[s.files[2].RelPath])
 	}
 }
 
@@ -164,9 +248,9 @@ func TestConflicts_EmptyWriteResultRendersGracefully(t *testing.T) {
 	wr := &generate.WriteResult{}
 	s := NewConflictsStage(initflow.StageContext{StartedAt: time.Now()}, wr)
 	if len(s.files) != 0 {
-		t.Fatalf("empty wr should produce 0 tabs; got %d", len(s.files))
+		t.Fatalf("empty wr should produce 0 rows; got %d", len(s.files))
 	}
-	// Render should not panic even with no tabs. View depends on SetSize.
+	// Render should not panic even with no rows. View depends on SetSize.
 	s.SetSize(100, 30)
 	_ = s.View()
 	// Enter completes.
@@ -184,25 +268,33 @@ func TestConflicts_EmptyWriteResultRendersGracefully(t *testing.T) {
 	}
 }
 
-// TestConflicts_ResetPreservesPicks verifies Reset clears done but keeps tab
-// focus, radio focus, and per-file action picks.
+// TestConflicts_ResetPreservesPicks verifies Reset clears done but keeps
+// focus and per-file action picks.
 func TestConflicts_ResetPreservesPicks(t *testing.T) {
 	s := newTestConflicts()
-	// Pick Backup on tab 0, advance to tab 1.
-	conflictsPressKey(s, tea.KeyDown) // Overwrite
-	conflictsPressKey(s, tea.KeyDown) // Backup
-	conflictsPressKey(s, tea.KeyRight)
+	// Pick Backup on row 0, advance focus to row 1.
+	conflictsPressRune(s, '3')
+	conflictsPressKey(s, tea.KeyDown)
 	// Complete + reset.
 	s.MarkDone()
 	s.Reset()
 	if s.Done() {
 		t.Fatal("Reset should clear Done")
 	}
-	if s.catIdx != 1 {
-		t.Fatalf("Reset changed catIdx = %d, want 1", s.catIdx)
+	if s.focus != 1 {
+		t.Fatalf("Reset changed focus = %d, want 1", s.focus)
 	}
 	if s.action[s.files[0].RelPath] != config.ConflictActionBackup {
 		t.Fatalf("Reset changed action = %v, want Backup", s.action[s.files[0].RelPath])
+	}
+}
+
+// TestConflicts_Chromeless verifies the stage reports Chromeless=true so the
+// harness yields its View() verbatim (Plan 27 PR2 §C1).
+func TestConflicts_Chromeless(t *testing.T) {
+	s := newTestConflicts()
+	if !s.Chromeless() {
+		t.Fatal("ConflictsStage should be chromeless")
 	}
 }
 
@@ -218,5 +310,27 @@ func TestConflicts_RenderDoesNotPanic(t *testing.T) {
 	} {
 		s.SetSize(dim.w, dim.h)
 		_ = s.View()
+	}
+}
+
+// TestConflicts_ColorFollowsAction smokes renderRow at each action pick to
+// prove the row composition doesn't panic when colors flip per action.
+// Verifies the per-file color (Plan 27 PR2 §C3) is keyed off the current
+// action for that row.
+func TestConflicts_ColorFollowsAction(t *testing.T) {
+	s := newTestConflicts()
+	s.SetSize(100, 30)
+
+	// Cycle through every action on row 0 and verify render produces output.
+	for _, a := range []config.ConflictAction{
+		config.ConflictActionKeep,
+		config.ConflictActionOverwrite,
+		config.ConflictActionBackup,
+	} {
+		s.action[s.files[0].RelPath] = a
+		out := s.renderRow(0)
+		if out == "" {
+			t.Fatalf("renderRow returned empty for action %v", a)
+		}
 	}
 }

--- a/internal/tui/addflow/ground.go
+++ b/internal/tui/addflow/ground.go
@@ -143,17 +143,48 @@ func (s *GroundStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return s, cmd
 }
 
-// View composes the body inside the shared frame.
+// Chromeless reports true so the harness yields View() verbatim without its
+// default header/footer wrap. Plan 27 PR2 §C6 — GroundStage renders a
+// centred off-rail form panel without the enso rail / header / footer
+// chrome used by the four on-rail stages. The rail visible to the user
+// stays anchored on SELECT while Ground collects the workspace.
+func (s *GroundStage) Chromeless() bool { return true }
+
+// View returns the full AltScreen frame for the Ground stage. Chromeless —
+// body centred vertically, inline key-hint row below the form. Mirrors the
+// layout rhythm of initflow.PlantedStage (centre body + inline hint) so the
+// off-rail Ground reads as part of the same cinematic.
 func (s *GroundStage) View() string {
-	return s.RenderFrame(s.renderBody(), s.keyHints())
+	w := s.Width()
+	h := s.Height()
+	if w <= 0 {
+		w = 80
+	}
+	if h <= 0 {
+		h = 24
+	}
+	if initflow.TerminalTooSmall(s.Width(), s.Height()) {
+		return initflow.RenderMinSizeFloor(s.Width(), s.Height())
+	}
+
+	body := s.renderBody() + "\n\n" + initflow.CenterBlock(s.renderInlineHints(), w)
+
+	rows := strings.Count(body, "\n") + 1
+	topPad := (h - rows) / 2
+	if topPad < 1 {
+		topPad = 1
+	}
+	bottomPad := h - rows - topPad
+	if bottomPad < 0 {
+		bottomPad = 0
+	}
+	return strings.Repeat("\n", topPad) + body + strings.Repeat("\n", bottomPad)
 }
 
-func (s *GroundStage) keyHints() []initflow.KeyHint {
-	return []initflow.KeyHint{
-		{Key: "↵", Desc: "next"},
-		{Key: "esc", Desc: "back"},
-		{Key: "ctrl-c", Desc: "quit"},
-	}
+// renderInlineHints renders the key-hint row inline (replaces RenderFooter).
+func (s *GroundStage) renderInlineHints() string {
+	dim := initflow.DimStyle()
+	return dim.Render("↵  next  ·  esc  back  ·  ctrl-c  quit")
 }
 
 func (s *GroundStage) renderBody() string {

--- a/internal/tui/addflow/grow.go
+++ b/internal/tui/addflow/grow.go
@@ -30,5 +30,9 @@ func NewGrowStage(ctx initflow.StageContext, action initflow.GenerateAction) *in
 	g.SetLabel(growLabel)
 	g.SetBodyTitle(growLabel.Kanji, "GROWING")
 	g.SetRailHidden(true)
+	// Plan 27 PR2 §C7 — Grow renders chromeless. No header, no enso rail, no
+	// footer. The bonsai spinner sits centred in the AltScreen with an
+	// inline key-hint row beneath it.
+	g.SetBodyOnly(true)
 	return g
 }

--- a/internal/tui/addflow/select.go
+++ b/internal/tui/addflow/select.go
@@ -196,14 +196,17 @@ func (s *SelectStage) listHeight() int {
 	return v
 }
 
-// renderRow renders a single agent entry. Matches BranchesStage row layout
-// for cross-flow consistency:
+// renderRow renders a single agent entry (Plan 27 PR2 §C8 layout). Row:
 //
-//	[border 2] [glyph 1] [sp 1] [name + tag] [sp 1] [desc]
+//		[border 2] [glyph 1] [sp 1] [name] [sp 2] [description fill...] [sp 2] [installed-badge right-aligned]
 //
-// Focused rows use FocusBorder + FocusedNameStyle + FocusedDescStyle; the
-// "(installed)" suffix renders in bark gold after the name so the badge sits
-// inside the name column.
+//	  - The word "Agent" (case-insensitive) is stripped from DisplayName at
+//	    render time so "Tech Lead Agent" → "Tech Lead". opt.DisplayName is not
+//	    mutated; machine-name opt.Name is untouched.
+//	  - The full description is rendered; truncation only fires if it would
+//	    overflow the row's visible width.
+//	  - The "(installed)" badge is pad-right aligned at the trailing edge of
+//	    the row — outside the name column, outside the description column.
 func (s *SelectStage) renderRow(idx int) string {
 	opt := s.options[idx]
 	focused := idx == s.focus
@@ -226,12 +229,10 @@ func (s *SelectStage) renderRow(idx int) string {
 		border = initflow.FocusBorder()
 	}
 
-	nameColW, descColW, tagColW := initflow.ClampColumns(s.Width() - 4)
-	// Recover the tag column for desc (no trailing badge) — same move as
-	// Branches post-2026-04-22 polish.
-	descColW += tagColW - 2
-
-	name := opt.DisplayName
+	// Display name — strip trailing " Agent" / "Agent" (case-insensitive)
+	// so "Tech Lead Agent" → "Tech Lead". Fall back to machine name when
+	// the stripped display name is empty.
+	name := stripAgentSuffix(opt.DisplayName)
 	if name == "" {
 		name = opt.Name
 	}
@@ -244,45 +245,78 @@ func (s *SelectStage) renderRow(idx int) string {
 		nameStyle = initflow.UnfocusedNameStyle()
 	}
 
-	// Reserve space for the "(installed)" suffix when present so the name is
-	// truncated before the badge rather than after.
-	suffix := ""
+	// Trailing badge — right-aligned at the row's visible edge.
+	badgeText := ""
 	if opt.Installed {
-		suffix = " " + bark.Render("(installed)")
+		badgeText = bark.Render("(installed)")
 	}
-	suffixW := lipgloss.Width(suffix)
+	badgeW := lipgloss.Width(badgeText)
 
-	nameBudget := nameColW - suffixW
-	if nameBudget < 6 {
-		nameBudget = 6
+	// Row budget — everything between the left border and the right edge.
+	rowTotal := s.Width() - 4
+	if rowTotal < 40 {
+		rowTotal = 40
 	}
-	if lipgloss.Width(name) > nameBudget {
+
+	// Name column — fixed budget so rows align vertically.
+	const nameColW = 22
+	if lipgloss.Width(name) > nameColW {
 		rr := []rune(name)
-		if len(rr) > nameBudget-1 && nameBudget > 1 {
-			name = string(rr[:nameBudget-1]) + "…"
+		if len(rr) > nameColW-1 && nameColW > 1 {
+			name = string(rr[:nameColW-1]) + "…"
 		}
 	}
-	nameText := nameStyle.Render(name) + suffix
-	nameCol := initflow.PadRight(nameText, nameColW)
+	namePadded := initflow.PadRight(nameStyle.Render(name), nameColW)
 
-	// Description column.
-	var descCol string
-	if descColW > 0 {
-		desc := opt.Description
-		if lipgloss.Width(desc) > descColW {
-			rr := []rune(desc)
-			if len(rr) > descColW-1 {
-				desc = string(rr[:descColW-1]) + "…"
-			}
-		}
-		descStyle := initflow.UnfocusedDescStyle()
-		if focused {
-			descStyle = initflow.FocusedDescStyle()
-		}
-		descCol = " " + descStyle.Render(initflow.PadRight(desc, descColW))
+	// Description budget = row total - border(2) - glyph(1) - sp(1) -
+	// name(nameColW) - sp(2) - badge(badgeW) - sp-before-badge(2 iff badge).
+	badgeGap := 0
+	if badgeW > 0 {
+		badgeGap = 2
+	}
+	descBudget := rowTotal - 2 - 1 - 1 - nameColW - 2 - badgeW - badgeGap
+	if descBudget < 10 {
+		descBudget = 10
 	}
 
-	return border + glyphStyle.Render(glyph) + " " + nameCol + descCol
+	desc := opt.Description
+	if lipgloss.Width(desc) > descBudget {
+		rr := []rune(desc)
+		if len(rr) > descBudget-1 {
+			desc = string(rr[:descBudget-1]) + "…"
+		}
+	}
+	descStyle := initflow.UnfocusedDescStyle()
+	if focused {
+		descStyle = initflow.FocusedDescStyle()
+	}
+	descPadded := initflow.PadRight(descStyle.Render(desc), descBudget)
+
+	row := border + glyphStyle.Render(glyph) + " " + namePadded + "  " + descPadded
+	if badgeW > 0 {
+		row += "  " + badgeText
+	}
+	return row
+}
+
+// stripAgentSuffix drops a trailing " Agent" / "Agent" token (case-
+// insensitive) from s. The replacement is display-only; the caller stores
+// the original DisplayName unchanged. Used by SelectStage.renderRow per
+// Plan 27 PR2 §C8.
+func stripAgentSuffix(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return trimmed
+	}
+	lower := strings.ToLower(trimmed)
+	const suffix = "agent"
+	if strings.HasSuffix(lower, " "+suffix) {
+		return strings.TrimSpace(trimmed[:len(trimmed)-len(suffix)-1])
+	}
+	if lower == suffix {
+		return ""
+	}
+	return trimmed
 }
 
 // Result returns the selected agent machine name. Zero value ("") on empty

--- a/internal/tui/addflow/select_test.go
+++ b/internal/tui/addflow/select_test.go
@@ -119,6 +119,51 @@ func TestSelect_ViewRendersInstalledBadge(t *testing.T) {
 	}
 }
 
+// TestSelect_StripsAgentSuffix verifies the display-only "Agent" suffix
+// strip (Plan 27 PR2 §C8). "Tech Lead Agent" should render as "Tech Lead";
+// the stored DisplayName is not mutated.
+func TestSelect_StripsAgentSuffix(t *testing.T) {
+	opts := []AgentOption{
+		{Name: "tech-lead", DisplayName: "Tech Lead Agent", Description: "orchestrator", Installed: false},
+	}
+	s := NewSelectStage(initflow.StageContext{StartedAt: time.Now()}, opts)
+	s.SetSize(120, 40)
+	out := s.View()
+	if !strings.Contains(out, "Tech Lead") {
+		t.Fatal("expected 'Tech Lead' in rendered view")
+	}
+	// The word "Agent" should NOT appear for the stripped display name.
+	// Allow for case-sensitive match on " Agent" with surrounding context
+	// — the description text doesn't contain "Agent".
+	if strings.Contains(out, "Tech Lead Agent") {
+		t.Fatal("expected 'Agent' suffix to be stripped, but full name found")
+	}
+	// Underlying DisplayName must not be mutated.
+	if opts[0].DisplayName != "Tech Lead Agent" {
+		t.Fatalf("opt.DisplayName mutated — got %q, want %q", opts[0].DisplayName, "Tech Lead Agent")
+	}
+}
+
+// TestStripAgentSuffix_Cases table-tests the display-only suffix strip.
+func TestStripAgentSuffix_Cases(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Tech Lead Agent", "Tech Lead"},
+		{"Backend Agent", "Backend"},
+		{"tech lead agent", "tech lead"},
+		{"Designer", "Designer"}, // no suffix — unchanged
+		{"", ""},
+		{"agent", ""}, // standalone
+		{"  Tech Lead Agent  ", "Tech Lead"},
+		{"DevOps AGENT", "DevOps"},
+	}
+	for _, c := range cases {
+		got := stripAgentSuffix(c.in)
+		if got != c.want {
+			t.Errorf("stripAgentSuffix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 // TestSelect_JKBindings verifies j/k map to down/up.
 func TestSelect_JKBindings(t *testing.T) {
 	s := newTestSelect()

--- a/internal/tui/addflow/yield.go
+++ b/internal/tui/addflow/yield.go
@@ -110,6 +110,13 @@ func newYield(ctx initflow.StageContext, mode yieldMode, tail func(*YieldStage))
 	return y
 }
 
+// Chromeless reports true so the harness yields View() verbatim. Plan 27 PR2
+// §C9 — YieldStage renders its own chromeless full-screen frame (no enso
+// rail, no header, no footer), matching initflow.PlantedStage's exit-card
+// treatment. Embedded initflow.Stage.Chromeless() already reports true, but
+// the explicit method here keeps the contract obvious at the call-site.
+func (s *YieldStage) Chromeless() bool { return true }
+
 // Init implements tea.Model — no cmd on entry.
 func (s *YieldStage) Init() tea.Cmd { return nil }
 
@@ -212,6 +219,19 @@ func (s *YieldStage) renderSuccess() string {
 		heroSub = white.Render(fmt.Sprintf("Grafted %d new abilities onto %s.", s.totalSelected, agentDisplay))
 	}
 
+	// Hero stats line — mirrors initflow.PlantedStage's
+	// "N files written · N conflicts · lock synced" rhythm so the two flows
+	// land their success card with the same typographic beat.
+	totalAbilitiesStat := 0
+	if s.installed != nil {
+		totalAbilitiesStat = len(s.installed.Skills) + len(s.installed.Workflows) +
+			len(s.installed.Protocols) + len(s.installed.Sensors) + len(s.installed.Routines)
+	}
+	heroStats := dim.Render(fmt.Sprintf(
+		"%d abilities wired · %s · lock synced",
+		totalAbilitiesStat, agentDisplay,
+	))
+
 	summaryHeader := initflow.RenderSectionHeader("SUMMARY", initflow.PanelWidth(s.Width()))
 	const labelW = 14
 	const indent = "  "
@@ -258,6 +278,7 @@ func (s *YieldStage) renderSuccess() string {
 	body := []string{
 		heroTitle,
 		heroSub,
+		heroStats,
 		"",
 		"",
 		strings.Join(summaryRows, "\n"),

--- a/internal/tui/initflow/generate.go
+++ b/internal/tui/initflow/generate.go
@@ -79,6 +79,14 @@ type GenerateStage struct {
 	// the init-flow default.
 	bodyKanji   string
 	bodyEnglish string
+
+	// bodyOnly (Plan 27 PR2 §C7) disables the stage's header/footer chrome
+	// entirely. When true, View() composes a centred-in-AltScreen body with
+	// an inline key-hint row instead of invoking renderFrame. Used by
+	// addflow's GrowStage so the spinner renders without rail, header, or
+	// footer — matching the chromeless off-rail treatment of Ground and
+	// Conflicts.
+	bodyOnly bool
 }
 
 // SetBodyTitle overrides the "生 · PLANTING" body header. Used by addflow's
@@ -88,6 +96,12 @@ func (s *GenerateStage) SetBodyTitle(kanji, english string) {
 	s.bodyKanji = kanji
 	s.bodyEnglish = english
 }
+
+// SetBodyOnly toggles Plan 27 PR2 §C7 chromeless mode. When true, View()
+// returns a centred-in-AltScreen body with inline key hints, skipping the
+// enso rail / header / footer chrome entirely. Used by addflow's GrowStage
+// so the spinner renders off-rail with no chrome at all.
+func (s *GenerateStage) SetBodyOnly(v bool) { s.bodyOnly = v }
 
 // NewGenerateStage constructs the Generate stage. The action closure wraps
 // the caller's generate pipeline and is invoked once on Init. Remaining
@@ -203,9 +217,56 @@ func (s *GenerateStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return s, nil
 }
 
-// View composes the Generate stage body inside the shared frame.
+// View composes the Generate stage body inside the shared frame. When the
+// stage has been flipped into body-only mode (Plan 27 PR2 §C7) the chrome
+// is dropped entirely — the body is vertically centred in the AltScreen and
+// the key-hint row renders inline below it. Otherwise the standard
+// header+rail+footer frame wraps the body as for init's Planting stage.
 func (s *GenerateStage) View() string {
+	if s.bodyOnly {
+		width := s.width
+		if width <= 0 {
+			width = 80
+		}
+		height := s.height
+		if height <= 0 {
+			height = 24
+		}
+		if TerminalTooSmall(s.width, s.height) {
+			return RenderMinSizeFloor(s.width, s.height)
+		}
+
+		dim := lipgloss.NewStyle().Foreground(tui.ColorRule2)
+		hints := dim.Render(renderKeyHintsInline(s.keyHints()))
+		body := s.renderBody() + "\n\n" + CenterBlock(hints, width)
+
+		rows := strings.Count(body, "\n") + 1
+		topPad := (height - rows) / 2
+		if topPad < 1 {
+			topPad = 1
+		}
+		bottomPad := height - rows - topPad
+		if bottomPad < 0 {
+			bottomPad = 0
+		}
+		return strings.Repeat("\n", topPad) + body + strings.Repeat("\n", bottomPad)
+	}
 	return s.renderFrame(s.renderBody(), s.keyHints())
+}
+
+// renderKeyHintsInline returns a one-line "↵  label  ·  ctrl-c  quit"
+// formatted string from a KeyHint slice. Used by body-only GenerateStage and
+// any sibling flow package that needs the key-row format without the full
+// footer chrome. Mirrors the separator style in RenderFooter.
+func renderKeyHintsInline(keys []KeyHint) string {
+	if len(keys) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k.Key+"  "+k.Desc)
+	}
+	return strings.Join(parts, "  ·  ")
 }
 
 // keyHints builds the footer key row. The key set is minimal while


### PR DESCRIPTION
## Summary
Plan 27 PR2 — Phase C (polish) + Phase D (verification) for `bonsai add` cinematic.
Conflict surface redesigned as chromeless full-screen vertical picker with per-file
color-by-action + batch-resolve row. Ground/Grow go chromeless (off-rail body polish).
Agent rows cleaned (strip "Agent" suffix, full desc, right-align installed badge).
Yield success aligned with init's Planted rhythm.

## Changes
- `internal/tui/addflow/conflicts.go` — chromeless + vertical list + per-file color
  + batch-resolve row (§C1-C5)
- `internal/tui/addflow/ground.go` — chromeless body with inline key hints (§C6)
- `internal/tui/addflow/grow.go` — chromeless spinner via `SetBodyOnly(true)` (§C7)
- `internal/tui/addflow/select.go` — strip "Agent" suffix, full desc, right-align
  installed badge (§C8)
- `internal/tui/addflow/yield.go` — hero-stats line + explicit `Chromeless()` for
  Planted parity (§C9)
- `internal/tui/initflow/generate.go` — additive `SetBodyOnly` export so addflow's
  GrowStage can opt into chromeless rendering without duplicating the spinner body
- `internal/tui/addflow/conflicts_test.go` — rewritten for vertical-list keybindings,
  batch-resolve K/O/B, lowercase k/o/b no-op, per-file color
- `internal/tui/addflow/select_test.go` — adds `stripAgentSuffix` table test + a
  view-level check that the Agent suffix is dropped at render time

## Plan
`station/Playbook/Plans/Active/27-add-flow-polish.md` (Phase C + D)

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes (6/6 packages)
- [x] `gofmt -s -l internal/tui/ cmd/` — clean
- [ ] Manual dogfood — 5-step script in plan §D: NOT runnable in the sandbox used
  here (no PTY → `bonsai init` / `add` error out with "could not open a new TTY").
  The stage renders were exercised via targeted test dumps; one sample ConflictsStage
  render is below.

### ConflictsStage render sample (100×30, 3 synthetic conflicts)

```
      衝 · CONFLICT
      Reconcile edited files.
      Pick an action per file — nothing overwritten silently.


      ─── RECONCILE ──────────────────────────────────────────────────────────────────────

      │ ▸ station/agent/Skills/foo.md                                 ◆ keep local
          station/agent/Protocols/bar.md                              ◆ keep local
          station/agent/Core/identity.md                              ◆ keep local

        batch resolve:
        [ K Keep all ]  [ O Overwrite all ]  [ B Backup all ]

        file 1 of 3 · focus: keep local

      ↑↓ focus  ·  1/2/3 action  ·  ␣ cycle  ·  K/O/B batch  ·  ↵ next  ·  esc back
```

Action cycling (§C3), digit keys (§C2), batch resolve uppercase-only (§C4),
chromeless frame (§C1), and empty-conflicts graceful render are all covered by
unit tests in `conflicts_test.go`.

## Notes for reviewer
- Touched `internal/tui/initflow/generate.go` only additively: new `bodyOnly bool`
  field + `SetBodyOnly(v bool)` setter + bodyOnly branch in `View()`. Init flow's
  Planting stage is unaffected (bodyOnly stays false).
- Harness + generator are untouched (PR1 handled those).
- `bonsai init` / `bonsai update` surfaces are not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)