### PR TITLE
feat(plan-28): Phase 3 — bonsai guide cinematic

### DIFF
--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -2,30 +2,41 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
-	"github.com/charmbracelet/huh"
+	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 
-	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/guideflow"
 )
 
 // guideTopic pairs a machine key (looked up in guideContents) with a
-// human-readable label shown in the interactive picker.
+// human-readable label. The label is informational only — the cinematic
+// viewer renders its own tab strip via guideflow.NewTopics.
 type guideTopic struct {
 	Key   string
 	Label string
 }
 
-// guideTopics is the ordered list of topics shown in the picker. Order here
-// drives picker order — keep it deterministic.
+// guideTopics is the canonical topic order used for validation error
+// messages and the fallback topic list. The cinematic viewer uses
+// guideflow.NewTopics' own canonicalOrder constant which mirrors
+// this slice; keep the two in sync when adding a topic.
 var guideTopics = []guideTopic{
 	{"quickstart", "Quickstart — 5-step post-install walkthrough"},
 	{"concepts", "Concepts — the mental model"},
 	{"cli", "CLI — command-by-command reference"},
 	{"custom-files", "Custom Files — add your own abilities"},
 }
+
+// noTTYNoArgErr is the exact error message surfaced when guide is
+// invoked with neither an arg nor a TTY (e.g. piped through less
+// without specifying a topic). Decision D4 in Plan 28's 2026-04-23
+// deltas locks the wording; test asserts verbatim.
+const noTTYNoArgErr = "bonsai guide: specify a topic when piping output (quickstart, concepts, cli, custom-files)"
 
 func init() {
 	rootCmd.AddCommand(guideCmd)
@@ -34,11 +45,20 @@ func init() {
 var guideCmd = &cobra.Command{
 	Use:   "guide [topic]",
 	Short: "View bundled guides in the terminal.",
-	Long:  "Render one of the bundled guides as styled terminal output. Run without a topic to pick interactively, or pass one of: quickstart, concepts, cli, custom-files.",
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  runGuide,
+	Long: "Render one of the bundled guides as styled terminal output. Run without a " +
+		"topic to open the cinematic viewer on the first topic; pass one of: " +
+		"quickstart, concepts, cli, custom-files.",
+	Args: cobra.MaximumNArgs(1),
+	RunE: runGuide,
 }
 
+// runGuide is the guide command entry point. On a TTY it launches
+// the cinematic guideflow viewer (tabbed scroll viewport over the
+// four bundled docs). Off a TTY it either renders the specified
+// topic as static glamour output (preserves the pre-Plan-28
+// behavior for piped consumption) or errors out when no topic was
+// passed (decision D4 — piping needs an explicit pick so the
+// downstream tool sees a stable single doc).
 func runGuide(cmd *cobra.Command, args []string) error {
 	var key string
 	if len(args) == 1 {
@@ -46,35 +66,34 @@ func runGuide(cmd *cobra.Command, args []string) error {
 		if _, ok := guideContents[key]; !ok {
 			return fmt.Errorf("unknown topic %q. Available: quickstart, concepts, cli, custom-files", key)
 		}
-	} else {
-		options := make([]huh.Option[string], 0, len(guideTopics))
-		for _, t := range guideTopics {
-			options = append(options, huh.NewOption(t.Label, t.Key))
+	}
+
+	if !isatty.IsTerminal(os.Stdout.Fd()) {
+		if key == "" {
+			return fmt.Errorf("%s", noTTYNoArgErr)
 		}
-		selected, err := tui.AskSelect("Pick a guide", options)
-		if err != nil {
-			return err
-		}
-		key = selected
+		return renderStatic(guideContents[key])
 	}
 
-	content, ok := guideContents[key]
-	if !ok {
-		return fmt.Errorf("unknown topic %q. Available: quickstart, concepts, cli, custom-files", key)
+	topics := guideflow.NewTopics(guideContents)
+	if len(topics) == 0 {
+		return fmt.Errorf("no guide topics available")
 	}
 
-	out, err := renderMarkdown(content)
-	if err != nil {
-		return err
+	cwd, _ := os.Getwd()
+	stage := guideflow.NewViewer(topics, key, Version, cwd)
+	if _, err := tea.NewProgram(stage, tea.WithAltScreen()).Run(); err != nil {
+		return fmt.Errorf("guide viewer: %w", err)
 	}
-
-	fmt.Print(out)
 	return nil
 }
 
-// renderMarkdown strips YAML frontmatter (if present) and renders the remaining
-// markdown via glamour with the auto-selected terminal style.
-func renderMarkdown(content string) (string, error) {
+// renderStatic renders the given markdown content through glamour
+// with auto-style and a fixed word-wrap of 100 columns — the
+// pre-Plan-28 behavior preserved verbatim for piped invocations.
+// The cinematic TTY path binds glamour's width to the live
+// terminal instead (see guideflow/render.go).
+func renderStatic(content string) error {
 	if strings.HasPrefix(content, "---") {
 		if idx := strings.Index(content[3:], "---"); idx >= 0 {
 			content = strings.TrimSpace(content[idx+6:])
@@ -86,13 +105,14 @@ func renderMarkdown(content string) (string, error) {
 		glamour.WithWordWrap(100),
 	)
 	if err != nil {
-		return "", fmt.Errorf("failed to create renderer: %w", err)
+		return fmt.Errorf("failed to create renderer: %w", err)
 	}
 
 	out, err := renderer.Render(content)
 	if err != nil {
-		return "", fmt.Errorf("failed to render guide: %w", err)
+		return fmt.Errorf("failed to render guide: %w", err)
 	}
 
-	return out, nil
+	fmt.Print(out)
+	return nil
 }

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -13,25 +13,6 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/guideflow"
 )
 
-// guideTopic pairs a machine key (looked up in guideContents) with a
-// human-readable label. The label is informational only — the cinematic
-// viewer renders its own tab strip via guideflow.NewTopics.
-type guideTopic struct {
-	Key   string
-	Label string
-}
-
-// guideTopics is the canonical topic order used for validation error
-// messages and the fallback topic list. The cinematic viewer uses
-// guideflow.NewTopics' own canonicalOrder constant which mirrors
-// this slice; keep the two in sync when adding a topic.
-var guideTopics = []guideTopic{
-	{"quickstart", "Quickstart — 5-step post-install walkthrough"},
-	{"concepts", "Concepts — the mental model"},
-	{"cli", "CLI — command-by-command reference"},
-	{"custom-files", "Custom Files — add your own abilities"},
-}
-
 // noTTYNoArgErr is the exact error message surfaced when guide is
 // invoked with neither an arg nor a TTY (e.g. piped through less
 // without specifying a topic). Decision D4 in Plan 28's 2026-04-23

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -51,7 +52,7 @@ func runGuide(cmd *cobra.Command, args []string) error {
 
 	if !isatty.IsTerminal(os.Stdout.Fd()) {
 		if key == "" {
-			return fmt.Errorf("%s", noTTYNoArgErr)
+			return errors.New(noTTYNoArgErr)
 		}
 		return renderStatic(guideContents[key])
 	}

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeGuides populates the package-level guideContents map with
+// minimal markdown for each canonical topic so runGuide-adjacent
+// tests can validate lookups and the static-render path.
+func fakeGuides() map[string]string {
+	return map[string]string{
+		"quickstart":   "# Quickstart\n\nstart here.\n",
+		"concepts":     "# Concepts\n\nthe mental model.\n",
+		"cli":          "# CLI\n\ncommand reference.\n",
+		"custom-files": "# Custom Files\n\nadd your own.\n",
+	}
+}
+
+// withGuides swaps in the fake content map for the duration of fn
+// and restores the original on completion so tests don't leak
+// state between runs.
+func withGuides(t *testing.T, fn func()) {
+	t.Helper()
+	prev := guideContents
+	guideContents = fakeGuides()
+	defer func() { guideContents = prev }()
+	fn()
+}
+
+// TestRenderStatic_ProducesNonEmptyOutput verifies the non-TTY
+// static render path emits glamour output to stdout.
+func TestRenderStatic_ProducesNonEmptyOutput(t *testing.T) {
+	withGuides(t, func() {
+		out := captureStdout(t, func() {
+			if err := renderStatic(guideContents["quickstart"]); err != nil {
+				t.Fatalf("renderStatic: %v", err)
+			}
+		})
+		if strings.TrimSpace(out) == "" {
+			t.Fatalf("renderStatic produced empty output")
+		}
+		// The glamour-rendered output should contain some form of
+		// the "Quickstart" heading text (glamour may reformat it
+		// with styling glyphs, but the word survives).
+		if !strings.Contains(out, "Quickstart") {
+			t.Fatalf("renderStatic output missing 'Quickstart' heading:\n%s", out)
+		}
+	})
+}
+
+// TestRenderStatic_StripsFrontmatter verifies the static path
+// strips YAML frontmatter before handing to glamour, preserving
+// the pre-Plan-28 behavior.
+func TestRenderStatic_StripsFrontmatter(t *testing.T) {
+	withGuides(t, func() {
+		content := "---\ndescription: x\n---\n# Heading\n\nbody\n"
+		out := captureStdout(t, func() {
+			if err := renderStatic(content); err != nil {
+				t.Fatalf("renderStatic: %v", err)
+			}
+		})
+		if strings.Contains(out, "description:") {
+			t.Fatalf("renderStatic leaked frontmatter:\n%s", out)
+		}
+	})
+}
+
+// TestRunGuide_UnknownTopicErrors verifies passing an invalid topic
+// key produces the pre-existing error message (unchanged by the
+// Plan 28 Phase 3 rewire).
+func TestRunGuide_UnknownTopicErrors(t *testing.T) {
+	withGuides(t, func() {
+		err := runGuide(guideCmd, []string{"bogus-topic"})
+		if err == nil {
+			t.Fatalf("expected error for unknown topic; got nil")
+		}
+		if !strings.Contains(err.Error(), "unknown topic") {
+			t.Fatalf("expected 'unknown topic' in error; got: %v", err)
+		}
+	})
+}
+
+// TestRunGuide_NoArgNonTTYExactMessage verifies the decision-D4
+// error: running `bonsai guide` with no arg while stdout is not
+// a TTY must produce the exact canonical message.
+//
+// Relies on the fact that `go test` redirects stdout into the
+// test harness (not a TTY), so isatty.IsTerminal returns false
+// without any mocking required.
+func TestRunGuide_NoArgNonTTYExactMessage(t *testing.T) {
+	withGuides(t, func() {
+		err := runGuide(guideCmd, nil)
+		if err == nil {
+			t.Fatalf("expected error for no-arg non-TTY invocation; got nil")
+		}
+		want := "bonsai guide: specify a topic when piping output (quickstart, concepts, cli, custom-files)"
+		if err.Error() != want {
+			t.Fatalf("error mismatch:\n got=%q\nwant=%q", err.Error(), want)
+		}
+	})
+}
+
+// TestRunGuide_ArgNonTTYRendersStatic verifies passing a valid
+// topic with stdout-not-a-TTY (the `go test` default) falls
+// through to the static glamour render — no BubbleTea program
+// is started, so the test returns cleanly and stdout contains
+// the rendered markdown.
+func TestRunGuide_ArgNonTTYRendersStatic(t *testing.T) {
+	withGuides(t, func() {
+		var runErr error
+		out := captureStdout(t, func() {
+			runErr = runGuide(guideCmd, []string{"concepts"})
+		})
+		if runErr != nil {
+			t.Fatalf("runGuide with valid topic: %v", runErr)
+		}
+		if !strings.Contains(out, "Concepts") {
+			t.Fatalf("runGuide concepts output missing 'Concepts':\n%s", out)
+		}
+	})
+}

--- a/internal/tui/guideflow/guideflow.go
+++ b/internal/tui/guideflow/guideflow.go
@@ -1,0 +1,99 @@
+// Package guideflow implements the cinematic `bonsai guide` viewer —
+// a tabbed BubbleTea scroll viewport that renders bundled markdown
+// guides through glamour inside the shared initflow chrome (header
+// + footer + min-size floor). The package is consumed by
+// cmd/guide.go on TTY invocations; non-TTY (piped output) falls
+// back to a static one-shot glamour render in cmd/guide.go.
+//
+// Topics are supplied by the caller as a pre-ordered slice; the
+// viewer preserves that order on the tab strip. No kanji labels —
+// per Plan 28 Session 2026-04-23 decision D1 the guide surface is
+// English-only.
+package guideflow
+
+import "strings"
+
+// Topic is one guide entry shown on a tab. Label is the full-width
+// cell text; Short is the narrow-width fallback rendered when the
+// full strip would exceed the clamp budget. Markdown is the raw
+// embedded content (frontmatter retained — the renderer strips it
+// at render time so the cache key stays pure).
+type Topic struct {
+	Key      string // machine identifier, e.g. "quickstart"
+	Label    string // full label, e.g. "QUICKSTART"
+	Short    string // narrow-width fallback, e.g. "START"
+	Markdown string // raw embedded markdown body
+}
+
+// canonicalOrder is the required tab ordering across the guide
+// surface. Matches the pre-Plan-28 static picker order so users
+// encountering the viewer for the first time still see the same
+// "quickstart first" entry point.
+var canonicalOrder = []string{"quickstart", "concepts", "cli", "custom-files"}
+
+// labelFor returns the full-width label for a topic key. Unknown
+// keys fall through to an uppercased, hyphen-stripped form so
+// callers that extend the topic set don't need to edit this file
+// — only the canonicalOrder slice.
+func labelFor(key string) string {
+	switch key {
+	case "quickstart":
+		return "QUICKSTART"
+	case "concepts":
+		return "CONCEPTS"
+	case "cli":
+		return "CLI"
+	case "custom-files":
+		return "CUSTOM"
+	default:
+		return strings.ToUpper(strings.ReplaceAll(key, "-", " "))
+	}
+}
+
+// shortFor returns the narrow-width fallback label for a topic
+// key. Kept ≤5 chars so the 4-tab strip fits inside the 70-col
+// min-size floor with the default two-space separator.
+func shortFor(key string) string {
+	switch key {
+	case "quickstart":
+		return "START"
+	case "concepts":
+		return "CONCP"
+	case "cli":
+		return "CLI"
+	case "custom-files":
+		return "CUSTM"
+	default:
+		up := labelFor(key)
+		if len(up) > 5 {
+			return up[:5]
+		}
+		return up
+	}
+}
+
+// NewTopics builds the []Topic slice in canonical order from a
+// rawContents map keyed by machine identifier. Missing keys are
+// silently skipped — the caller (cmd/guide.go) owns the
+// "unknown topic" error path, so the viewer tolerates an
+// incomplete map without panicking.
+//
+// Order is locked to canonicalOrder regardless of the rawContents
+// iteration order — map iteration is non-deterministic and the
+// tab strip must render the same sequence every invocation.
+func NewTopics(rawContents map[string]string) []Topic {
+	out := make([]Topic, 0, len(canonicalOrder))
+	for _, key := range canonicalOrder {
+		md, ok := rawContents[key]
+		if !ok {
+			continue
+		}
+		out = append(out, Topic{
+			Key:      key,
+			Label:    labelFor(key),
+			Short:    shortFor(key),
+			Markdown: md,
+		})
+	}
+	return out
+}

--- a/internal/tui/guideflow/render.go
+++ b/internal/tui/guideflow/render.go
@@ -1,0 +1,93 @@
+package guideflow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/glamour"
+)
+
+// defaultRenderWidth is the clamp applied when the caller passes a
+// zero or negative width. Matches glamour's own default sensibility
+// so narrow-terminal callers still get readable output rather than
+// a single long line.
+const defaultRenderWidth = 80
+
+// renderMarkdown strips an optional YAML frontmatter block from
+// content (fenced by leading/trailing `---` lines) and renders the
+// remainder through glamour's auto-style terminal renderer.
+//
+// width drives glamour's word-wrap. Values ≤ 0 clamp to
+// defaultRenderWidth so the viewer can call this before the first
+// WindowSizeMsg lands without producing a broken render. Empty
+// content returns an empty string and no error — glamour handles
+// the empty case gracefully and callers (tab cache warmup) benefit
+// from not having to special-case it.
+func renderMarkdown(content string, width int) (string, error) {
+	if width <= 0 {
+		width = defaultRenderWidth
+	}
+	body := stripFrontmatter(content)
+
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(width),
+	)
+	if err != nil {
+		return "", fmt.Errorf("guideflow: create renderer: %w", err)
+	}
+	out, err := renderer.Render(body)
+	if err != nil {
+		return "", fmt.Errorf("guideflow: render markdown: %w", err)
+	}
+	return out, nil
+}
+
+// stripFrontmatter removes a leading YAML frontmatter block from
+// content, bounded by the first two `---` delimiter lines. Inputs
+// without a frontmatter block (no leading `---`) are returned
+// unchanged. Malformed blocks (leading `---` but no closing
+// delimiter) are also returned unchanged so the renderer has
+// something to work with instead of an empty string.
+//
+// The trim treats the delimiter strictly — it must appear on a
+// line of its own (leading `---` followed by a newline). A stray
+// `---` embedded in prose mid-file is not a frontmatter boundary
+// and will not trigger the strip.
+func stripFrontmatter(content string) string {
+	if !strings.HasPrefix(content, "---\n") && content != "---" && !strings.HasPrefix(content, "---\r\n") {
+		// Not a frontmatter block — return as-is. The `content == "---"`
+		// guard is pedantic but keeps the function symmetric for the
+		// degenerate single-line input.
+		return content
+	}
+	// Find the end of the first delimiter line so we know where to
+	// start searching for the closer.
+	firstNL := strings.Index(content, "\n")
+	if firstNL < 0 {
+		return content
+	}
+	rest := content[firstNL+1:]
+	// Closing `---` must start a line — search for "\n---" and
+	// handle the edge case where the closer is at offset 0 (empty
+	// frontmatter body).
+	var closeIdx int
+	if strings.HasPrefix(rest, "---\n") || strings.HasPrefix(rest, "---\r\n") || rest == "---" {
+		closeIdx = 0
+	} else {
+		nl := strings.Index(rest, "\n---")
+		if nl < 0 {
+			return content
+		}
+		closeIdx = nl + 1 // skip the preceding \n so closeIdx points at `---`
+	}
+	// Advance past the closer's own line.
+	tail := rest[closeIdx:]
+	tailNL := strings.Index(tail, "\n")
+	if tailNL < 0 {
+		// Frontmatter closer is the last line of the file with no
+		// trailing newline — return empty body.
+		return ""
+	}
+	return strings.TrimLeft(tail[tailNL+1:], "\n")
+}

--- a/internal/tui/guideflow/render_test.go
+++ b/internal/tui/guideflow/render_test.go
@@ -1,0 +1,127 @@
+package guideflow
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStripFrontmatter_NoBlock verifies content without leading
+// `---` delimiters is returned unchanged.
+func TestStripFrontmatter_NoBlock(t *testing.T) {
+	input := "# Heading\n\nbody text\n"
+	got := stripFrontmatter(input)
+	if got != input {
+		t.Fatalf("stripFrontmatter should be a no-op without a frontmatter block;\n got=%q\nwant=%q", got, input)
+	}
+}
+
+// TestStripFrontmatter_WithBlock verifies a well-formed frontmatter
+// block is stripped including the closing delimiter line.
+func TestStripFrontmatter_WithBlock(t *testing.T) {
+	input := "---\ndescription: demo\ntag: x\n---\n# Heading\n\nbody\n"
+	got := stripFrontmatter(input)
+	if strings.Contains(got, "description:") || strings.Contains(got, "tag:") {
+		t.Fatalf("stripFrontmatter left YAML keys in place:\n%s", got)
+	}
+	if !strings.HasPrefix(got, "# Heading") {
+		t.Fatalf("stripFrontmatter should leave body starting at heading;\n got=%q", got)
+	}
+}
+
+// TestStripFrontmatter_Malformed verifies an unterminated
+// frontmatter block (leading `---` but no closer) returns the
+// original content so the renderer still has something to work
+// with.
+func TestStripFrontmatter_Malformed(t *testing.T) {
+	input := "---\ndescription: demo\nno closer here\n"
+	got := stripFrontmatter(input)
+	if got != input {
+		t.Fatalf("stripFrontmatter on malformed input should return original;\n got=%q\nwant=%q", got, input)
+	}
+}
+
+// TestStripFrontmatter_EmptyBody verifies an empty YAML block
+// (two adjacent `---` lines) strips cleanly.
+func TestStripFrontmatter_EmptyBody(t *testing.T) {
+	input := "---\n---\n# Heading\n"
+	got := stripFrontmatter(input)
+	if !strings.HasPrefix(got, "# Heading") {
+		t.Fatalf("stripFrontmatter on empty frontmatter should leave heading;\n got=%q", got)
+	}
+}
+
+// TestRenderMarkdown_NarrowVsWide verifies the renderer honours
+// the width hint — a narrow width produces a taller render
+// (more wrapped lines) than a wide one for the same long-prose
+// input.
+func TestRenderMarkdown_NarrowVsWide(t *testing.T) {
+	input := "# Heading\n\n" + strings.Repeat("The quick brown fox jumps over the lazy dog. ", 20)
+	narrow, err := renderMarkdown(input, 40)
+	if err != nil {
+		t.Fatalf("narrow render: %v", err)
+	}
+	wide, err := renderMarkdown(input, 120)
+	if err != nil {
+		t.Fatalf("wide render: %v", err)
+	}
+	narrowLines := strings.Count(narrow, "\n")
+	wideLines := strings.Count(wide, "\n")
+	if narrowLines <= wideLines {
+		t.Fatalf("narrow render should produce more lines than wide; narrow=%d wide=%d", narrowLines, wideLines)
+	}
+}
+
+// TestRenderMarkdown_ZeroWidthClamps verifies passing width=0
+// doesn't error and produces non-empty output — the viewer may
+// call this before its first WindowSizeMsg and should not
+// explode.
+func TestRenderMarkdown_ZeroWidthClamps(t *testing.T) {
+	input := "# Heading\n\nsome body text.\n"
+	out, err := renderMarkdown(input, 0)
+	if err != nil {
+		t.Fatalf("zero-width render: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("zero-width render produced empty output")
+	}
+}
+
+// TestRenderMarkdown_NegativeWidthClamps verifies negative widths
+// also clamp instead of panicking inside glamour.
+func TestRenderMarkdown_NegativeWidthClamps(t *testing.T) {
+	out, err := renderMarkdown("# Heading\n", -10)
+	if err != nil {
+		t.Fatalf("negative-width render: %v", err)
+	}
+	if strings.TrimSpace(out) == "" {
+		t.Fatalf("negative-width render produced empty output")
+	}
+}
+
+// TestRenderMarkdown_EmptyContent verifies empty input renders
+// without error. Glamour handles this gracefully; the viewer's
+// cache warmup benefits from not needing a special case.
+func TestRenderMarkdown_EmptyContent(t *testing.T) {
+	out, err := renderMarkdown("", 80)
+	if err != nil {
+		t.Fatalf("empty render: %v", err)
+	}
+	// Empty-in → empty-ish out (glamour may emit trailing
+	// whitespace). Assert no panic + no error; contents
+	// immaterial.
+	_ = out
+}
+
+// TestRenderMarkdown_StripsFrontmatter verifies the renderer
+// integrates the frontmatter strip — YAML keys should not leak
+// into the rendered output.
+func TestRenderMarkdown_StripsFrontmatter(t *testing.T) {
+	input := "---\ndescription: demo\n---\n# Heading\n\nbody text\n"
+	out, err := renderMarkdown(input, 80)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(out, "description:") {
+		t.Fatalf("rendered output leaked frontmatter YAML:\n%s", out)
+	}
+}

--- a/internal/tui/guideflow/viewer.go
+++ b/internal/tui/guideflow/viewer.go
@@ -34,14 +34,12 @@ type ViewerStage struct {
 	quit     bool
 }
 
-// narrowStripThreshold defines the cell budget above which the full
-// tab labels (QUICKSTART · CONCEPTS · CLI · CUSTOM) are rendered.
-// Below the threshold the short labels (START · CONCP · CLI · CUSTM)
-// kick in so the strip still fits inside the 70-col min-size floor.
-// The threshold is measured dynamically at render time — this
-// constant only supplies the hard minimum below which short labels
-// are always used even if they would technically fit.
-const narrowStripThreshold = 60
+// Tab-label fallback is measurement-driven: renderTabs compares the
+// rendered full-label strip width against the live panel budget
+// (initflow.PanelWidth) and switches to the short labels
+// (START · CONCP · CLI · CUSTM) whenever the full strip would
+// overflow. No hard threshold — the viewport-relative budget makes
+// the decision at every WindowSizeMsg.
 
 // NewViewer constructs a ViewerStage from the given topics + the
 // initial topic key (empty or unknown → idx 0). version and
@@ -153,14 +151,12 @@ func (s *ViewerStage) Title() string { return "GUIDE" }
 func (s *ViewerStage) Result() any { return nil }
 
 // View composes the full frame: header + tab strip + viewport +
-// footer. Falls back to the min-size floor when the terminal is
-// below the 70×20 threshold.
+// footer. Stage.RenderFrame short-circuits to the min-size floor
+// when the terminal falls below the 70×20 threshold, so the check
+// isn't duplicated here.
 func (s *ViewerStage) View() string {
 	if s.quit {
 		return ""
-	}
-	if initflow.TerminalTooSmall(s.width, s.height) {
-		return initflow.RenderMinSizeFloor(s.width, s.height)
 	}
 
 	width := s.width
@@ -185,31 +181,25 @@ func (s *ViewerStage) keyHints() []initflow.KeyHint {
 
 // renderTabs renders the single-row topic tab strip. Active tab is
 // bold ColorPrimary; inactive tabs are ColorMuted. Chooses the full
-// label set when the rendered strip fits inside
-// initflow.ClampColumns(width).Total; otherwise falls back to the
-// compact short labels so the 4-tab strip fits inside the 70-col
-// min-size floor.
+// label set when the rendered strip fits inside the live panel
+// budget (initflow.PanelWidth); otherwise falls back to the compact
+// short labels so the 4-tab strip still fits on narrow terminals.
 func (s *ViewerStage) renderTabs(width int) string {
-	full := s.buildTabStrip(width, false)
-	// Measure full-label strip against the available content budget.
-	// ClampColumns returns (nameW, descW, tagW); sum is the effective
-	// panel budget in cells. The +4 adds back the init-flow sidePad
-	// margin so the threshold compares like-for-like against the
-	// rendered strip (which itself has no margin baked in).
-	nameW, descW, tagW := initflow.ClampColumns(width - 4)
-	budget := nameW + descW + tagW
-	if budget < narrowStripThreshold {
-		budget = narrowStripThreshold
-	}
-	if lipgloss.Width(full) > budget {
-		return s.buildTabStrip(width, true)
+	full := s.buildTabStrip(false)
+	// Measure the rendered full-label strip against the live panel
+	// content budget. PanelWidth clamps to the design target on wide
+	// terminals and falls back to (width-4) on narrow ones, so the
+	// comparison fires only when full labels would actually overflow.
+	budget := initflow.PanelWidth(width)
+	if budget > 0 && lipgloss.Width(full) > budget {
+		return s.buildTabStrip(true)
 	}
 	return full
 }
 
 // buildTabStrip assembles the tab row from s.topics. When useShort
 // is true each cell uses the Topic.Short label.
-func (s *ViewerStage) buildTabStrip(_ int, useShort bool) string {
+func (s *ViewerStage) buildTabStrip(useShort bool) string {
 	active := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
 	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
 

--- a/internal/tui/guideflow/viewer.go
+++ b/internal/tui/guideflow/viewer.go
@@ -1,0 +1,280 @@
+package guideflow
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// ViewerStage is the BubbleTea model for `bonsai guide`. Four
+// topic tabs across the top, a scrollable glamour-rendered body
+// below, standard initflow chrome wrapping the whole frame. Embeds
+// initflow.Stage with railHidden=true — guide is read-only (no
+// mutation process, no rail segments to walk).
+//
+// Markdown output is cached per (topicIdx, viewport width) so
+// resize events only re-render when the width actually changes and
+// tab cycles re-use prior renders.
+type ViewerStage struct {
+	initflow.Stage
+
+	topics   []Topic
+	idx      int
+	viewport viewport.Model
+	rendered map[string]string // key: "idx:width" → glamour output
+	width    int
+	height   int
+	quit     bool
+}
+
+// narrowStripThreshold defines the cell budget above which the full
+// tab labels (QUICKSTART · CONCEPTS · CLI · CUSTOM) are rendered.
+// Below the threshold the short labels (START · CONCP · CLI · CUSTM)
+// kick in so the strip still fits inside the 70-col min-size floor.
+// The threshold is measured dynamically at render time — this
+// constant only supplies the hard minimum below which short labels
+// are always used even if they would technically fit.
+const narrowStripThreshold = 60
+
+// NewViewer constructs a ViewerStage from the given topics + the
+// initial topic key (empty or unknown → idx 0). version and
+// projectDir feed the header chrome; projectDir may be empty if the
+// caller couldn't resolve it (guide doesn't strictly need it).
+func NewViewer(topics []Topic, initialKey, version, projectDir string) *ViewerStage {
+	idx := 0
+	if initialKey != "" {
+		for i, t := range topics {
+			if t.Key == initialKey {
+				idx = i
+				break
+			}
+		}
+	}
+
+	base := initflow.NewStage(
+		0,
+		initflow.StageLabel{English: "GUIDE"},
+		"GUIDE",
+		version,
+		projectDir,
+		"",
+		"",
+		time.Time{},
+	)
+	base.SetRailHidden(true)
+	base.SetHeaderAction("GUIDE")
+	// Guide is scope-global (docs are the same wherever you run it),
+	// so omit the destination preamble on the right block — project
+	// path still renders on row 2 via the base chrome.
+	base.SetHeaderRightLabel("")
+
+	vp := viewport.New(0, 0)
+
+	return &ViewerStage{
+		Stage:    base,
+		topics:   topics,
+		idx:      idx,
+		viewport: vp,
+		rendered: make(map[string]string),
+	}
+}
+
+// Init implements tea.Model. No-op — the first render is wired up
+// on the first WindowSizeMsg.
+func (s *ViewerStage) Init() tea.Cmd { return nil }
+
+// Update implements tea.Model.
+//
+// Keys:
+//   - tab / right / l       — next topic (wraps)
+//   - shift+tab / left / h  — prev topic (wraps)
+//   - g / home              — viewport top
+//   - G / end               — viewport bottom
+//   - up/down, j/k, pgup/pgdn, space, u/d — scroll (viewport)
+//   - q / esc / ctrl+c      — quit
+func (s *ViewerStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch m := msg.(type) {
+	case tea.WindowSizeMsg:
+		s.width = m.Width
+		s.height = m.Height
+		s.SetSize(m.Width, m.Height)
+		s.resizeViewport()
+		s.refreshViewportContent()
+		return s, nil
+	case tea.KeyMsg:
+		switch m.String() {
+		case "q", "esc", "ctrl+c":
+			s.quit = true
+			s.MarkDone()
+			return s, tea.Quit
+		case "tab", "right", "l":
+			if len(s.topics) == 0 {
+				return s, nil
+			}
+			s.idx = (s.idx + 1) % len(s.topics)
+			s.refreshViewportContent()
+			s.viewport.GotoTop()
+			return s, nil
+		case "shift+tab", "left", "h":
+			if len(s.topics) == 0 {
+				return s, nil
+			}
+			s.idx = (s.idx - 1 + len(s.topics)) % len(s.topics)
+			s.refreshViewportContent()
+			s.viewport.GotoTop()
+			return s, nil
+		case "g", "home":
+			s.viewport.GotoTop()
+			return s, nil
+		case "G", "end":
+			s.viewport.GotoBottom()
+			return s, nil
+		}
+		// Fall through to viewport for scroll keys (up/down, j/k,
+		// pgup/pgdn, space, u/d).
+		var cmd tea.Cmd
+		s.viewport, cmd = s.viewport.Update(msg)
+		return s, cmd
+	}
+	return s, nil
+}
+
+// Title implements harness.Step.
+func (s *ViewerStage) Title() string { return "GUIDE" }
+
+// Result implements harness.Step. Guide is read-only — no payload.
+func (s *ViewerStage) Result() any { return nil }
+
+// View composes the full frame: header + tab strip + viewport +
+// footer. Falls back to the min-size floor when the terminal is
+// below the 70×20 threshold.
+func (s *ViewerStage) View() string {
+	if s.quit {
+		return ""
+	}
+	if initflow.TerminalTooSmall(s.width, s.height) {
+		return initflow.RenderMinSizeFloor(s.width, s.height)
+	}
+
+	width := s.width
+	if width <= 0 {
+		width = 80
+	}
+
+	tabRow := s.renderTabs(width)
+	body := tabRow + "\n\n" + s.viewport.View()
+	return s.RenderFrame(body, s.keyHints())
+}
+
+// keyHints returns the footer key row.
+func (s *ViewerStage) keyHints() []initflow.KeyHint {
+	return []initflow.KeyHint{
+		{Key: "←→", Desc: "tabs"},
+		{Key: "↑↓", Desc: "scroll"},
+		{Key: "g/G", Desc: "top/bot"},
+		{Key: "q", Desc: "quit"},
+	}
+}
+
+// renderTabs renders the single-row topic tab strip. Active tab is
+// bold ColorPrimary; inactive tabs are ColorMuted. Chooses the full
+// label set when the rendered strip fits inside
+// initflow.ClampColumns(width).Total; otherwise falls back to the
+// compact short labels so the 4-tab strip fits inside the 70-col
+// min-size floor.
+func (s *ViewerStage) renderTabs(width int) string {
+	full := s.buildTabStrip(width, false)
+	// Measure full-label strip against the available content budget.
+	// ClampColumns returns (nameW, descW, tagW); sum is the effective
+	// panel budget in cells. The +4 adds back the init-flow sidePad
+	// margin so the threshold compares like-for-like against the
+	// rendered strip (which itself has no margin baked in).
+	nameW, descW, tagW := initflow.ClampColumns(width - 4)
+	budget := nameW + descW + tagW
+	if budget < narrowStripThreshold {
+		budget = narrowStripThreshold
+	}
+	if lipgloss.Width(full) > budget {
+		return s.buildTabStrip(width, true)
+	}
+	return full
+}
+
+// buildTabStrip assembles the tab row from s.topics. When useShort
+// is true each cell uses the Topic.Short label.
+func (s *ViewerStage) buildTabStrip(_ int, useShort bool) string {
+	active := lipgloss.NewStyle().Foreground(tui.ColorPrimary).Bold(true)
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+
+	cells := make([]string, 0, len(s.topics))
+	for i, t := range s.topics {
+		label := t.Label
+		if useShort {
+			label = t.Short
+		}
+		if i == s.idx {
+			cells = append(cells, active.Render(label))
+		} else {
+			cells = append(cells, muted.Render(label))
+		}
+	}
+	sep := "  "
+	return strings.Join(cells, sep)
+}
+
+// resizeViewport recomputes the viewport dims from the current
+// terminal size. Body area = height minus chrome (header 2 + 2
+// blanks + footer 2) minus tab strip (1 + 1 blank). Floor at 3 so
+// at least a small scroll window is visible on short terminals.
+func (s *ViewerStage) resizeViewport() {
+	w := initflow.PanelWidth(s.width)
+	if w <= 0 {
+		w = 80
+	}
+	// Chrome: header (2 rows) + 2 blank + footer (2 rows, rule +
+	// brand row) = 6. Tab strip row (1) + 1 blank = 2. Total 8.
+	const chromeRows = 8
+	h := s.height - chromeRows
+	if h < 3 {
+		h = 3
+	}
+	s.viewport.Width = w
+	s.viewport.Height = h
+}
+
+// refreshViewportContent resolves the rendered markdown for the
+// current topic at the current width, pushing it into the
+// viewport. Uses the cache keyed by "idx:width" so repeated
+// resize-to-same-width and tab-revisits skip the glamour call.
+func (s *ViewerStage) refreshViewportContent() {
+	if len(s.topics) == 0 {
+		s.viewport.SetContent("")
+		return
+	}
+	w := s.viewport.Width
+	if w <= 0 {
+		w = defaultRenderWidth
+	}
+	key := fmt.Sprintf("%d:%d", s.idx, w)
+	if cached, ok := s.rendered[key]; ok {
+		s.viewport.SetContent(cached)
+		return
+	}
+	rendered, err := renderMarkdown(s.topics[s.idx].Markdown, w)
+	if err != nil {
+		// Surface the render failure inside the viewport itself
+		// so the user sees something rather than a blank pane;
+		// quit key still exits cleanly.
+		s.viewport.SetContent("Render error: " + err.Error())
+		return
+	}
+	s.rendered[key] = rendered
+	s.viewport.SetContent(rendered)
+}

--- a/internal/tui/guideflow/viewer_test.go
+++ b/internal/tui/guideflow/viewer_test.go
@@ -1,6 +1,7 @@
 package guideflow
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -203,6 +204,71 @@ func TestViewer_ViewContainsBrandAndTabs(t *testing.T) {
 		if !strings.Contains(out, label) {
 			t.Fatalf("expected tab label %q in view; got:\n%s", label, out)
 		}
+	}
+}
+
+// longTopics returns a 4-element Topic slice where the first topic's
+// Markdown is long enough to exceed any reasonable viewport height,
+// so scroll-key tests can observe a non-zero YOffset after a line /
+// page down. Each paragraph is deliberately unique so glamour doesn't
+// collapse or dedupe.
+func longTopics() []Topic {
+	var body strings.Builder
+	body.WriteString("# Long Topic\n\n")
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&body, "Paragraph %d — lorem ipsum dolor sit amet, consectetur adipiscing elit.\n\n", i)
+	}
+	return []Topic{
+		{Key: "quickstart", Label: "QUICKSTART", Short: "START", Markdown: body.String()},
+		{Key: "concepts", Label: "CONCEPTS", Short: "CONCP", Markdown: "# Concepts\n\nbody"},
+		{Key: "cli", Label: "CLI", Short: "CLI", Markdown: "# CLI\n\nref"},
+		{Key: "custom-files", Label: "CUSTOM", Short: "CUSTM", Markdown: "# Custom\n\ndetails"},
+	}
+}
+
+// TestViewer_ScrollKeyDelegation verifies the fall-through path in
+// Update forwards scroll keys (j/k, pgdn/pgup) to the embedded
+// bubbles/viewport model, which responds by moving YOffset. The
+// viewport's DefaultKeyMap binds Down→{down,j}, PageDown→{pgdown,
+// space,f}, Up→{up,k}, PageUp→{pgup,b} — this test uses the single-
+// char forms so the assertion doesn't depend on tea.KeyType→string
+// aliasing.
+func TestViewer_ScrollKeyDelegation(t *testing.T) {
+	s := NewViewer(longTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	if s.viewport.YOffset != 0 {
+		t.Fatalf("precondition: YOffset = %d, want 0 before any scroll", s.viewport.YOffset)
+	}
+
+	// Line down (j) — YOffset should advance by ~1.
+	s.Update(key("j"))
+	afterLineDown := s.viewport.YOffset
+	if afterLineDown <= 0 {
+		t.Fatalf("YOffset after j = %d, want > 0 (viewport should advance)", afterLineDown)
+	}
+
+	// Page down (f is a DefaultKeyMap alias for PageDown; we use it
+	// here because pgdown typed into a tea.KeyMsg can round-trip
+	// through tea.KeyPgDown.String() == "pgdown", which the viewport
+	// keymap also matches — either path proves delegation).
+	s.Update(key("f"))
+	afterPageDown := s.viewport.YOffset
+	if afterPageDown <= afterLineDown {
+		t.Fatalf("YOffset after pgdown = %d, want > %d", afterPageDown, afterLineDown)
+	}
+
+	// Line up (k) — YOffset should move back toward the top.
+	s.Update(key("k"))
+	afterLineUp := s.viewport.YOffset
+	if afterLineUp >= afterPageDown {
+		t.Fatalf("YOffset after k = %d, want < %d", afterLineUp, afterPageDown)
+	}
+
+	// Page up (b is the DefaultKeyMap alias for PageUp).
+	s.Update(key("b"))
+	afterPageUp := s.viewport.YOffset
+	if afterPageUp >= afterLineUp {
+		t.Fatalf("YOffset after pgup = %d, want < %d", afterPageUp, afterLineUp)
 	}
 }
 

--- a/internal/tui/guideflow/viewer_test.go
+++ b/internal/tui/guideflow/viewer_test.go
@@ -1,0 +1,270 @@
+package guideflow
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// fakeTopics returns a 4-element Topic slice suitable for viewer
+// tests. Markdown bodies are deliberately non-empty so the cache
+// population assertion has something to observe.
+func fakeTopics() []Topic {
+	return []Topic{
+		{Key: "quickstart", Label: "QUICKSTART", Short: "START", Markdown: "# Quickstart\n\nhello"},
+		{Key: "concepts", Label: "CONCEPTS", Short: "CONCP", Markdown: "# Concepts\n\nbody"},
+		{Key: "cli", Label: "CLI", Short: "CLI", Markdown: "# CLI\n\nref"},
+		{Key: "custom-files", Label: "CUSTOM", Short: "CUSTM", Markdown: "# Custom\n\ndetails"},
+	}
+}
+
+// key builds a tea.KeyMsg for a single named key, matching the
+// helper used across initflow / catalogflow test files.
+func key(name string) tea.KeyMsg {
+	switch name {
+	case "left":
+		return tea.KeyMsg{Type: tea.KeyLeft}
+	case "right":
+		return tea.KeyMsg{Type: tea.KeyRight}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	case "tab":
+		return tea.KeyMsg{Type: tea.KeyTab}
+	case "shift+tab":
+		return tea.KeyMsg{Type: tea.KeyShiftTab}
+	case "home":
+		return tea.KeyMsg{Type: tea.KeyHome}
+	case "end":
+		return tea.KeyMsg{Type: tea.KeyEnd}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "ctrl+c":
+		return tea.KeyMsg{Type: tea.KeyCtrlC}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(name)}
+	}
+}
+
+// TestNewViewer_InitialKeyResolved verifies an initial key maps to
+// the matching topic index.
+func TestNewViewer_InitialKeyResolved(t *testing.T) {
+	s := NewViewer(fakeTopics(), "concepts", "1.0.0", "/tmp")
+	if s.idx != 1 {
+		t.Fatalf("idx for concepts = %d, want 1", s.idx)
+	}
+}
+
+// TestNewViewer_InitialKeyMissingDefaultsToZero verifies unknown
+// initial keys fall back to idx 0.
+func TestNewViewer_InitialKeyMissingDefaultsToZero(t *testing.T) {
+	s := NewViewer(fakeTopics(), "no-such-key", "", "")
+	if s.idx != 0 {
+		t.Fatalf("idx for unknown key = %d, want 0", s.idx)
+	}
+}
+
+// TestNewViewer_EmptyInitialKeyDefaultsToZero verifies the empty
+// string initial key resolves to idx 0.
+func TestNewViewer_EmptyInitialKeyDefaultsToZero(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	if s.idx != 0 {
+		t.Fatalf("idx for empty key = %d, want 0", s.idx)
+	}
+}
+
+// TestViewer_TabCycleForwardWraps verifies tab / right / l cycle
+// past the last topic back to index 0.
+func TestViewer_TabCycleForwardWraps(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	// Seed a window size so resizeViewport + refreshViewportContent
+	// don't trip on a zero-width viewport on the first key event
+	// (they tolerate it, but the test is more meaningful with a
+	// real frame size).
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	for range s.topics {
+		s.Update(key("right"))
+	}
+	if s.idx != 0 {
+		t.Fatalf("idx after full forward cycle = %d, want 0", s.idx)
+	}
+}
+
+// TestViewer_TabCycleBackwardWraps verifies left / shift+tab / h
+// cycle from idx 0 to the last topic.
+func TestViewer_TabCycleBackwardWraps(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	s.Update(key("left"))
+	if s.idx != len(s.topics)-1 {
+		t.Fatalf("idx after one backward cycle = %d, want %d", s.idx, len(s.topics)-1)
+	}
+}
+
+// TestViewer_TabKeyCyclesForward verifies the Tab key path
+// (separate from "right"/"l").
+func TestViewer_TabKeyCyclesForward(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	s.Update(key("tab"))
+	if s.idx != 1 {
+		t.Fatalf("idx after tab = %d, want 1", s.idx)
+	}
+}
+
+// TestViewer_ShiftTabCyclesBackward verifies shift+tab mirrors the
+// left-arrow behavior.
+func TestViewer_ShiftTabCyclesBackward(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	s.Update(key("shift+tab"))
+	if s.idx != len(s.topics)-1 {
+		t.Fatalf("idx after shift+tab = %d, want %d", s.idx, len(s.topics)-1)
+	}
+}
+
+// TestViewer_WindowSizePopulatesRenderCache verifies a
+// WindowSizeMsg triggers a render for the current idx+width —
+// the cache map should have at least one entry after the resize.
+func TestViewer_WindowSizePopulatesRenderCache(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	if len(s.rendered) == 0 {
+		t.Fatalf("rendered cache empty after WindowSizeMsg; want >=1 entry")
+	}
+}
+
+// TestViewer_QuitKeys verifies each quit key (q / esc / ctrl+c)
+// flips the quit flag and issues a tea.Quit command.
+func TestViewer_QuitKeys(t *testing.T) {
+	for _, k := range []string{"q", "esc", "ctrl+c"} {
+		s := NewViewer(fakeTopics(), "", "", "")
+		_, cmd := s.Update(key(k))
+		if !s.quit {
+			t.Fatalf("key %q: quit flag = false, want true", k)
+		}
+		if cmd == nil {
+			t.Fatalf("key %q: cmd = nil, want tea.Quit", k)
+		}
+	}
+}
+
+// TestViewer_HomeScrollsToTop verifies the "home" key path
+// (delegates to viewport.GotoTop — we can't easily observe the
+// Y offset without invoking viewport internals, so assert the
+// Update returns no error + stays on the current tab).
+func TestViewer_HomeScrollsToTop(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	before := s.idx
+	s.Update(key("home"))
+	if s.idx != before {
+		t.Fatalf("home key should not change tab; idx before=%d after=%d", before, s.idx)
+	}
+}
+
+// TestViewer_EndScrollsToBottom mirrors the home-key test for
+// the "end" key path.
+func TestViewer_EndScrollsToBottom(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	before := s.idx
+	s.Update(key("end"))
+	if s.idx != before {
+		t.Fatalf("end key should not change tab; idx before=%d after=%d", before, s.idx)
+	}
+}
+
+// TestViewer_MinSizeFloorUnder70x20 verifies View returns the
+// min-size floor panel when the terminal is below the
+// initflow 70×20 threshold.
+func TestViewer_MinSizeFloorUnder70x20(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
+	out := s.View()
+	if !strings.Contains(out, "please enlarge your terminal") {
+		t.Fatalf("expected min-size floor under 40×10; got:\n%s", out)
+	}
+}
+
+// TestViewer_ViewContainsBrandAndTabs verifies a full-sized render
+// includes the BONSAI brand and every tab label (full form when
+// the budget allows).
+func TestViewer_ViewContainsBrandAndTabs(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	out := s.View()
+	if !strings.Contains(out, "BONSAI") {
+		t.Fatalf("expected BONSAI brand in view; got:\n%s", out)
+	}
+	for _, label := range []string{"QUICKSTART", "CONCEPTS", "CLI", "CUSTOM"} {
+		if !strings.Contains(out, label) {
+			t.Fatalf("expected tab label %q in view; got:\n%s", label, out)
+		}
+	}
+}
+
+// TestNewTopics_PreservesCanonicalOrder verifies the helper
+// preserves the quickstart → concepts → cli → custom-files order
+// regardless of map iteration.
+func TestNewTopics_PreservesCanonicalOrder(t *testing.T) {
+	raw := map[string]string{
+		"custom-files": "body d",
+		"cli":          "body c",
+		"concepts":     "body b",
+		"quickstart":   "body a",
+	}
+	topics := NewTopics(raw)
+	wantOrder := []string{"quickstart", "concepts", "cli", "custom-files"}
+	if len(topics) != len(wantOrder) {
+		t.Fatalf("NewTopics len = %d, want %d", len(topics), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if topics[i].Key != want {
+			t.Fatalf("topics[%d].Key = %q, want %q", i, topics[i].Key, want)
+		}
+	}
+}
+
+// TestNewTopics_SkipsMissingKeys verifies the helper tolerates a
+// rawContents map that's missing one or more canonical keys.
+func TestNewTopics_SkipsMissingKeys(t *testing.T) {
+	raw := map[string]string{
+		"quickstart": "hello",
+		"cli":        "ref",
+	}
+	topics := NewTopics(raw)
+	if len(topics) != 2 {
+		t.Fatalf("NewTopics len = %d, want 2", len(topics))
+	}
+	if topics[0].Key != "quickstart" || topics[1].Key != "cli" {
+		t.Fatalf("order mismatch: %+v", topics)
+	}
+}
+
+// TestNewTopics_LabelAndShortPopulated verifies each Topic has both
+// Label and Short set to the expected values.
+func TestNewTopics_LabelAndShortPopulated(t *testing.T) {
+	raw := map[string]string{
+		"quickstart":   "a",
+		"concepts":     "b",
+		"cli":          "c",
+		"custom-files": "d",
+	}
+	topics := NewTopics(raw)
+	wantLabels := map[string][2]string{
+		"quickstart":   {"QUICKSTART", "START"},
+		"concepts":     {"CONCEPTS", "CONCP"},
+		"cli":          {"CLI", "CLI"},
+		"custom-files": {"CUSTOM", "CUSTM"},
+	}
+	for _, topic := range topics {
+		want := wantLabels[topic.Key]
+		if topic.Label != want[0] || topic.Short != want[1] {
+			t.Fatalf("topic %q: label=%q short=%q, want label=%q short=%q",
+				topic.Key, topic.Label, topic.Short, want[0], want[1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Plan 28 Phase 3 — replace the Huh picker + fixed-width glamour print in `bonsai guide` with a cinematic BubbleTea viewer: 4 topic tabs over a `bubbles/viewport` scroll pane whose glamour render width binds to the live terminal. No kanji anywhere (decision D1).

- New `internal/tui/guideflow/` package: `Topic` type, `NewTopics` helper, `renderMarkdown` + `stripFrontmatter`, and `ViewerStage` BubbleTea model embedding `initflow.Stage` (railHidden).
- `cmd/guide.go` rewired: TTY → cinematic viewer; non-TTY + arg → preserved static glamour; non-TTY + no-arg → exact D4 error message, exit 1.
- 23 guideflow tests + 5 cmd tests cover frontmatter strip, width clamp (narrow/wide/zero/neg), tab cycle wrap both directions, all quit keys, min-size floor, initial-key lookup, no-TTY+no-arg message, and unknown-topic error path.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all pass (including new files)
- [x] `gofmt -l .` no diff
- [x] `go vet ./...` clean
- [x] `./bonsai guide` in TTY: opens AltScreen on quickstart, tab cycles, q quits
- [x] `./bonsai guide > /tmp/out` → exit 1 with exact D4 message
- [x] `./bonsai guide quickstart > /tmp/out` → static glamour render
- [x] `./bonsai guide bogus` → `unknown topic` error unchanged

## Keys (TTY viewer)

- `tab` / `shift+tab` / `← →` / `h l` — cycle topic (wraps)
- `↑ ↓` / `j k` / `pgup/pgdn` / `space` / `u d` — scroll body
- `g` / `home` — top; `G` / `end` — bottom
- `q` / `esc` / `ctrl-c` — quit

Plan: `station/Playbook/Plans/Active/28-view-cmds-cinematic.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)