### PR TITLE
feat(plan-28): Phase 2 — bonsai list cinematic

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
-	"github.com/LastStep/Bonsai/internal/catalog"
-	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/listflow"
 )
 
 func init() {
@@ -22,6 +21,11 @@ var listCmd = &cobra.Command{
 	RunE:  runList,
 }
 
+// runList renders the cinematic `bonsai list` surface — a single
+// fmt.Print of listflow.RenderAll's pure-function output. The TUI
+// pipeline is static (no BubbleTea) so piped invocations produce
+// clean non-ANSI output via the existing tui.DisableColor() pathway
+// in internal/tui/styles.go.
 func runList(cmd *cobra.Command, args []string) error {
 	cwd := mustCwd()
 	configPath := filepath.Join(cwd, configFile)
@@ -29,122 +33,21 @@ func runList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	tui.Heading(cfg.ProjectName)
-
-	if len(cfg.Scaffolding) > 0 {
-		scaffoldDisplay := make([]string, len(cfg.Scaffolding))
-		for i, s := range cfg.Scaffolding {
-			scaffoldDisplay[i] = catalog.DisplayNameFrom(s)
-		}
-		tui.Info("Scaffolding: " + strings.Join(scaffoldDisplay, ", "))
-	}
-
-	if len(cfg.Agents) == 0 {
-		tui.Blank()
-		tui.EmptyPanel("No agents installed.\nRun bonsai add to get started.")
-		return nil
-	}
-
 	cat := loadCatalog()
 
-	displayNames := func(names []string, lookup func(string) string) string {
-		display := make([]string, len(names))
-		for i, n := range names {
-			if dn := lookup(n); dn != "" {
-				display[i] = dn
-			} else {
-				display[i] = catalog.DisplayNameFrom(n)
-			}
-		}
-		return strings.Join(display, ", ")
-	}
-
-	agentNames := make([]string, 0, len(cfg.Agents))
-	for name := range cfg.Agents {
-		agentNames = append(agentNames, name)
-	}
-	sort.Strings(agentNames)
-
-	for _, name := range agentNames {
-		agent := cfg.Agents[name]
-		displayName := name
-		if agentDef := cat.GetAgent(name); agentDef != nil {
-			displayName = agentDef.DisplayName
-		}
-
-		pairs := [][2]string{{"Workspace", agent.Workspace}}
-		if len(agent.Skills) > 0 {
-			pairs = append(pairs, [2]string{"Skills", displayNames(agent.Skills, func(n string) string {
-				if s := cat.GetSkill(n); s != nil {
-					return s.DisplayName
-				}
-				return ""
-			})})
-		}
-		if len(agent.Workflows) > 0 {
-			pairs = append(pairs, [2]string{"Workflows", displayNames(agent.Workflows, func(n string) string {
-				if w := cat.GetWorkflow(n); w != nil {
-					return w.DisplayName
-				}
-				return ""
-			})})
-		}
-		if len(agent.Protocols) > 0 {
-			pairs = append(pairs, [2]string{"Protocols", displayNames(agent.Protocols, func(n string) string {
-				if p := cat.GetProtocol(n); p != nil {
-					return p.DisplayName
-				}
-				return ""
-			})})
-		}
-		if len(agent.Sensors) > 0 {
-			pairs = append(pairs, [2]string{"Sensors", displayNames(agent.Sensors, func(n string) string {
-				if s := cat.GetSensor(n); s != nil {
-					return s.DisplayName
-				}
-				return ""
-			})})
-		}
-		if len(agent.Routines) > 0 {
-			pairs = append(pairs, [2]string{"Routines", displayNames(agent.Routines, func(n string) string {
-				if r := cat.GetRoutine(n); r != nil {
-					return r.DisplayName
-				}
-				return ""
-			})})
-		}
-
-		content := tui.CardFields(pairs)
-		tui.TitledPanel(displayName, content, tui.Water)
-	}
-
-	totalSkills, totalWorkflows, totalProtocols, totalSensors, totalRoutines := 0, 0, 0, 0, 0
-	for _, a := range cfg.Agents {
-		totalSkills += len(a.Skills)
-		totalWorkflows += len(a.Workflows)
-		totalProtocols += len(a.Protocols)
-		totalSensors += len(a.Sensors)
-		totalRoutines += len(a.Routines)
-	}
-
-	parts := []string{
-		pluralize(len(cfg.Agents), "agent", "agents"),
-		pluralize(totalSkills, "skill", "skills"),
-		pluralize(totalWorkflows, "workflow", "workflows"),
-		pluralize(totalProtocols, "protocol", "protocols"),
-		pluralize(totalSensors, "sensor", "sensors"),
-		pluralize(totalRoutines, "routine", "routines"),
-	}
-	fmt.Println("\n  " + tui.StyleMuted.Render(strings.Join(parts, " "+tui.GlyphDot+" ")))
-
-	tui.Blank()
+	termW, termH := terminalSize()
+	fmt.Print(listflow.RenderAll(cfg, cat, Version, cwd, termW, termH))
 	return nil
 }
 
-func pluralize(n int, singular, plural string) string {
-	if n == 1 {
-		return fmt.Sprintf("%d %s", n, singular)
+// terminalSize queries the live terminal dims for the list renderer.
+// Falls back to 80×24 when stdout is not a TTY or the syscall errors —
+// `bonsai list` must produce readable piped output, so a non-TTY is a
+// valid case (the initflow min-size check won't trigger at 80×24).
+func terminalSize() (int, int) {
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 || h <= 0 {
+		return 80, 24
 	}
-	return fmt.Sprintf("%d %s", n, plural)
+	return w, h
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -11,16 +11,22 @@ import (
 	"github.com/LastStep/Bonsai/internal/config"
 )
 
-// TestMain wires the embedded catalog into the cmd package's package-level
-// catalogFS variable so runList's loadCatalog() call can find a populated
-// catalog during tests. The production wiring happens in cmd/bonsai/main.go;
-// the test binary skips that entry point and needs an equivalent here.
-func TestMain(m *testing.M) {
+// setupListTestCatalog wires the embedded catalog into the cmd package's
+// package-level catalogFS variable so runList's loadCatalog() call can
+// find a populated catalog. The production wiring happens in
+// cmd/bonsai/main.go; the test binary skips that entry point, so each
+// test that needs the catalog opts in explicitly via this helper. Prior
+// value is restored via t.Cleanup so other tests in the package (which
+// previously ran with catalogFS nil) are unaffected.
+func setupListTestCatalog(t *testing.T) {
+	t.Helper()
 	sub, err := fs.Sub(bonsai.CatalogFS, "catalog")
-	if err == nil {
-		catalogFS = sub
+	if err != nil {
+		t.Fatalf("fs.Sub(CatalogFS): %v", err)
 	}
-	os.Exit(m.Run())
+	prev := catalogFS
+	catalogFS = sub
+	t.Cleanup(func() { catalogFS = prev })
 }
 
 // TestRunList_HappyPath sets up a minimal project with one agent + one
@@ -29,6 +35,8 @@ func TestMain(m *testing.M) {
 // and the live workspace file. Uses captureStdout (defined in
 // add_test.go) for output redirection.
 func TestRunList_HappyPath(t *testing.T) {
+	setupListTestCatalog(t)
+
 	// Isolate the test from the developer's home dir / Bonsai config —
 	// runList calls mustCwd + requireConfig which read the real filesystem.
 	tmp := t.TempDir()
@@ -72,12 +80,6 @@ func TestRunList_HappyPath(t *testing.T) {
 		t.Fatalf("chdir: %v", err)
 	}
 	defer func() { _ = os.Chdir(origCwd) }()
-
-	// Load the bundled catalog so GetAgent("tech-lead") resolves the
-	// display name. The test binary has catalogFS/guideContents set to
-	// nil by default; init-time bundled load happens in main.go — we
-	// bypass it here by loading via a nil-safe catalog inside listflow
-	// (display name falls back to DisplayNameFrom("tech-lead")).
 
 	stdout := captureStdout(t, func() {
 		if err := runList(nil, nil); err != nil {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	bonsai "github.com/LastStep/Bonsai"
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// TestMain wires the embedded catalog into the cmd package's package-level
+// catalogFS variable so runList's loadCatalog() call can find a populated
+// catalog during tests. The production wiring happens in cmd/bonsai/main.go;
+// the test binary skips that entry point and needs an equivalent here.
+func TestMain(m *testing.M) {
+	sub, err := fs.Sub(bonsai.CatalogFS, "catalog")
+	if err == nil {
+		catalogFS = sub
+	}
+	os.Exit(m.Run())
+}
+
+// TestRunList_HappyPath sets up a minimal project with one agent + one
+// workspace file and asserts the cinematic output contains the expected
+// anchors: LIST action label, agent display-name panel, counts footer,
+// and the live workspace file. Uses captureStdout (defined in
+// add_test.go) for output redirection.
+func TestRunList_HappyPath(t *testing.T) {
+	// Isolate the test from the developer's home dir / Bonsai config —
+	// runList calls mustCwd + requireConfig which read the real filesystem.
+	tmp := t.TempDir()
+	projectDir := filepath.Join(tmp, "demo-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir projectDir: %v", err)
+	}
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "CLAUDE.md"), []byte("# hello"), 0o644); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "INDEX.md"), []byte("# index"), 0o644); err != nil {
+		t.Fatalf("write index file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "memory.md"), []byte("# memory"), 0o644); err != nil {
+		t.Fatalf("write memory file: %v", err)
+	}
+
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo-project",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": {
+				AgentType: "tech-lead",
+				Workspace: "station",
+			},
+		},
+	}
+	if err := cfg.Save(filepath.Join(projectDir, configFile)); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	// chdir into projectDir so mustCwd resolves to the right root.
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origCwd) }()
+
+	// Load the bundled catalog so GetAgent("tech-lead") resolves the
+	// display name. The test binary has catalogFS/guideContents set to
+	// nil by default; init-time bundled load happens in main.go — we
+	// bypass it here by loading via a nil-safe catalog inside listflow
+	// (display name falls back to DisplayNameFrom("tech-lead")).
+
+	stdout := captureStdout(t, func() {
+		if err := runList(nil, nil); err != nil {
+			t.Fatalf("runList: %v", err)
+		}
+	})
+
+	// Header should include the LIST action label.
+	if !strings.Contains(stdout, "LIST") {
+		t.Fatalf("expected 'LIST' in header, got:\n%s", stdout)
+	}
+	// Agent display-name (catalog may be nil in test — DisplayNameFrom
+	// still produces "Tech Lead").
+	if !strings.Contains(stdout, "Tech Lead") {
+		t.Fatalf("expected 'Tech Lead' panel title, got:\n%s", stdout)
+	}
+	// Counts footer — single agent, zero abilities installed here.
+	if !strings.Contains(stdout, "1 agent") {
+		t.Fatalf("expected '1 agent' count, got:\n%s", stdout)
+	}
+	// At least one of the workspace files should appear in the tree.
+	if !strings.Contains(stdout, "CLAUDE.md") {
+		t.Fatalf("expected CLAUDE.md in workspace tree, got:\n%s", stdout)
+	}
+}

--- a/internal/tui/listflow/agent_panel.go
+++ b/internal/tui/listflow/agent_panel.go
@@ -1,0 +1,398 @@
+package listflow
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui"
+)
+
+// maxTreeEntries caps the per-agent workspace file tree. Over this, the
+// tree truncates to maxTreeEntries real rows plus one muted "... (N more)"
+// synthetic row. Decision D2 from Plan 28 session 2026-04-23 — a large
+// workspace should not balloon the list output.
+const maxTreeEntries = 50
+
+// RenderAgentPanel renders one agent's TitledPanel + workspace tree (or
+// missing-workspace hint) as a single string block, ready to be joined
+// into RenderAll's output.
+//
+// agentName is the machine name used as the config map key; agent is
+// the full installed-agent record; cat is consulted for display-name
+// lookups (nil is tolerated — falls back to DisplayNameFrom).
+// projectDir is the absolute project root — used as the anchor for the
+// workspace path-escape check.
+func RenderAgentPanel(agentName string, agent *config.InstalledAgent, cat *catalog.Catalog, projectDir string, termW int) string {
+	if agent == nil {
+		return ""
+	}
+
+	// Display name — prefer the catalog's canonical form when available,
+	// fall back to DisplayNameFrom(name) when the agent type isn't in the
+	// loaded catalog (e.g. an old project on a newer Bonsai) or when cat
+	// is nil (as in unit tests).
+	displayName := catalog.DisplayNameFrom(agentName)
+	if cat != nil {
+		if def := cat.GetAgent(agentName); def != nil && def.DisplayName != "" {
+			displayName = def.DisplayName
+		}
+	}
+
+	pairs := buildPairs(agent, cat)
+	content := tui.CardFields(pairs)
+	panel := tui.TitledPanelString(displayName, content, tui.Water)
+
+	var b strings.Builder
+	b.WriteString(panel)
+	b.WriteString("\n")
+
+	// Workspace tree / hint / warning — rendered below the panel with
+	// one blank line between. The tree helper emits a root label line
+	// that includes the workspace path, so no extra heading is needed.
+	subblock := renderWorkspaceBlock(agent.Workspace, projectDir)
+	if subblock != "" {
+		b.WriteString("\n")
+		b.WriteString(subblock)
+	}
+
+	return b.String()
+}
+
+// buildPairs reconstructs the [][2]string field list used by CardFields.
+// Same shape as the pre-Plan-28 cmd/list.go code: Workspace + per-category
+// comma-joined display names. Empty categories are omitted so the panel
+// stays compact.
+func buildPairs(agent *config.InstalledAgent, cat *catalog.Catalog) [][2]string {
+	pairs := [][2]string{{"Workspace", agent.Workspace}}
+
+	lookup := func(name string, get func(string) string) string {
+		if get != nil {
+			if dn := get(name); dn != "" {
+				return dn
+			}
+		}
+		return catalog.DisplayNameFrom(name)
+	}
+	join := func(names []string, get func(string) string) string {
+		out := make([]string, len(names))
+		for i, n := range names {
+			out[i] = lookup(n, get)
+		}
+		return strings.Join(out, ", ")
+	}
+
+	getSkill := func(string) string { return "" }
+	getWorkflow := func(string) string { return "" }
+	getProtocol := func(string) string { return "" }
+	getSensor := func(string) string { return "" }
+	getRoutine := func(string) string { return "" }
+	if cat != nil {
+		getSkill = func(n string) string {
+			if s := cat.GetSkill(n); s != nil {
+				return s.DisplayName
+			}
+			return ""
+		}
+		getWorkflow = func(n string) string {
+			if w := cat.GetWorkflow(n); w != nil {
+				return w.DisplayName
+			}
+			return ""
+		}
+		getProtocol = func(n string) string {
+			if p := cat.GetProtocol(n); p != nil {
+				return p.DisplayName
+			}
+			return ""
+		}
+		getSensor = func(n string) string {
+			if s := cat.GetSensor(n); s != nil {
+				return s.DisplayName
+			}
+			return ""
+		}
+		getRoutine = func(n string) string {
+			if r := cat.GetRoutine(n); r != nil {
+				return r.DisplayName
+			}
+			return ""
+		}
+	}
+
+	if len(agent.Skills) > 0 {
+		pairs = append(pairs, [2]string{"Skills", join(agent.Skills, getSkill)})
+	}
+	if len(agent.Workflows) > 0 {
+		pairs = append(pairs, [2]string{"Workflows", join(agent.Workflows, getWorkflow)})
+	}
+	if len(agent.Protocols) > 0 {
+		pairs = append(pairs, [2]string{"Protocols", join(agent.Protocols, getProtocol)})
+	}
+	if len(agent.Sensors) > 0 {
+		pairs = append(pairs, [2]string{"Sensors", join(agent.Sensors, getSensor)})
+	}
+	if len(agent.Routines) > 0 {
+		pairs = append(pairs, [2]string{"Routines", join(agent.Routines, getRoutine)})
+	}
+	return pairs
+}
+
+// renderWorkspaceBlock returns the file-tree / hint / warning block below
+// an agent panel. Returns empty string only when workspace is explicitly
+// empty-string in config (shouldn't happen for a generated project — but
+// defensive). Contracts:
+//
+//   - workspace path contains ".." or escapes projectDir → muted warning
+//     line, no walk ("workspace path escapes project root — tree skipped").
+//   - workspace dir does not exist on disk → Hint CTA "Workspace missing
+//     — run: bonsai update" (decision D3).
+//   - exists but zero entries after filtering → tree with a single
+//     "(empty)" row.
+//   - exists with ≤ maxTreeEntries entries → full tree.
+//   - exists with > maxTreeEntries entries → first 50 rows + synthetic
+//     "... (N more)" muted row appended inside the tree (decision D2).
+func renderWorkspaceBlock(workspace, projectDir string) string {
+	if workspace == "" {
+		// No workspace configured. Treat as "missing" so the user still
+		// sees a CTA rather than a silent void.
+		return renderHintLine("Workspace missing — run: bonsai update")
+	}
+
+	// Resolve the absolute workspace path. Refuse any path that contains
+	// ".." (after Clean) or escapes projectDir.
+	cleaned := filepath.Clean(workspace)
+	if strings.Contains(cleaned, "..") {
+		return renderWarningLine("workspace path escapes project root — tree skipped")
+	}
+	absWorkspace := cleaned
+	if !filepath.IsAbs(absWorkspace) {
+		absWorkspace = filepath.Join(projectDir, cleaned)
+	}
+	absWorkspace = filepath.Clean(absWorkspace)
+	if projectDir != "" {
+		absProject, err := filepath.Abs(projectDir)
+		if err == nil {
+			rel, relErr := filepath.Rel(absProject, absWorkspace)
+			if relErr != nil || strings.HasPrefix(rel, "..") || rel == ".." {
+				return renderWarningLine("workspace path escapes project root — tree skipped")
+			}
+		}
+	}
+
+	// Stat the resolved path. A missing directory surfaces the D3 CTA.
+	info, err := statDir(absWorkspace)
+	if err != nil || info == nil || !info.IsDir() {
+		return renderHintLine("Workspace missing — run: bonsai update")
+	}
+
+	entries, truncated, total := scanWorkspace(absWorkspace)
+	if len(entries) == 0 {
+		// Present the root label with an "(empty)" marker so the user
+		// knows the scan ran but produced nothing.
+		tree := tui.FileTree([]string{"(empty)"}, workspace)
+		return tree
+	}
+
+	if truncated {
+		// Append a synthetic "... (N more)" entry to the flat list so it
+		// renders as the final leaf in the tree. The helper treats it as
+		// any other leaf — muted styling is applied by re-rendering the
+		// tree output (below). Cheap alternative: pad with a special
+		// marker and post-process. We use the post-process route to keep
+		// styling consistent with the rest of the tree.
+		extra := total - maxTreeEntries
+		placeholder := "... (" + itoa(extra) + " more)"
+		entries = append(entries, placeholder)
+	}
+
+	return tui.FileTree(entries, workspace)
+}
+
+// renderHintLine renders the muted single-line hint used for missing
+// workspace + other terse CTAs below an agent panel. Indent matches the
+// panel inset.
+func renderHintLine(msg string) string {
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	return "    " + muted.Render(msg)
+}
+
+// renderWarningLine renders an amber warning line used for the path-
+// escape refusal. Kept visually distinct from the blue Hint CTA so the
+// user notices the config issue rather than treating it as informational.
+func renderWarningLine(msg string) string {
+	warn := lipgloss.NewStyle().Foreground(tui.ColorWarning)
+	return "    " + warn.Render(tui.GlyphWarn+" "+msg)
+}
+
+// statDir wraps filepath-safe Stat so the caller can distinguish "does not
+// exist" from "exists but unreadable". Returns (nil, nil) when the path
+// does not exist so the caller can short-circuit to the D3 CTA.
+func statDir(path string) (fs.FileInfo, error) {
+	info, err := osStat(path)
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// scanWorkspace walks root collecting relative paths, skipping hidden
+// entries, .git, and node_modules. Symlinks are not followed — they
+// appear as leaves in the tree but their targets are never traversed,
+// which defuses symlink loop attacks.
+//
+// Returns (entries, truncated, total). truncated=true means the caller
+// should append a "... (N more)" row where N = total - maxTreeEntries.
+func scanWorkspace(root string) ([]string, bool, int) {
+	// Resolve the root for symlink-target comparisons. When EvalSymlinks
+	// fails (dangling link, etc.), we fall back to `root` — the walk
+	// still terminates because symlinks are skipped rather than followed.
+	resolvedRoot := root
+	if real, err := evalSymlinks(root); err == nil {
+		resolvedRoot = real
+	}
+
+	var files []string
+	total := 0
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Skip unreadable sub-trees rather than aborting the entire
+			// walk — a best-effort list is more useful than no list.
+			if d != nil && d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+
+		name := d.Name()
+		if isSkippable(name) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		// Symlink handling — do not follow. For symlink directories,
+		// returning SkipDir ensures we don't attempt to traverse into
+		// them. For symlink files, they render as-is.
+		if d.Type()&fs.ModeSymlink != 0 {
+			// Defensive check: even with SkipDir, verify the symlink
+			// target is inside the resolved workspace root before
+			// counting it. Targets outside are dropped entirely.
+			if target, err := evalSymlinks(path); err == nil {
+				if !isWithin(target, resolvedRoot) {
+					if d.IsDir() {
+						return fs.SkipDir
+					}
+					return nil
+				}
+			}
+			rel, relErr := filepath.Rel(root, path)
+			if relErr == nil {
+				total++
+				if len(files) < maxTreeEntries {
+					files = append(files, filepath.ToSlash(rel))
+				}
+			}
+			// Never descend into symlinked directories — sidesteps loops.
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			// Directories are implicit in the tree (the FileTree helper
+			// splits on "/" and promotes intermediate segments to
+			// branches), so we don't emit them explicitly. The walk
+			// continues into the subtree below.
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return nil
+		}
+		total++
+		if len(files) < maxTreeEntries {
+			files = append(files, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+
+	// Sort for deterministic output — filesystem walk order can vary
+	// between runs / platforms.
+	sort.Strings(files)
+
+	truncated := total > maxTreeEntries
+	return files, truncated, total
+}
+
+// isSkippable returns true for entries excluded from the workspace tree:
+// hidden files/dirs (leading dot), .git, node_modules. The leading-dot
+// check subsumes .git and .claude / .bonsai-lock.yaml but we keep the
+// named pair listed explicitly for clarity and as a guard if the hidden
+// rule is ever relaxed.
+func isSkippable(name string) bool {
+	if name == "" {
+		return true
+	}
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	if name == "node_modules" || name == ".git" {
+		return true
+	}
+	return false
+}
+
+// isWithin reports whether target is under root (inclusive). Both paths
+// should be absolute + symlink-resolved. Used to drop symlinks whose
+// targets escape the workspace — a path-traversal defense-in-depth
+// even though we already SkipDir on symlink directories.
+func isWithin(target, root string) bool {
+	if target == "" || root == "" {
+		return false
+	}
+	target = filepath.Clean(target)
+	root = filepath.Clean(root)
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, "..")
+}
+
+// itoa is a tiny strconv.Itoa wrapper kept local so the file avoids a
+// strconv import for a single call site. Mirrors the pattern in
+// initflow/chrome.go.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var digits [20]byte
+	i := len(digits)
+	for n > 0 {
+		i--
+		digits[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		digits[i] = '-'
+	}
+	return string(digits[i:])
+}

--- a/internal/tui/listflow/agent_panel.go
+++ b/internal/tui/listflow/agent_panel.go
@@ -1,6 +1,7 @@
 package listflow
 
 import (
+	"errors"
 	"io/fs"
 	"path/filepath"
 	"sort"
@@ -28,7 +29,7 @@ const maxTreeEntries = 50
 // lookups (nil is tolerated — falls back to DisplayNameFrom).
 // projectDir is the absolute project root — used as the anchor for the
 // workspace path-escape check.
-func RenderAgentPanel(agentName string, agent *config.InstalledAgent, cat *catalog.Catalog, projectDir string, termW int) string {
+func RenderAgentPanel(agentName string, agent *config.InstalledAgent, cat *catalog.Catalog, projectDir string) string {
 	if agent == nil {
 		return ""
 	}
@@ -164,12 +165,11 @@ func renderWorkspaceBlock(workspace, projectDir string) string {
 		return renderHintLine("Workspace missing — run: bonsai update")
 	}
 
-	// Resolve the absolute workspace path. Refuse any path that contains
-	// ".." (after Clean) or escapes projectDir.
+	// Resolve the absolute workspace path. The filepath.Rel-based ancestor
+	// check below is the canonical escape defense — legitimate workspace
+	// names that happen to contain ".." as a substring (e.g. "my..ws") are
+	// allowed through because Rel correctly reports them as non-escaping.
 	cleaned := filepath.Clean(workspace)
-	if strings.Contains(cleaned, "..") {
-		return renderWarningLine("workspace path escapes project root — tree skipped")
-	}
 	absWorkspace := cleaned
 	if !filepath.IsAbs(absWorkspace) {
 		absWorkspace = filepath.Join(projectDir, cleaned)
@@ -179,15 +179,24 @@ func renderWorkspaceBlock(workspace, projectDir string) string {
 		absProject, err := filepath.Abs(projectDir)
 		if err == nil {
 			rel, relErr := filepath.Rel(absProject, absWorkspace)
-			if relErr != nil || strings.HasPrefix(rel, "..") || rel == ".." {
+			if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 				return renderWarningLine("workspace path escapes project root — tree skipped")
 			}
 		}
 	}
 
 	// Stat the resolved path. A missing directory surfaces the D3 CTA.
-	info, err := statDir(absWorkspace)
-	if err != nil || info == nil || !info.IsDir() {
+	// Unreadable (permission-denied) paths also collapse to the same hint
+	// rather than silently vanishing — the user's next action is identical
+	// (investigate / bonsai update) in either case.
+	info, err := osStat(absWorkspace)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return renderHintLine("Workspace missing — run: bonsai update")
+		}
+		return renderHintLine("Workspace missing — run: bonsai update")
+	}
+	if info == nil || !info.IsDir() {
 		return renderHintLine("Workspace missing — run: bonsai update")
 	}
 
@@ -230,17 +239,6 @@ func renderWarningLine(msg string) string {
 	return "    " + warn.Render(tui.GlyphWarn+" "+msg)
 }
 
-// statDir wraps filepath-safe Stat so the caller can distinguish "does not
-// exist" from "exists but unreadable". Returns (nil, nil) when the path
-// does not exist so the caller can short-circuit to the D3 CTA.
-func statDir(path string) (fs.FileInfo, error) {
-	info, err := osStat(path)
-	if err != nil {
-		return nil, err
-	}
-	return info, nil
-}
-
 // scanWorkspace walks root collecting relative paths, skipping hidden
 // entries, .git, and node_modules. Symlinks are not followed — they
 // appear as leaves in the tree but their targets are never traversed,
@@ -281,18 +279,13 @@ func scanWorkspace(root string) ([]string, bool, int) {
 			return nil
 		}
 
-		// Symlink handling — do not follow. For symlink directories,
-		// returning SkipDir ensures we don't attempt to traverse into
-		// them. For symlink files, they render as-is.
+		// Symlink handling — do not follow. filepath.WalkDir does not
+		// follow symlinks by default; no SkipDir needed here. We still
+		// verify the symlink target resolves inside the workspace root
+		// as defense-in-depth — targets that escape are dropped.
 		if d.Type()&fs.ModeSymlink != 0 {
-			// Defensive check: even with SkipDir, verify the symlink
-			// target is inside the resolved workspace root before
-			// counting it. Targets outside are dropped entirely.
 			if target, err := evalSymlinks(path); err == nil {
 				if !isWithin(target, resolvedRoot) {
-					if d.IsDir() {
-						return fs.SkipDir
-					}
 					return nil
 				}
 			}
@@ -302,10 +295,6 @@ func scanWorkspace(root string) ([]string, bool, int) {
 				if len(files) < maxTreeEntries {
 					files = append(files, filepath.ToSlash(rel))
 				}
-			}
-			// Never descend into symlinked directories — sidesteps loops.
-			if d.IsDir() {
-				return fs.SkipDir
 			}
 			return nil
 		}

--- a/internal/tui/listflow/agent_panel_test.go
+++ b/internal/tui/listflow/agent_panel_test.go
@@ -28,7 +28,7 @@ func TestRenderAgentPanel_MissingWorkspaceShowsHint(t *testing.T) {
 	projectDir := t.TempDir()
 	agent := newAgent("station") // no dir created
 
-	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
 
 	if !strings.Contains(out, "Workspace missing — run: bonsai update") {
 		t.Fatalf("expected D3 hint in output, got:\n%s", out)
@@ -54,7 +54,7 @@ func TestRenderAgentPanel_EmptyWorkspaceShowsMarker(t *testing.T) {
 	}
 
 	agent := newAgent("station")
-	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
 
 	if !strings.Contains(out, "(empty)") {
 		t.Fatalf("expected (empty) marker in tree, got:\n%s", out)
@@ -77,7 +77,7 @@ func TestRenderAgentPanel_UnderCapShowsAllFiles(t *testing.T) {
 	}
 
 	agent := newAgent("station")
-	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
 
 	for i := 0; i < 10; i++ {
 		name := "file" + strconv.Itoa(i) + ".md"
@@ -108,7 +108,7 @@ func TestRenderAgentPanel_OverCapTruncatesWithSummary(t *testing.T) {
 	}
 
 	agent := newAgent("station")
-	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
 
 	if !strings.Contains(out, "(10 more)") {
 		t.Fatalf("expected '... (10 more)' truncation row, got:\n%s", out)
@@ -129,7 +129,7 @@ func TestRenderAgentPanel_EscapePathRefused(t *testing.T) {
 	projectDir := t.TempDir()
 	agent := newAgent("../outside")
 
-	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
 
 	if !strings.Contains(out, "escapes project root") {
 		t.Fatalf("expected escape-warning line, got:\n%s", out)
@@ -164,7 +164,7 @@ func TestRenderAgentPanel_SymlinkLoopTerminates(t *testing.T) {
 	done := make(chan string, 1)
 	go func() {
 		agent := newAgent("station")
-		done <- RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+		done <- RenderAgentPanel("tech-lead", agent, nil, projectDir)
 	}()
 	select {
 	case out := <-done:
@@ -195,7 +195,7 @@ func TestRenderAgentPanel_PairsIncludeInstalledAbilities(t *testing.T) {
 		Routines:  []string{"backlog-hygiene"},
 	}
 
-	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
 
 	for _, want := range []string{
 		"Workspace",
@@ -208,6 +208,89 @@ func TestRenderAgentPanel_PairsIncludeInstalledAbilities(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("expected %q in panel output, got:\n%s", want, out)
 		}
+	}
+}
+
+// TestRenderAgentPanel_AbsolutePathEscape covers the escape-detection
+// ancestor check for absolute workspace paths outside projectDir (e.g.
+// /etc). The warning line must render and the tree walk must be skipped.
+func TestRenderAgentPanel_AbsolutePathEscape(t *testing.T) {
+	projectDir := t.TempDir()
+	agent := newAgent("/etc")
+
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
+
+	if !strings.Contains(out, "escapes project root") {
+		t.Fatalf("expected escape-warning line for absolute path, got:\n%s", out)
+	}
+	if strings.Contains(out, "├─") || strings.Contains(out, "└─") {
+		t.Fatalf("did not expect tree glyphs for absolute escape path, got:\n%s", out)
+	}
+}
+
+// TestRenderAgentPanel_SkipsNodeModulesAndGit covers isSkippable: the
+// walker must skip .git + node_modules subtrees and still include a
+// regular file in the rendered tree.
+func TestRenderAgentPanel_SkipsNodeModulesAndGit(t *testing.T) {
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(filepath.Join(ws, "node_modules"), 0o755); err != nil {
+		t.Fatalf("mkdir node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "node_modules", "foo.js"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write node_modules file: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(ws, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, ".git", "config"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "real.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write real file: %v", err)
+	}
+
+	agent := newAgent("station")
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
+
+	if !strings.Contains(out, "real.md") {
+		t.Fatalf("expected real.md in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "node_modules") {
+		t.Fatalf("did not expect node_modules in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "foo.js") {
+		t.Fatalf("did not expect node_modules contents in output, got:\n%s", out)
+	}
+	// `.git` itself is hidden (leading-dot) and filtered; its contents
+	// must not leak either.
+	if strings.Contains(out, ".git") {
+		t.Fatalf("did not expect .git in output, got:\n%s", out)
+	}
+}
+
+// TestRenderAgentPanel_LegitimateDotDotInName regresses M1: a workspace
+// directory named "my..workspace" — the cleaned path contains ".." as a
+// substring but does not escape projectDir. The tree must render normally
+// rather than being refused as a path-escape.
+func TestRenderAgentPanel_LegitimateDotDotInName(t *testing.T) {
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "my..workspace")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(ws, "real.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	agent := newAgent("my..workspace")
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir)
+
+	if strings.Contains(out, "escapes project root") {
+		t.Fatalf("did not expect escape-warning for legitimate '..'-in-name, got:\n%s", out)
+	}
+	if !strings.Contains(out, "real.md") {
+		t.Fatalf("expected real.md in tree for legitimate '..'-in-name workspace, got:\n%s", out)
 	}
 }
 

--- a/internal/tui/listflow/agent_panel_test.go
+++ b/internal/tui/listflow/agent_panel_test.go
@@ -1,0 +1,223 @@
+package listflow
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// newAgent is a minimal InstalledAgent factory used across tests. Only
+// fields the panel actually reads are populated — empty ability slices
+// stay empty so pairs assertions stay tight.
+func newAgent(workspace string) *config.InstalledAgent {
+	return &config.InstalledAgent{
+		AgentType: "tech-lead",
+		Workspace: workspace,
+	}
+}
+
+// TestRenderAgentPanel_MissingWorkspaceShowsHint covers case (a) from the
+// plan: a config whose workspace path does not exist on disk surfaces the
+// D3 CTA — Workspace missing — run: bonsai update — and no tree.
+func TestRenderAgentPanel_MissingWorkspaceShowsHint(t *testing.T) {
+	projectDir := t.TempDir()
+	agent := newAgent("station") // no dir created
+
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+
+	if !strings.Contains(out, "Workspace missing — run: bonsai update") {
+		t.Fatalf("expected D3 hint in output, got:\n%s", out)
+	}
+	// No tree markers when the dir doesn't exist.
+	if strings.Contains(out, "├─") || strings.Contains(out, "└─") {
+		t.Fatalf("did not expect tree glyphs, got:\n%s", out)
+	}
+}
+
+// TestRenderAgentPanel_EmptyWorkspaceShowsMarker covers case (b): the
+// workspace dir exists but is empty (or contains only hidden entries).
+// The tree should render with a single "(empty)" leaf.
+func TestRenderAgentPanel_EmptyWorkspaceShowsMarker(t *testing.T) {
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Add a hidden file — it should be filtered out and the dir treated as empty.
+	if err := os.WriteFile(filepath.Join(ws, ".hidden"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	agent := newAgent("station")
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+
+	if !strings.Contains(out, "(empty)") {
+		t.Fatalf("expected (empty) marker in tree, got:\n%s", out)
+	}
+}
+
+// TestRenderAgentPanel_UnderCapShowsAllFiles covers case (c): a workspace
+// with 10 files renders all 10 in the tree without a truncation row.
+func TestRenderAgentPanel_UnderCapShowsAllFiles(t *testing.T) {
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		name := "file" + strconv.Itoa(i) + ".md"
+		if err := os.WriteFile(filepath.Join(ws, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	agent := newAgent("station")
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+
+	for i := 0; i < 10; i++ {
+		name := "file" + strconv.Itoa(i) + ".md"
+		if !strings.Contains(out, name) {
+			t.Fatalf("expected %s in output, got:\n%s", name, out)
+		}
+	}
+	if strings.Contains(out, "more)") {
+		t.Fatalf("did not expect truncation row under cap, got:\n%s", out)
+	}
+}
+
+// TestRenderAgentPanel_OverCapTruncatesWithSummary covers case (d): 60
+// files → first 50 entries + synthetic "... (10 more)" row.
+func TestRenderAgentPanel_OverCapTruncatesWithSummary(t *testing.T) {
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for i := 0; i < 60; i++ {
+		// Zero-pad so the sort order matches numeric order and the
+		// "(10 more)" assertion is deterministic.
+		name := "file" + fmtInt(i, 2) + ".md"
+		if err := os.WriteFile(filepath.Join(ws, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	agent := newAgent("station")
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+
+	if !strings.Contains(out, "(10 more)") {
+		t.Fatalf("expected '... (10 more)' truncation row, got:\n%s", out)
+	}
+	// The 51st file (file50.md, sorted) should NOT appear in output.
+	if strings.Contains(out, "file50.md") {
+		t.Fatalf("did not expect file50 when cap=50; got:\n%s", out)
+	}
+	// The 50th file (file49.md) should appear.
+	if !strings.Contains(out, "file49.md") {
+		t.Fatalf("expected file49.md in truncated output, got:\n%s", out)
+	}
+}
+
+// TestRenderAgentPanel_EscapePathRefused covers case (e): a workspace
+// path containing ".." is refused with a warning line and no walk.
+func TestRenderAgentPanel_EscapePathRefused(t *testing.T) {
+	projectDir := t.TempDir()
+	agent := newAgent("../outside")
+
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+
+	if !strings.Contains(out, "escapes project root") {
+		t.Fatalf("expected escape-warning line, got:\n%s", out)
+	}
+	if strings.Contains(out, "├─") || strings.Contains(out, "└─") {
+		t.Fatalf("did not expect tree glyphs for escape path, got:\n%s", out)
+	}
+}
+
+// TestRenderAgentPanel_SymlinkLoopTerminates covers case (f): a symlink
+// cycle must not produce infinite recursion. A 2s deadline is the
+// smoke-test budget — the SkipDir-on-symlink policy should return in
+// milliseconds.
+func TestRenderAgentPanel_SymlinkLoopTerminates(t *testing.T) {
+	if _, err := os.Lstat("/"); err != nil {
+		t.Skip("filesystem lstat unavailable")
+	}
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(filepath.Join(ws, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Create a symlink loop: ws/sub/loop -> ws
+	if err := os.Symlink(ws, filepath.Join(ws, "sub", "loop")); err != nil {
+		t.Skipf("symlink unsupported on this platform: %v", err)
+	}
+	// Add a regular file so we have something non-symlink to render.
+	if err := os.WriteFile(filepath.Join(ws, "real.md"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	done := make(chan string, 1)
+	go func() {
+		agent := newAgent("station")
+		done <- RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+	}()
+	select {
+	case out := <-done:
+		if !strings.Contains(out, "real.md") {
+			t.Fatalf("expected real.md to render alongside the symlink, got:\n%s", out)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("symlink loop did not terminate within 2s — SkipDir policy regressed")
+	}
+}
+
+// TestRenderAgentPanel_PairsIncludeInstalledAbilities covers the panel
+// field list: a populated agent renders Skills/Workflows/Protocols/
+// Sensors/Routines rows. Workspace row is always present.
+func TestRenderAgentPanel_PairsIncludeInstalledAbilities(t *testing.T) {
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	agent := &config.InstalledAgent{
+		AgentType: "tech-lead",
+		Workspace: "station",
+		Skills:    []string{"planning-template"},
+		Workflows: []string{"code-review"},
+		Protocols: []string{"memory"},
+		Sensors:   []string{"status-bar"},
+		Routines:  []string{"backlog-hygiene"},
+	}
+
+	out := RenderAgentPanel("tech-lead", agent, nil, projectDir, 120)
+
+	for _, want := range []string{
+		"Workspace",
+		"Skills", "Planning Template",
+		"Workflows", "Code Review",
+		"Protocols", "Memory",
+		"Sensors", "Status Bar",
+		"Routines", "Backlog Hygiene",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in panel output, got:\n%s", want, out)
+		}
+	}
+}
+
+// fmtInt zero-pads n to at least width digits. Avoids pulling strconv in
+// again (already imported above, but we keep this local so if the import
+// slims later the test still compiles).
+func fmtInt(n, width int) string {
+	s := strconv.Itoa(n)
+	for len(s) < width {
+		s = "0" + s
+	}
+	return s
+}

--- a/internal/tui/listflow/fs_helpers.go
+++ b/internal/tui/listflow/fs_helpers.go
@@ -1,0 +1,21 @@
+package listflow
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Filesystem indirection kept in a single file so the workspace-scan code
+// in agent_panel.go stays readable. Thin wrappers around the stdlib — the
+// indirection also gives tests a single seam to stub in future (none do
+// today; every test uses t.TempDir and real syscalls).
+
+// osStat is a thin wrapper around os.Stat used by renderWorkspaceBlock's
+// existence check. Kept isolated so the caller doesn't import "os".
+func osStat(path string) (fs.FileInfo, error) { return os.Stat(path) }
+
+// evalSymlinks wraps filepath.EvalSymlinks so scanWorkspace can resolve
+// the workspace root + each symlink's target without the caller pulling
+// in path/filepath directly alongside its own walk logic.
+func evalSymlinks(path string) (string, error) { return filepath.EvalSymlinks(path) }

--- a/internal/tui/listflow/listflow.go
+++ b/internal/tui/listflow/listflow.go
@@ -88,7 +88,7 @@ func RenderAll(cfg *config.ProjectConfig, cat *catalog.Catalog, version, project
 
 	for i, name := range agentNames {
 		agent := cfg.Agents[name]
-		b.WriteString(RenderAgentPanel(name, agent, cat, projectDir, width))
+		b.WriteString(RenderAgentPanel(name, agent, cat, projectDir))
 		if i < len(agentNames)-1 {
 			b.WriteString("\n")
 		}
@@ -144,9 +144,7 @@ func renderCountsFooter(agents, skills, workflows, protocols, sensors, routines 
 	return "  " + muted.Render(strings.Join(parts, " "+tui.GlyphDot+" "))
 }
 
-// pluralize picks singular or plural based on count. Duplicated from
-// cmd/list.go's helper (also kept there for the e2e test). Lifting to a
-// shared package is overkill for a 4-line helper used in two places.
+// pluralize picks singular or plural based on count.
 func pluralize(n int, singular, plural string) string {
 	if n == 1 {
 		return fmt.Sprintf("%d %s", n, singular)

--- a/internal/tui/listflow/listflow.go
+++ b/internal/tui/listflow/listflow.go
@@ -1,0 +1,155 @@
+// Package listflow renders the cinematic `bonsai list` surface — a
+// static, non-interactive string output composed of the shared initflow
+// chrome (header + min-size floor) plus per-agent panels and a counts
+// footer. Unlike catalogflow/guideflow, this package has no BubbleTea
+// model: RenderAll is a pure function returning the complete rendered
+// output ready for a single fmt.Print call from cmd/list.go.
+//
+// Layout (top to bottom):
+//
+//	<initflow header — action "LIST", rightLabel "">
+//	<optional scaffolding row, muted>
+//	<per-agent panel + workspace tree/hint stack, alphabetical>
+//	<muted counts footer — agents · skills · workflows · protocols · sensors · routines>
+//
+// When the terminal is below the initflow min-size floor (70×20), the
+// output collapses to RenderMinSizeFloor and nothing else.
+package listflow
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// RenderAll builds the complete `bonsai list` output as a single string.
+// version and projectDir feed the initflow header. termW / termH are the
+// live terminal dims — below the min-size floor, the function short-circuits
+// to RenderMinSizeFloor.
+//
+// cat is consulted for display-name lookups on installed abilities; when
+// nil, callers fall back to DisplayNameFrom (still renders, just without
+// catalog-side overrides).
+func RenderAll(cfg *config.ProjectConfig, cat *catalog.Catalog, version, projectDir string, termW, termH int) string {
+	if initflow.TerminalTooSmall(termW, termH) {
+		return initflow.RenderMinSizeFloor(termW, termH)
+	}
+
+	width := termW
+	if width <= 0 {
+		width = 80
+	}
+
+	var b strings.Builder
+
+	header := initflow.RenderHeader(version, projectDir, "LIST", "", width, initflow.WideCharSafe())
+	b.WriteString(header)
+	b.WriteString("\n\n")
+
+	// Scaffolding row — single muted line above the agent panels. Only
+	// rendered when scaffolding is non-empty; a zero-scaffolding project
+	// collapses straight to the agent section.
+	if cfg != nil && len(cfg.Scaffolding) > 0 {
+		names := make([]string, len(cfg.Scaffolding))
+		for i, s := range cfg.Scaffolding {
+			names[i] = catalog.DisplayNameFrom(s)
+		}
+		muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+		b.WriteString("  " + muted.Render("Scaffolding: "+strings.Join(names, ", ")))
+		b.WriteString("\n\n")
+	}
+
+	// Empty-state short-circuit — when no agents are installed, show the
+	// EmptyPanel CTA + zero counts and stop. Scaffolding may still have
+	// rendered above when the user ran `bonsai init` but hasn't added any
+	// agents yet; that row stays.
+	if cfg == nil || len(cfg.Agents) == 0 {
+		b.WriteString(renderEmptyPanel("No agents installed.\nRun bonsai add to get started."))
+		b.WriteString("\n\n")
+		b.WriteString(renderCountsFooter(0, 0, 0, 0, 0, 0))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	// Per-agent panels — alphabetical by agent name. Panels and trees are
+	// stacked with a blank line between agents for visual breathing room.
+	agentNames := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		agentNames = append(agentNames, name)
+	}
+	sort.Strings(agentNames)
+
+	for i, name := range agentNames {
+		agent := cfg.Agents[name]
+		b.WriteString(RenderAgentPanel(name, agent, cat, projectDir, width))
+		if i < len(agentNames)-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	// Counts footer — aggregate totals across all installed agents.
+	totalSkills, totalWorkflows, totalProtocols, totalSensors, totalRoutines := 0, 0, 0, 0, 0
+	for _, a := range cfg.Agents {
+		totalSkills += len(a.Skills)
+		totalWorkflows += len(a.Workflows)
+		totalProtocols += len(a.Protocols)
+		totalSensors += len(a.Sensors)
+		totalRoutines += len(a.Routines)
+	}
+
+	b.WriteString("\n")
+	b.WriteString(renderCountsFooter(
+		len(cfg.Agents),
+		totalSkills, totalWorkflows, totalProtocols, totalSensors, totalRoutines,
+	))
+	b.WriteString("\n")
+
+	return b.String()
+}
+
+// renderEmptyPanel builds the bordered "no agents installed" panel as a
+// string. Mirrors tui.EmptyPanel's visual (same PanelEmpty style) but
+// returns rather than fmt.Println'ing so it can compose into RenderAll's
+// single-string output. Every line of the rendered panel is indented two
+// columns to match the rail/panel inset used elsewhere in the flow.
+func renderEmptyPanel(msg string) string {
+	rendered := tui.PanelEmpty.Render(msg)
+	lines := strings.Split(rendered, "\n")
+	for i, l := range lines {
+		lines[i] = "  " + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+// renderCountsFooter renders the aggregate footer line. GlyphDot (mid-dot)
+// separates each count; pluralize matches the current cmd/list.go output
+// (no change to wording across the Plan 28 Phase 2 rewrite).
+func renderCountsFooter(agents, skills, workflows, protocols, sensors, routines int) string {
+	muted := lipgloss.NewStyle().Foreground(tui.ColorMuted)
+	parts := []string{
+		pluralize(agents, "agent", "agents"),
+		pluralize(skills, "skill", "skills"),
+		pluralize(workflows, "workflow", "workflows"),
+		pluralize(protocols, "protocol", "protocols"),
+		pluralize(sensors, "sensor", "sensors"),
+		pluralize(routines, "routine", "routines"),
+	}
+	return "  " + muted.Render(strings.Join(parts, " "+tui.GlyphDot+" "))
+}
+
+// pluralize picks singular or plural based on count. Duplicated from
+// cmd/list.go's helper (also kept there for the e2e test). Lifting to a
+// shared package is overkill for a 4-line helper used in two places.
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return fmt.Sprintf("%d %s", n, singular)
+	}
+	return fmt.Sprintf("%d %s", n, plural)
+}

--- a/internal/tui/listflow/listflow_test.go
+++ b/internal/tui/listflow/listflow_test.go
@@ -1,0 +1,170 @@
+package listflow
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui/initflow"
+)
+
+// TestRenderAll_EmptyConfigShowsEmptyState covers case (a): zero agents
+// → empty-state panel + zero counts footer.
+func TestRenderAll_EmptyConfigShowsEmptyState(t *testing.T) {
+	cfg := &config.ProjectConfig{ProjectName: "demo"}
+
+	out := RenderAll(cfg, nil, "0.1.2", t.TempDir(), 120, 40)
+
+	if !strings.Contains(out, "No agents installed") {
+		t.Fatalf("expected empty-state CTA, got:\n%s", out)
+	}
+	if !strings.Contains(out, "bonsai add") {
+		t.Fatalf("expected bonsai add CTA, got:\n%s", out)
+	}
+	if !strings.Contains(out, "0 agents") {
+		t.Fatalf("expected '0 agents' in counts footer, got:\n%s", out)
+	}
+}
+
+// TestRenderAll_OneAgentNoScaffolding covers case (b): one installed
+// agent, no scaffolding — one panel, no scaffolding row.
+func TestRenderAll_OneAgentNoScaffolding(t *testing.T) {
+	projectDir := t.TempDir()
+	ws := filepath.Join(projectDir, "station")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": {
+				AgentType: "tech-lead",
+				Workspace: "station",
+			},
+		},
+	}
+
+	out := RenderAll(cfg, nil, "0.1.2", projectDir, 120, 40)
+
+	if strings.Contains(out, "Scaffolding:") {
+		t.Fatalf("did not expect scaffolding row when cfg.Scaffolding is empty, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Tech Lead") {
+		t.Fatalf("expected Tech Lead panel title, got:\n%s", out)
+	}
+}
+
+// TestRenderAll_AgentsSortedAlphabetically covers case (c): two agents
+// in the config map, rendered in alphabetical order regardless of the
+// map key iteration order. Uses "alpha" and "tech-lead" so the test
+// catches a naive range-over-map ordering bug.
+func TestRenderAll_AgentsSortedAlphabetically(t *testing.T) {
+	projectDir := t.TempDir()
+
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": {AgentType: "tech-lead", Workspace: "station"},
+			"alpha":     {AgentType: "alpha", Workspace: "alpha-ws"},
+		},
+	}
+
+	out := RenderAll(cfg, nil, "0.1.2", projectDir, 120, 40)
+
+	alphaIdx := strings.Index(out, "Alpha")
+	techIdx := strings.Index(out, "Tech Lead")
+	if alphaIdx < 0 || techIdx < 0 {
+		t.Fatalf("expected both panel titles, got:\n%s", out)
+	}
+	if alphaIdx >= techIdx {
+		t.Fatalf("expected 'Alpha' before 'Tech Lead' (alphabetical), got alpha=%d tech=%d:\n%s", alphaIdx, techIdx, out)
+	}
+}
+
+// TestRenderAll_CountsFooterMatchesTotals covers case (d): counts footer
+// reflects the sum across all agents.
+func TestRenderAll_CountsFooterMatchesTotals(t *testing.T) {
+	projectDir := t.TempDir()
+
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo",
+		Agents: map[string]*config.InstalledAgent{
+			"a": {
+				AgentType: "a",
+				Workspace: "ws-a",
+				Skills:    []string{"s1", "s2"},
+				Workflows: []string{"w1"},
+				Protocols: []string{"p1", "p2", "p3"},
+				Sensors:   []string{"sen1"},
+				Routines:  []string{"r1", "r2"},
+			},
+			"b": {
+				AgentType: "b",
+				Workspace: "ws-b",
+				Skills:    []string{"s3"},
+				Workflows: []string{},
+				Protocols: []string{},
+				Sensors:   []string{"sen2", "sen3"},
+				Routines:  []string{},
+			},
+		},
+	}
+
+	out := RenderAll(cfg, nil, "0.1.2", projectDir, 120, 40)
+
+	for _, want := range []string{
+		"2 agents",
+		"3 skills",
+		"1 workflow",
+		"3 protocols",
+		"3 sensors",
+		"2 routines",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in counts footer, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderAll_MinSizeFloor covers case (e): below the 70×20 threshold,
+// the output collapses to RenderMinSizeFloor and nothing else.
+func TestRenderAll_MinSizeFloor(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": {AgentType: "tech-lead", Workspace: "station"},
+		},
+	}
+
+	out := RenderAll(cfg, nil, "0.1.2", t.TempDir(), 40, 10)
+	want := initflow.RenderMinSizeFloor(40, 10)
+
+	if out != want {
+		t.Fatalf("expected min-size floor output exactly, got mismatch\n--- want ---\n%s\n--- got ---\n%s", want, out)
+	}
+	if strings.Contains(out, "No agents installed") {
+		t.Fatalf("min-size floor must suppress agent body; got:\n%s", out)
+	}
+}
+
+// TestRenderAll_ScaffoldingRowRendered covers the scaffolding CTA line.
+// When scaffolding is non-empty, each item renders as its display-name
+// in a single muted row above the agent panels.
+func TestRenderAll_ScaffoldingRowRendered(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo",
+		Scaffolding: []string{"playbook", "logs"},
+	}
+
+	out := RenderAll(cfg, nil, "0.1.2", t.TempDir(), 120, 40)
+
+	if !strings.Contains(out, "Scaffolding:") {
+		t.Fatalf("expected 'Scaffolding:' label, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Playbook") || !strings.Contains(out, "Logs") {
+		t.Fatalf("expected scaffolding display names, got:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `bonsai list`'s flat print output with the cinematic shell shared with `init` / `add` / `catalog`: initflow header (action `LIST`, empty rightLabel), per-agent panels, live workspace file-tree, and counts footer.
- Static render (no BubbleTea) so piped invocations still produce clean non-ANSI output via the existing `tui.DisableColor()` pathway.
- Honour Plan 28 session 2026-04-23 decision deltas: no kanji (D1), 50-entry tree cap with `... (N more)` row (D2), `Workspace missing — run: bonsai update` CTA (D3).
- Harden the workspace walk against symlink loops and `..`-path escapes per the Security block.

### Files added

- `internal/tui/listflow/listflow.go` — `RenderAll` pure-function entry point, empty-state, scaffolding row, counts footer, min-size floor pass-through.
- `internal/tui/listflow/agent_panel.go` — per-agent panel + `filepath.WalkDir` workspace scan with cap / truncation synthetic row, `Workspace missing` CTA, path-escape refusal, symlink no-follow.
- `internal/tui/listflow/fs_helpers.go` — thin `os.Stat` / `filepath.EvalSymlinks` wrappers.
- `internal/tui/listflow/agent_panel_test.go` — 7 cases (missing / empty / under-cap / over-cap / path-escape / symlink-loop / full-pair panel).
- `internal/tui/listflow/listflow_test.go` — 6 cases (empty config / single-agent / sort order / counts totals / min-size floor / scaffolding row).
- `cmd/list_test.go` — E2E happy path (chdir + `.bonsai.yaml` round-trip + `captureStdout` assertion on header / panel / counts / workspace file).

### Files modified

- `cmd/list.go` — rewritten to a single `fmt.Print(listflow.RenderAll(…))` call after `mustCwd` + `requireConfig` + `loadCatalog`. Dropped the per-agent inline TitledPanel / CardFields scattering (lifted to listflow).

**Diff stat:** 7 files, +1125 / -150. **Tests added:** 14.

## Verification

- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass (incl. new listflow + cmd/list_test)
- [x] `gofmt -l .` — no output
- [x] `go vet ./...` — clean
- [x] Manual sanity: `bonsai list` with real project → cinematic output renders; scaffolding row, per-agent panel, workspace tree, counts footer all present.
- [x] Manual: empty agents config → `No agents installed. Run bonsai add to get started.` + zero counts.
- [x] Manual: workspace `../../../etc` → `workspace path escapes project root — tree skipped` warning, no walk.
- [x] Manual: missing workspace dir → `Workspace missing — run: bonsai update` hint.
- [x] Manual: `bonsai list | cat` (non-TTY) → clean ANSI-free output.
- [x] Manual: `bonsai list --no-color` → palette disabled, output still legible.

## Plan reference

`station/Playbook/Plans/Active/28-view-cmds-cinematic.md` — Phase 2 "list cinematic".

## Test plan

- [ ] Reviewer runs `bonsai list` in a real project with ≥ 1 agent and verifies panels + tree.
- [ ] Reviewer pipes `bonsai list > /tmp/out.txt` and confirms clean output.
- [ ] Reviewer runs under a terminal narrower than 70×20 and confirms the min-size floor panel.

---

Draft — do not merge. Phase 3 (`bonsai guide` cinematic) is running in a parallel worktree; trivial to rebase if it lands first (no file overlap).