### PR TITLE
perf+refactor: guide viewer perf + list/catalog/guide polish bundle (Plan 30)

### DIFF
--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -105,3 +105,53 @@ func TestRunList_HappyPath(t *testing.T) {
 		t.Fatalf("expected CLAUDE.md in workspace tree, got:\n%s", stdout)
 	}
 }
+
+// TestRunList_NoAgents covers the zero-agents branch — a project
+// config with an empty Agents map must still render the cinematic
+// LIST header + a 0-agent count + return nil (no panic on the
+// empty-map loop). Mirrors TestRunList_HappyPath's scaffold but
+// swaps in an empty Agents map.
+//
+// The non-TTY fallback case isn't a separate test: captureStdout
+// redirects os.Stdout to a pipe, so runList's `isTerminal(os.Stdout)`
+// check returns false and the happy-path + no-agents tests already
+// exercise the non-TTY render. Mentioned in the PR body.
+func TestRunList_NoAgents(t *testing.T) {
+	setupListTestCatalog(t)
+
+	tmp := t.TempDir()
+	projectDir := filepath.Join(tmp, "demo-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir projectDir: %v", err)
+	}
+
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo-project",
+		Agents:      map[string]*config.InstalledAgent{},
+	}
+	if err := cfg.Save(filepath.Join(projectDir, configFile)); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origCwd) }()
+
+	stdout := captureStdout(t, func() {
+		if err := runList(nil, nil); err != nil {
+			t.Fatalf("runList: %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "LIST") {
+		t.Fatalf("expected 'LIST' in header, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "0 agent") {
+		t.Fatalf("expected '0 agent' count, got:\n%s", stdout)
+	}
+}

--- a/internal/tui/catalogflow/browser.go
+++ b/internal/tui/catalogflow/browser.go
@@ -13,16 +13,17 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
 
-// timeZero returns the zero-value time.Time used for stages that have
-// no session-start anchor (catalog is a single-shot browser — no
-// ELAPSED row to render, so any zero-value is safe).
-func timeZero() time.Time { return time.Time{} }
-
-// category is one of the seven catalog section tabs. The tab's header
-// cell renders as "LABEL (N)" where N counts the filtered entries;
-// filterHidZero is the agent-filter's greyed-out suffix signal (tabs
-// with zero filtered items render with a muted (0) suffix but stay in
-// the tab strip so the user sees what their filter excludes).
+// category is one of the seven catalog section tabs. Fields:
+//
+//   - key         — the stable machine identifier (e.g. "sensors").
+//   - displayName — the uppercase full label rendered in the tab
+//     strip (e.g. "SENSORS"); the narrow-width short form is derived
+//     via shortLabel at render time.
+//   - entries     — the filtered + ordered per-tab Entry list. An
+//     empty slice renders a muted "(0)" count suffix on the tab
+//     strip so the user sees which sections their agent filter
+//     excluded — that presentation rule lives in renderTabs, not on
+//     this struct.
 type category struct {
 	key         string
 	displayName string
@@ -123,7 +124,7 @@ func NewBrowser(cat *catalog.Catalog, agentFilter string, projectDir string) *Br
 		// Zero time — catalog has no elapsed counter. Matches the
 		// initflow precedent (StageContext.StartedAt zero-value is safe
 		// for stages that never render an ELAPSED row).
-		timeZero(),
+		time.Time{},
 	)
 	base.SetRailHidden(true)
 	base.SetHeaderAction("CATALOG")
@@ -136,14 +137,16 @@ func NewBrowser(cat *catalog.Catalog, agentFilter string, projectDir string) *Br
 		categories: categories,
 		catIdx:     0,
 		itemIdx:    itemIdx,
-		expanded:   false,
 	}
 }
 
 // buildCategories walks the seven catalog sections and packs each into
 // the per-tab category shape. Per-section Meta packing:
 //
-//   - Agents: Meta = nil.
+//   - Agents: Meta = {"Kind": "agent"} — surfaces parity with the
+//     other sections' metadata blocks (every entry in this tab IS an
+//     agent; the kind line reads as a deliberate tag rather than the
+//     pre-fix "(no extra metadata)" placeholder).
 //   - Skills / Workflows / Protocols: Meta = nil.
 //   - Sensors: Meta = {"Event": event, "Matcher": matcher} (matcher omitted if empty).
 //   - Routines: Meta = {"Frequency": freq}.
@@ -168,6 +171,7 @@ func buildCategories(cat *catalog.Catalog, agentFilter string) []category {
 				Name:        a.Name,
 				DisplayName: display,
 				Description: a.Description,
+				Meta:        map[string]string{"Kind": "agent"},
 			})
 		}
 		out = append(out, category{key: "agents", displayName: "AGENTS", entries: entries})

--- a/internal/tui/catalogflow/browser_test.go
+++ b/internal/tui/catalogflow/browser_test.go
@@ -356,19 +356,10 @@ func TestBrowser_ZeroCountTabRendersMuted(t *testing.T) {
 	// The SKILLS substring is preceded by the style-open SGR for the
 	// dim.Render call. Grab a window that should include the escape
 	// prefix and assert it contains an ESC + '['.
-	window := strip[maxInt(0, idx-16):idx]
+	window := strip[max(0, idx-16):idx]
 	if !strings.Contains(window, "\x1b[") {
 		t.Fatalf("expected ANSI SGR escape prefixing the muted SKILLS (0) cell; window=%q strip=%q", window, strip)
 	}
-}
-
-// maxInt is a tiny local int-max helper for substring window
-// arithmetic — stdlib math.Max is float-only.
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }
 
 // TestRenderTabs_FullLabelsAtWideWidth verifies that at widths >= 96

--- a/internal/tui/catalogflow/browser_test.go
+++ b/internal/tui/catalogflow/browser_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 
 	"github.com/LastStep/Bonsai/internal/catalog"
 )
@@ -297,6 +298,77 @@ func TestRenderTabs_ShortLabelsAtNarrowWidth(t *testing.T) {
 	if idx := strings.Index(strip, "AGENT"); idx != 0 {
 		t.Fatalf("active tab AGENT should render first in strip, got index %d:\n%s", idx, strip)
 	}
+}
+
+// TestBrowser_ZeroCountTabRendersMuted verifies that a tab whose
+// filtered entry count is zero renders with a muted styling
+// (different ANSI from the active + default-inactive cells). The
+// test forces a truecolor profile so lipgloss emits SGR escapes —
+// by default the Go test env picks the Ascii profile (stdout not a
+// TTY), which would strip all styling and defeat the assertion.
+//
+// Uses an agent filter that yields zero Skills entries (only the
+// "code"-scoped skill exists, and the filter is "tech-lead" with
+// the All-true skill removed from the fake catalog so the Skills
+// tab is forced to (0)).
+func TestBrowser_ZeroCountTabRendersMuted(t *testing.T) {
+	// Force truecolor so lipgloss emits ANSI SGR sequences that the
+	// assertion can find.
+	prev := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(prev) })
+
+	// Build a catalog whose Skills section has only a code-agent
+	// entry so the "tech-lead" filter yields an empty Skills tab.
+	cat := &catalog.Catalog{
+		Agents: []catalog.AgentDef{
+			{Name: "tech-lead", DisplayName: "Tech Lead", Description: "x"},
+		},
+		Skills: []catalog.CatalogItem{
+			{
+				Name: "coding-standards", DisplayName: "Coding Standards",
+				Description: "style", Agents: catalog.AgentCompat{Names: []string{"code"}},
+			},
+		},
+	}
+	s := NewBrowser(cat, "tech-lead", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	strip := s.renderTabs()
+
+	// Skills tab should now render "(0)" — confirm the literal suffix
+	// is present first (sanity check that the test is looking at the
+	// right cell).
+	if !strings.Contains(strip, "(0)") {
+		t.Fatalf("expected '(0)' suffix for empty Skills tab, got:\n%s", strip)
+	}
+
+	// Locate the SKILLS cell in the strip and assert it carries ANSI
+	// SGR escapes (muted styling). The active AGENTS cell at catIdx=0
+	// also has SGR escapes but those encode the active bold+primary
+	// styling — the invariant we're asserting is "(0) cells are
+	// styled distinctly from plain text", which is exactly what the
+	// `dim.Render(label + countSuffix)` branch produces.
+	idx := strings.Index(strip, "SKILLS")
+	if idx < 0 {
+		t.Fatalf("SKILLS tab missing from strip:\n%s", strip)
+	}
+	// The SKILLS substring is preceded by the style-open SGR for the
+	// dim.Render call. Grab a window that should include the escape
+	// prefix and assert it contains an ESC + '['.
+	window := strip[maxInt(0, idx-16):idx]
+	if !strings.Contains(window, "\x1b[") {
+		t.Fatalf("expected ANSI SGR escape prefixing the muted SKILLS (0) cell; window=%q strip=%q", window, strip)
+	}
+}
+
+// maxInt is a tiny local int-max helper for substring window
+// arithmetic — stdlib math.Max is float-only.
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // TestRenderTabs_FullLabelsAtWideWidth verifies that at widths >= 96

--- a/internal/tui/guideflow/guideflow.go
+++ b/internal/tui/guideflow/guideflow.go
@@ -31,10 +31,19 @@ type Topic struct {
 // "quickstart first" entry point.
 var canonicalOrder = []string{"quickstart", "concepts", "cli", "custom-files"}
 
+// deriveLabel produces the default uppercased, hyphen-stripped form
+// used as the fallback for both labelFor and shortFor when a key
+// isn't in the known switch cases. Centralising the derivation
+// keeps the full-label / short-label defaults consistent (shortFor
+// truncates deriveLabel's output, so the two derivations share the
+// same base).
+func deriveLabel(key string) string {
+	return strings.ToUpper(strings.ReplaceAll(key, "-", " "))
+}
+
 // labelFor returns the full-width label for a topic key. Unknown
-// keys fall through to an uppercased, hyphen-stripped form so
-// callers that extend the topic set don't need to edit this file
-// — only the canonicalOrder slice.
+// keys fall through to deriveLabel so callers that extend the topic
+// set don't need to edit this file — only the canonicalOrder slice.
 func labelFor(key string) string {
 	switch key {
 	case "quickstart":
@@ -46,7 +55,7 @@ func labelFor(key string) string {
 	case "custom-files":
 		return "CUSTOM"
 	default:
-		return strings.ToUpper(strings.ReplaceAll(key, "-", " "))
+		return deriveLabel(key)
 	}
 }
 
@@ -64,7 +73,7 @@ func shortFor(key string) string {
 	case "custom-files":
 		return "CUSTM"
 	default:
-		up := labelFor(key)
+		up := deriveLabel(key)
 		if len(up) > 5 {
 			return up[:5]
 		}

--- a/internal/tui/guideflow/render.go
+++ b/internal/tui/guideflow/render.go
@@ -13,22 +13,10 @@ import (
 // a single long line.
 const defaultRenderWidth = 80
 
-// renderMarkdown strips an optional YAML frontmatter block from
-// content (fenced by leading/trailing `---` lines) and renders the
-// remainder through glamour's auto-style terminal renderer.
-//
-// width drives glamour's word-wrap. Values ≤ 0 clamp to
-// defaultRenderWidth so the viewer can call this before the first
-// WindowSizeMsg lands without producing a broken render. Empty
-// content returns an empty string and no error — glamour handles
-// the empty case gracefully and callers (tab cache warmup) benefit
-// from not having to special-case it.
-//
-// This function constructs a fresh renderer on every call — it is
-// kept for the non-TTY one-shot code path (cmd/guide.go renderStatic
-// has its own equivalent) and for unit tests that don't care about
-// renderer reuse. Interactive viewer code should build a renderer
-// once via ViewerStage.rendererFor and call renderMarkdownWith.
+// renderMarkdown strips an optional YAML frontmatter block and renders
+// the remainder through a fresh glamour auto-style renderer. Kept for
+// unit tests that exercise the render pipeline in isolation; the viewer
+// uses renderMarkdownWith with a cached renderer instead.
 func renderMarkdown(content string, width int) (string, error) {
 	if width <= 0 {
 		width = defaultRenderWidth

--- a/internal/tui/guideflow/render.go
+++ b/internal/tui/guideflow/render.go
@@ -23,11 +23,16 @@ const defaultRenderWidth = 80
 // content returns an empty string and no error — glamour handles
 // the empty case gracefully and callers (tab cache warmup) benefit
 // from not having to special-case it.
+//
+// This function constructs a fresh renderer on every call — it is
+// kept for the non-TTY one-shot code path (cmd/guide.go renderStatic
+// has its own equivalent) and for unit tests that don't care about
+// renderer reuse. Interactive viewer code should build a renderer
+// once via ViewerStage.rendererFor and call renderMarkdownWith.
 func renderMarkdown(content string, width int) (string, error) {
 	if width <= 0 {
 		width = defaultRenderWidth
 	}
-	body := stripFrontmatter(content)
 
 	renderer, err := glamour.NewTermRenderer(
 		glamour.WithAutoStyle(),
@@ -36,6 +41,17 @@ func renderMarkdown(content string, width int) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("guideflow: create renderer: %w", err)
 	}
+	return renderMarkdownWith(content, renderer)
+}
+
+// renderMarkdownWith strips the optional YAML frontmatter block
+// from content and renders the remainder through the provided
+// glamour.TermRenderer. Splitting the renderer construction out of
+// the render call is how the interactive viewer amortises the
+// termenv OSC query + goldmark+chroma init across every tab-switch
+// at a given width — see ViewerStage.rendererFor for the cache.
+func renderMarkdownWith(content string, renderer *glamour.TermRenderer) (string, error) {
+	body := stripFrontmatter(content)
 	out, err := renderer.Render(body)
 	if err != nil {
 		return "", fmt.Errorf("guideflow: render markdown: %w", err)

--- a/internal/tui/guideflow/viewer.go
+++ b/internal/tui/guideflow/viewer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/LastStep/Bonsai/internal/tui"
@@ -29,9 +30,19 @@ type ViewerStage struct {
 	idx      int
 	viewport viewport.Model
 	rendered map[string]string // key: "idx:width" → glamour output
-	width    int
-	height   int
-	quit     bool
+	// renderers caches glamour.TermRenderer instances keyed by viewport
+	// width. Building a renderer is expensive (termenv OSC 11 background
+	// query + goldmark + chroma init — typically 100ms+), so we build
+	// once per distinct width and reuse for every tab switch / scroll
+	// at that width. Cache writes happen only on the tea.Update loop.
+	renderers map[int]*glamour.TermRenderer
+	// preWarmedWidth is the width for which preWarmCmd was already
+	// dispatched. Protects against re-dispatching on no-op
+	// WindowSizeMsg (same width, different height).
+	preWarmedWidth int
+	width          int
+	height         int
+	quit           bool
 }
 
 // Tab-label fallback is measurement-driven: renderTabs compares the
@@ -76,11 +87,81 @@ func NewViewer(topics []Topic, initialKey, version, projectDir string) *ViewerSt
 	vp := viewport.New(0, 0)
 
 	return &ViewerStage{
-		Stage:    base,
-		topics:   topics,
-		idx:      idx,
-		viewport: vp,
-		rendered: make(map[string]string),
+		Stage:     base,
+		topics:    topics,
+		idx:       idx,
+		viewport:  vp,
+		rendered:  make(map[string]string),
+		renderers: make(map[int]*glamour.TermRenderer),
+	}
+}
+
+// rendererFor returns the cached glamour.TermRenderer for the given
+// width, building + caching a fresh one if absent. Width ≤ 0 clamps
+// to defaultRenderWidth. Called on the tea.Update loop only — writes
+// to s.renderers are not goroutine-safe.
+func (s *ViewerStage) rendererFor(width int) (*glamour.TermRenderer, error) {
+	if width <= 0 {
+		width = defaultRenderWidth
+	}
+	if r, ok := s.renderers[width]; ok {
+		return r, nil
+	}
+	r, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(width),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("guideflow: create renderer: %w", err)
+	}
+	s.renderers[width] = r
+	return r, nil
+}
+
+// preWarmMsg is the result of a background pre-warm pass. results
+// maps topic idx → rendered markdown string at the given width.
+// Handled in Update where the values are committed to s.rendered on
+// the tea loop (no shared-state races).
+type preWarmMsg struct {
+	width   int
+	results map[int]string
+}
+
+// preWarmCmd returns a tea.Cmd that renders every topic at the given
+// width on a background goroutine and delivers the results as a
+// preWarmMsg. The goroutine constructs its own local renderer so it
+// never touches s.renderers — the cmd is race-free by construction.
+// Renderer construction on the goroutine is one extra build (~100ms)
+// but the tea loop is unblocked for the duration.
+func (s *ViewerStage) preWarmCmd(width int) tea.Cmd {
+	if width <= 0 {
+		width = defaultRenderWidth
+	}
+	// Snapshot topics into a local slice so the goroutine never reads
+	// through s.topics (which is never mutated today but would be a
+	// latent race if that ever changed).
+	topics := make([]Topic, len(s.topics))
+	copy(topics, s.topics)
+	return func() tea.Msg {
+		renderer, err := glamour.NewTermRenderer(
+			glamour.WithAutoStyle(),
+			glamour.WithWordWrap(width),
+		)
+		if err != nil {
+			// Silent drop — the synchronous path will retry on the
+			// tea loop when the user hits a tab. Returning a msg with
+			// empty results is a no-op in the Update handler.
+			return preWarmMsg{width: width, results: map[int]string{}}
+		}
+		results := make(map[int]string, len(topics))
+		for i, t := range topics {
+			body, err := renderMarkdownWith(t.Markdown, renderer)
+			if err != nil {
+				continue
+			}
+			results[i] = body
+		}
+		return preWarmMsg{width: width, results: results}
 	}
 }
 
@@ -105,6 +186,30 @@ func (s *ViewerStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		s.SetSize(m.Width, m.Height)
 		s.resizeViewport()
 		s.refreshViewportContent()
+		// Pre-warm the rest of the topics on first sight of each
+		// distinct viewport width, so subsequent tab-switches hit the
+		// cache and feel instant. Re-dispatch only when the viewport
+		// width actually changes (height-only resizes skip it).
+		vw := s.viewport.Width
+		if vw <= 0 {
+			vw = defaultRenderWidth
+		}
+		if vw != s.preWarmedWidth {
+			s.preWarmedWidth = vw
+			return s, s.preWarmCmd(vw)
+		}
+		return s, nil
+	case preWarmMsg:
+		for idx, body := range m.results {
+			key := fmt.Sprintf("%d:%d", idx, m.width)
+			// Preserve any value already written synchronously for the
+			// current tab (they're identical, but skipping the write
+			// keeps Update idempotent and avoids spurious map churn).
+			if _, ok := s.rendered[key]; ok {
+				continue
+			}
+			s.rendered[key] = body
+		}
 		return s, nil
 	case tea.KeyMsg:
 		switch m.String() {
@@ -257,7 +362,12 @@ func (s *ViewerStage) refreshViewportContent() {
 		s.viewport.SetContent(cached)
 		return
 	}
-	rendered, err := renderMarkdown(s.topics[s.idx].Markdown, w)
+	r, err := s.rendererFor(w)
+	if err != nil {
+		s.viewport.SetContent("Render error: " + err.Error())
+		return
+	}
+	rendered, err := renderMarkdownWith(s.topics[s.idx].Markdown, r)
 	if err != nil {
 		// Surface the render failure inside the viewport itself
 		// so the user sees something rather than a blank pane;

--- a/internal/tui/guideflow/viewer.go
+++ b/internal/tui/guideflow/viewer.go
@@ -67,10 +67,14 @@ func NewViewer(topics []Topic, initialKey, version, projectDir string) *ViewerSt
 		}
 	}
 
+	// Empty label + empty title — the rail is hidden (SetRailHidden
+	// below) and the chromeless viewer has no breadcrumb title slot,
+	// so both fields are unused. Header text comes exclusively from
+	// the SetHeaderAction("GUIDE") call a few lines down.
 	base := initflow.NewStage(
 		0,
-		initflow.StageLabel{English: "GUIDE"},
-		"GUIDE",
+		initflow.StageLabel{},
+		"",
 		version,
 		projectDir,
 		"",
@@ -325,17 +329,20 @@ func (s *ViewerStage) buildTabStrip(useShort bool) string {
 }
 
 // resizeViewport recomputes the viewport dims from the current
-// terminal size. Body area = height minus chrome (header 2 + 2
-// blanks + footer 2) minus tab strip (1 + 1 blank). Floor at 3 so
-// at least a small scroll window is visible on short terminals.
+// terminal size. Body area = height minus chrome (header + footer,
+// both from Stage.ChromeHeights) minus the inter-section blanks
+// rendered by Stage.renderFrame (2 rows) minus the tab strip (1
+// row + 1 blank). Floor at 3 so at least a small scroll window is
+// visible on short terminals.
 func (s *ViewerStage) resizeViewport() {
 	w := initflow.PanelWidth(s.width)
 	if w <= 0 {
 		w = 80
 	}
-	// Chrome: header (2 rows) + 2 blank + footer (2 rows, rule +
-	// brand row) = 6. Tab strip row (1) + 1 blank = 2. Total 8.
-	const chromeRows = 8
+	headerH, footerH := s.ChromeHeights(s.keyHints())
+	// +4 = 2 blank separators around the body (Stage.renderFrame) +
+	// tab strip (1 row) + blank below the tab strip (1 row).
+	chromeRows := headerH + footerH + 4
 	h := s.height - chromeRows
 	if h < 3 {
 		h = 3

--- a/internal/tui/guideflow/viewer_test.go
+++ b/internal/tui/guideflow/viewer_test.go
@@ -370,6 +370,34 @@ func TestViewer_PreWarmPopulatesCache(t *testing.T) {
 	}
 }
 
+// TestViewer_WidthChangeDispatchesPreWarm verifies the pre-warm cmd is
+// re-dispatched only when the viewport width actually changes. Same-
+// width resizes (e.g. height-only) must not spawn a redundant warm
+// pass; distinct widths must. Terminal widths are chosen so
+// initflow.PanelWidth maps them to different viewport widths — 120
+// clamps to 84, 80 collapses to 76.
+func TestViewer_WidthChangeDispatchesPreWarm(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	// First resize — should return a pre-warm cmd (preWarmedWidth was 0).
+	_, cmd1 := s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	if cmd1 == nil {
+		t.Fatalf("expected pre-warm cmd on first WindowSizeMsg, got nil")
+	}
+	// Execute the cmd and feed the result back so the cache populates.
+	msg1 := cmd1()
+	s.Update(msg1)
+	// Second resize — same viewport width — no new pre-warm needed.
+	_, cmd2 := s.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	if cmd2 != nil {
+		t.Fatalf("same-width resize should not redispatch pre-warm, got non-nil cmd")
+	}
+	// Third resize — distinct viewport width — should redispatch.
+	_, cmd3 := s.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	if cmd3 == nil {
+		t.Fatalf("distinct-width resize should redispatch pre-warm, got nil")
+	}
+}
+
 // TestViewer_TabSwitchUsesCachedRenderer verifies a tab switch after
 // the renderer cache is populated does not construct a new renderer.
 // Seeds the renderer cache with the viewport width and asserts the

--- a/internal/tui/guideflow/viewer_test.go
+++ b/internal/tui/guideflow/viewer_test.go
@@ -310,6 +310,84 @@ func TestNewTopics_SkipsMissingKeys(t *testing.T) {
 	}
 }
 
+// TestViewer_RendererCachedPerWidth verifies repeated WindowSizeMsg
+// events at the same viewport width re-use a single
+// *glamour.TermRenderer instance (the cache key is the width, not
+// the msg sequence).
+func TestViewer_RendererCachedPerWidth(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	first := len(s.renderers)
+	if first != 1 {
+		t.Fatalf("len(renderers) after first resize = %d, want 1", first)
+	}
+	// Second resize at the same width — renderer count must stay at 1.
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	if got := len(s.renderers); got != 1 {
+		t.Fatalf("len(renderers) after same-width resize = %d, want 1", got)
+	}
+}
+
+// TestViewer_RendererPerDistinctWidth verifies two WindowSizeMsgs at
+// different widths each build their own renderer — the cache is
+// width-keyed and per-width builds are independent.
+func TestViewer_RendererPerDistinctWidth(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	s.Update(tea.WindowSizeMsg{Width: 80, Height: 40})
+	if got := len(s.renderers); got != 2 {
+		t.Fatalf("len(renderers) after two distinct widths = %d, want 2", got)
+	}
+}
+
+// TestViewer_PreWarmPopulatesCache verifies the pre-warm tea.Cmd
+// returned on first WindowSizeMsg, when executed and its resulting
+// preWarmMsg fed back into Update, populates s.rendered with an
+// entry for every topic idx at that width.
+func TestViewer_PreWarmPopulatesCache(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	_, cmd := s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	if cmd == nil {
+		t.Fatalf("expected preWarmCmd on first WindowSizeMsg, got nil")
+	}
+	msg := cmd()
+	pw, ok := msg.(preWarmMsg)
+	if !ok {
+		t.Fatalf("cmd produced %T, want preWarmMsg", msg)
+	}
+	// Feed the msg back into Update so the results land in s.rendered.
+	s.Update(pw)
+	// Every topic idx should now have a "idx:width" entry.
+	vw := s.viewport.Width
+	if vw <= 0 {
+		vw = defaultRenderWidth
+	}
+	for i := range s.topics {
+		key := fmt.Sprintf("%d:%d", i, vw)
+		if _, ok := s.rendered[key]; !ok {
+			t.Fatalf("expected rendered cache entry for %q after pre-warm", key)
+		}
+	}
+}
+
+// TestViewer_TabSwitchUsesCachedRenderer verifies a tab switch after
+// the renderer cache is populated does not construct a new renderer.
+// Seeds the renderer cache with the viewport width and asserts the
+// map size is unchanged after cycling tabs.
+func TestViewer_TabSwitchUsesCachedRenderer(t *testing.T) {
+	s := NewViewer(fakeTopics(), "", "", "")
+	// Seed the size + renderer cache via an initial resize.
+	s.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	before := len(s.renderers)
+	// Cycle through every tab — none of these should build a renderer.
+	for range s.topics {
+		s.Update(key("right"))
+	}
+	if got := len(s.renderers); got != before {
+		t.Fatalf("len(renderers) after tab cycle = %d, want %d (no new builds)", got, before)
+	}
+}
+
 // TestNewTopics_LabelAndShortPopulated verifies each Topic has both
 // Label and Short set to the expected values.
 func TestNewTopics_LabelAndShortPopulated(t *testing.T) {

--- a/internal/tui/initflow/branches.go
+++ b/internal/tui/initflow/branches.go
@@ -231,7 +231,6 @@ func NewBranchesStage(ctx StageContext, cat *catalog.Catalog, agentDef *catalog.
 		Stage:      base,
 		categories: categories,
 		catIdx:     0,
-		expanded:   false,
 		itemIdx:    itemIdx,
 		selected:   selected,
 	}

--- a/internal/tui/initflow/chrome.go
+++ b/internal/tui/initflow/chrome.go
@@ -2,6 +2,7 @@ package initflow
 
 import (
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -199,8 +200,8 @@ func RenderMinSizeFloor(width, height int) string {
 	title := primary.Render("BONSAI")
 	subtitle := muted.Render("please enlarge your terminal")
 	hint := dim.Render(
-		"minimum " + itoa(MinTerminalWidth) + " × " + itoa(MinTerminalHeight) +
-			"   ·   current " + itoa(width) + " × " + itoa(height),
+		"minimum " + strconv.Itoa(MinTerminalWidth) + " × " + strconv.Itoa(MinTerminalHeight) +
+			"   ·   current " + strconv.Itoa(width) + " × " + strconv.Itoa(height),
 	)
 
 	lines := []string{title, "", subtitle, hint}

--- a/internal/tui/initflow/enso.go
+++ b/internal/tui/initflow/enso.go
@@ -244,4 +244,3 @@ func stageLabelTexts(labels []StageLabel, safe bool, current int) []string {
 	_ = current
 	return out
 }
-

--- a/internal/tui/initflow/enso.go
+++ b/internal/tui/initflow/enso.go
@@ -1,6 +1,7 @@
 package initflow
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -148,7 +149,7 @@ func anchorGlyph(i, current int, labels []StageLabel, safe bool) (string, int) {
 	case i < current:
 		return muted.Render("[") + doneStyle.Render("x") + muted.Render("]"), 3
 	case i == current:
-		return goldStyle.Render("[") + goldStyle.Render(itoa(i+1)) + goldStyle.Render("]"), 3
+		return goldStyle.Render("[") + goldStyle.Render(strconv.Itoa(i+1)) + goldStyle.Render("]"), 3
 	default:
 		return muted.Render("[ ]"), 3
 	}
@@ -244,27 +245,3 @@ func stageLabelTexts(labels []StageLabel, safe bool, current int) []string {
 	return out
 }
 
-// itoa is a tiny stdlib-free int-to-string used only for the ASCII fallback
-// rail where the current stage is rendered as "[N]". Avoids pulling strconv
-// into this file just for one callsite.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var buf [12]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
-}

--- a/internal/tui/initflow/stage.go
+++ b/internal/tui/initflow/stage.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Stage is the shared base type for every init-flow stage (Vessel, Soil,
@@ -176,6 +177,26 @@ func (s *Stage) ClearDone() { s.done = false }
 // unexported renderFrame remains for internal callers.
 func (s *Stage) RenderFrame(body string, keys []KeyHint) string {
 	return s.renderFrame(body, keys)
+}
+
+// ChromeHeights returns the rendered line-heights of the Stage's
+// persistent header and footer at the live terminal width. Sibling
+// packages that compose their own body area (guideflow's viewer,
+// etc.) use this to derive the body row budget from the actual
+// chrome output instead of hard-coding row counts that drift when
+// the chrome layout changes.
+//
+// headerH + footerH is the minimum chrome cost; callers that render
+// a rail or inter-section blank rows add those separately — this
+// method intentionally doesn't know about the caller's layout.
+func (s *Stage) ChromeHeights(keys []KeyHint) (headerH, footerH int) {
+	width := s.width
+	if width <= 0 {
+		width = 80
+	}
+	headerH = lipgloss.Height(RenderHeader(s.version, s.projectDir, s.headerAction, s.headerRightLabel, width, s.ensoSafe))
+	footerH = lipgloss.Height(RenderFooter(keys, width))
+	return
 }
 
 // Title implements harness.Step. Used only if the harness ever had to

--- a/internal/tui/listflow/agent_panel.go
+++ b/internal/tui/listflow/agent_panel.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -216,7 +217,7 @@ func renderWorkspaceBlock(workspace, projectDir string) string {
 		// marker and post-process. We use the post-process route to keep
 		// styling consistent with the rest of the tree.
 		extra := total - maxTreeEntries
-		placeholder := "... (" + itoa(extra) + " more)"
+		placeholder := "... (" + strconv.Itoa(extra) + " more)"
 		entries = append(entries, placeholder)
 	}
 
@@ -361,27 +362,3 @@ func isWithin(target, root string) bool {
 	return !strings.HasPrefix(rel, "..")
 }
 
-// itoa is a tiny strconv.Itoa wrapper kept local so the file avoids a
-// strconv import for a single call site. Mirrors the pattern in
-// initflow/chrome.go.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	var digits [20]byte
-	i := len(digits)
-	for n > 0 {
-		i--
-		digits[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		digits[i] = '-'
-	}
-	return string(digits[i:])
-}

--- a/internal/tui/listflow/agent_panel.go
+++ b/internal/tui/listflow/agent_panel.go
@@ -361,4 +361,3 @@ func isWithin(target, root string) bool {
 	}
 	return !strings.HasPrefix(rel, "..")
 }
-

--- a/internal/tui/listflow/agent_panel_test.go
+++ b/internal/tui/listflow/agent_panel_test.go
@@ -294,6 +294,18 @@ func TestRenderAgentPanel_LegitimateDotDotInName(t *testing.T) {
 	}
 }
 
+// TestRenderWorkspaceBlock_EmptyString locks the defensive contract
+// that a config with workspace="" never panics and always surfaces
+// the same "Workspace missing — run: bonsai update" hint as the
+// missing-directory path. Exercises the early-return branch at the
+// top of renderWorkspaceBlock.
+func TestRenderWorkspaceBlock_EmptyString(t *testing.T) {
+	out := renderWorkspaceBlock("", "/some/project/dir")
+	if !strings.Contains(out, "Workspace missing") {
+		t.Fatalf("expected 'Workspace missing' hint for empty workspace, got:\n%s", out)
+	}
+}
+
 // fmtInt zero-pads n to at least width digits. Avoids pulling strconv in
 // again (already imported above, but we keep this local so if the import
 // slims later the test still compiles).

--- a/station/Playbook/Plans/Active/30-guide-perf-and-view-polish.md
+++ b/station/Playbook/Plans/Active/30-guide-perf-and-view-polish.md
@@ -1,0 +1,207 @@
+---
+Status: Draft — 2026-04-23
+Plan: 30
+Title: Guide viewer perf + list/catalog/guide polish bundle
+Agent: general-purpose
+Tier: 2
+---
+
+# Plan 30 — Guide Viewer Perf + List/Catalog/Guide Polish Bundle
+
+**Tier:** 2
+**Status:** Draft
+**Agent:** general-purpose
+
+## Goal
+
+Make `bonsai guide` tab-switches feel instant (currently 4× slow because `glamour.NewTermRenderer(WithAutoStyle())` runs on every switch — each construction triggers `termenv.HasDarkBackground()` OSC query + goldmark+chroma init). Bundle two previously-filed "batch one-shot" backlog cleanups (Plan-28 Phase 1 NITs for catalog; Plan-28 Phase 2+3 NITs for list + guide) that touch the same three packages.
+
+## Context
+
+- User-visible complaint: *"bonsai guide command is very slow. going across guides at start takes a lot of time. this should be instant."*
+- Current cache in `internal/tui/guideflow/viewer.go:246` (`refreshViewportContent`) is keyed `idx:width` and skips glamour only on **repeat** visits. First visit to each of the 4 tabs pays the full construction cost.
+- Root cause (confirmed from glamour source at `~/go/pkg/mod/github.com/charmbracelet/glamour@v1.0.0/glamour.go:70-99` + `:306-322`):
+  1. `WithAutoStyle()` resolves via `getDefaultStyle(AutoStyle)` → `termenv.HasDarkBackground()` OSC 11 query (100ms+ timeout common).
+  2. `NewTermRenderer` also builds goldmark extensions, ANSI renderer, chroma dependencies each call.
+  3. WordWrap is frozen at construction — a per-width renderer is required, but nothing forces per-topic renderers.
+
+- **Backlog bundling rationale:** Three backlog items all tagged "batch one-shot" and all scoped to the same three packages (`guideflow`, `listflow`, `catalogflow`). Shipping together in one worktree is cheaper than three separate PRs and avoids the worktree-held-branch pattern that has hit 12× this month.
+  - `[Plan-28-cosmetic] Phase 1 review NITs` — catalog: `timeZero()` wrapper, stale `filterHidZero` docstring, redundant zero-value field, Agents details metadata gap, greyed-tab style test gap.
+  - `[Plan-28-cosmetic] Phase 2+3 post-fix NITs` — list: `itoa` duplication, empty-workspace test gap, empty-agents/non-TTY test gap. Guide: `chromeRows` magic constant, `labelFor`/`shortFor` inconsistency, wasted `NewStage` label args.
+
+## Phases
+
+### Phase A — Guide viewer perf (the user's ask)
+
+Two independent changes in `internal/tui/guideflow/`:
+
+**A1. Cache `*glamour.TermRenderer` per width in `ViewerStage`.**
+
+- Add field `renderers map[int]*glamour.TermRenderer` to `ViewerStage` struct (`viewer.go:25-35`), initialised in `NewViewer` alongside `rendered`.
+- New method `(s *ViewerStage) rendererFor(width int) (*glamour.TermRenderer, error)`: returns cached renderer for width or builds+caches a fresh one via `glamour.NewTermRenderer(WithAutoStyle(), WithWordWrap(width))`.
+- `renderMarkdown` in `render.go` **split into two functions**:
+  - Keep `renderMarkdown(content string, width int)` as the existing ctor-and-render one-shot (still used by `cmd/guide.go:78` `renderStatic` non-TTY path — keep that path unchanged).
+  - Add `renderMarkdownWith(content string, renderer *glamour.TermRenderer)` that strips frontmatter and calls `renderer.Render(body)`.
+- `refreshViewportContent` (`viewer.go:246`) swaps the direct `renderMarkdown(..., w)` call for:
+  ```go
+  r, err := s.rendererFor(w)
+  if err != nil { ... }
+  rendered, err := renderMarkdownWith(s.topics[s.idx].Markdown, r)
+  ```
+- **Rationale:** per-width renderer construction moves from O(tabs × widths) to O(widths). On a fixed-size terminal that's **1 construction** for the whole session, and every tab-switch drops to ~1-5ms pure goldmark conversion.
+
+**A2. Pre-warm remaining topics on first `WindowSizeMsg` via `tea.Cmd`.**
+
+- New message type `preWarmMsg struct { width int; results map[int]string }` in `viewer.go`.
+- New method `(s *ViewerStage) preWarmCmd(width int) tea.Cmd`: returns a `tea.Cmd` that, in a goroutine:
+  - Builds/reuses renderer at width via `rendererFor` (safe — renderer cache lookup inside `tea.Cmd` is fine because at this point nothing else races; see note below).
+  - Iterates `s.topics`, renders each into a local `map[int]string` keyed by topic idx, returns `preWarmMsg{width, results}`.
+- `Update` `WindowSizeMsg` branch: after existing `resizeViewport()` + `refreshViewportContent()` calls, if the width changed since last pre-warm, dispatch `s.preWarmCmd(m.Width)` and return it as the tea.Cmd.
+- `Update` handles `preWarmMsg`: for each `(idx, body)` pair, store `s.rendered[fmt.Sprintf("%d:%d", idx, msg.width)] = body`. Do not touch viewport content (current topic already rendered synchronously).
+- **Race concern:** `tea.Cmd` runs on a goroutine; the returned msg lands back on the Update loop (single-threaded). The cmd function must NOT mutate `s.rendered` or `s.renderers` directly — it returns results via the msg and Update writes them. `rendererFor` is called once synchronously in the goroutine for the pre-warm width; add field `renderersMu sync.Mutex` guarding `rendererFor` OR construct a fresh local renderer inside the cmd to avoid the lock (simpler, small cost).
+- **Simpler approach (preferred):** the `preWarmCmd` constructs a fresh `*glamour.TermRenderer` for its width locally (one extra construction on the goroutine), renders all topics, ships them back. Update loop writes results into `s.rendered`. No shared-state mutation from the goroutine. The `rendererFor` cache on the main goroutine stays lock-free.
+
+**A3. Regression tests** (`internal/tui/guideflow/viewer_test.go` — new tests, don't touch existing):
+
+- `TestViewer_RendererCachedPerWidth` — construct viewer, send two WindowSizeMsg with same width, assert `len(s.renderers) == 1` after both.
+- `TestViewer_RendererPerDistinctWidth` — two WindowSizeMsgs with different widths, assert `len(s.renderers) == 2`.
+- `TestViewer_PreWarmPopulatesCache` — construct viewer, send WindowSizeMsg, execute the returned cmd, send the resulting `preWarmMsg` back into Update, assert `s.rendered` has entries for all topic idx values at that width.
+- `TestViewer_TabSwitchUsesCachedRenderer` — seed `s.renderers` with a sentinel, switch tabs, assert no new renderer constructed (len unchanged).
+
+### Phase B — Guide polish (Plan-28 Phase 3 NITs)
+
+**B1. `chromeRows` magic constant → computed from rendered chrome heights.**
+
+- `internal/tui/guideflow/viewer.go:234` — replace `const chromeRows = 8` with:
+  ```go
+  header := initflow.RenderHeader(s.Stage.version(), ..., s.width, s.EnsoSafe())
+  footer := initflow.RenderFooter(s.keyHints(), s.width)
+  chromeRows := lipgloss.Height(header) + lipgloss.Height(footer) + 4 // 2 blank separators + tab strip (1) + blank (1)
+  ```
+  Pattern mirrors `Stage.renderFrame` (`internal/tui/initflow/stage.go:258-259`).
+- **Caveat:** `Stage.version`/`Stage.ensoSafe` are unexported. Options: (a) add a new accessor `Stage.Chrome() (header, footer string)` returning the two pre-rendered strings at current dims, (b) duplicate the render call in `resizeViewport`. Prefer (a) — one new Stage method:
+  ```go
+  func (s *Stage) ChromeHeights(keys []KeyHint) (headerH, footerH int) {
+      width := s.width; if width <= 0 { width = 80 }
+      headerH = lipgloss.Height(RenderHeader(s.version, s.projectDir, s.headerAction, s.headerRightLabel, width, s.ensoSafe))
+      footerH = lipgloss.Height(RenderFooter(keys, width))
+      return
+  }
+  ```
+  In `resizeViewport`:
+  ```go
+  headerH, footerH := s.ChromeHeights(s.keyHints())
+  chromeRows := headerH + footerH + 4
+  ```
+
+**B2. `labelFor`/`shortFor` inconsistency for unknown keys.**
+
+- `internal/tui/guideflow/guideflow.go:48-73` — `labelFor` defaults to `strings.ToUpper(strings.ReplaceAll(key, "-", " "))` (space-separated), `shortFor` defaults to `up[:5]` (raw truncation).
+- Unify the default fallback so both derive from the same base. New private helper `deriveLabel(key string) string` (hyphen→space, uppercase). `shortFor` default becomes `truncate(deriveLabel(key), 5)`.
+- No behaviour change for the 4 known keys (they hit the switch cases before fallback); future additions get consistent fallback.
+
+**B3. Drop wasted `NewStage` label args.**
+
+- `internal/tui/guideflow/viewer.go:59-68` — `NewStage(0, StageLabel{English:"GUIDE"}, "GUIDE", ...)` — both `label` and `title` are superseded by the subsequent `SetHeaderAction("GUIDE")` call and the rail is hidden, so `StageLabel{}` zero-value and `""` title are interchangeable. Change to:
+  ```go
+  base := initflow.NewStage(0, initflow.StageLabel{}, "", version, projectDir, "", "", time.Time{})
+  ```
+  Keep the `SetHeaderAction("GUIDE")` call — that's the one that actually renders. Doc-comment the `StageLabel{}` choice: *"Empty label — rail is hidden, title is unused for chromeless viewers. Header text comes from SetHeaderAction."*
+
+### Phase C — List polish (Plan-28 Phase 2 NITs)
+
+**C1. Dedupe `itoa` helper.**
+
+- `internal/tui/listflow/agent_panel.go:364-387` and `internal/tui/initflow/enso.go:247-270` are near-identical (minor buf-size difference). Neither is hot-path; both exist to avoid a `strconv` import.
+- **Swap both to `strconv.Itoa`.** Justification: `strconv` is a stdlib package, zero-cost import; keeping two copies of a textbook function because "we don't want to import strconv" is a code-smell. `internal/tui/initflow/chrome.go:202-203` also uses `itoa` — swap that too.
+- Call sites:
+  - `listflow/agent_panel.go:219` — `"... (" + strconv.Itoa(extra) + " more)"`
+  - `initflow/chrome.go:202-203` — swap both `itoa(...)` to `strconv.Itoa(...)`
+  - `initflow/enso.go:151` — swap `itoa(i+1)` to `strconv.Itoa(i+1)`
+- Add `"strconv"` import, remove the two `itoa` func defs (listflow/agent_panel.go and initflow/enso.go).
+
+**C2. Empty-workspace defensive-branch test.**
+
+- New test in `internal/tui/listflow/agent_panel_test.go`: `TestRenderWorkspaceBlock_EmptyString` — calls `renderWorkspaceBlock("", "/some/project/dir")`, asserts output contains `"Workspace missing"` string (matches the CTA at line 165). Locks the contract that `workspace: ""` never panics and always emits the same hint as missing-directory.
+
+**C3. Empty-agents + non-TTY e2e for `cmd/list`.**
+
+- New test in `cmd/list_test.go`: `TestRunList_NoAgents` — same scaffold as `TestRunList_HappyPath` but with `cfg.Agents = map[string]*config.InstalledAgent{}`. Asserts output still includes "LIST" header + "0 agents" count + exits without error. Ensures the agent-panel loop doesn't panic on empty input.
+- `TestRunList_NonTTYFallback` — **skip if happy path already covers it** (non-TTY is the default test environment since stdout is redirected via captureStdout). Leave the test gap note in Backlog if cannot be meaningfully added.
+
+### Phase D — Catalog polish (Plan-28 Phase 1 NITs)
+
+**D1. Drop `timeZero()` wrapper.**
+
+- `internal/tui/catalogflow/browser.go:16-19` — delete the `timeZero()` function + its doc comment.
+- `browser.go:126` — replace `timeZero()` call with `time.Time{}`.
+- `time` import stays (it's the `time.Time{}` type itself).
+
+**D2. Fix stale `filterHidZero` docstring.**
+
+- `internal/tui/catalogflow/browser.go:21-30` — the `category` struct docstring references a `filterHidZero` field that doesn't exist. Rewrite the docstring to describe only the real fields (`key`, `displayName`, `entries`) and the "(0)" muted rendering behaviour (which lives in the tab-render code, not on the struct).
+
+**D3. Drop redundant `expanded: false`.**
+
+- `browser.go:139` — delete the `expanded: false,` line in the `BrowserStage` struct literal (zero value is false). `internal/tui/initflow/branches.go:234` has the same pattern — drop there too for consistency.
+
+**D4. Agents section entry metadata.**
+
+- `browser.go:156-174` (`buildCategories` Agents block) — entries get `Meta: map[string]string{"Kind": "agent"}` so the details block renders `KIND: agent` instead of `(no extra metadata)`.
+- Alternatively: keep `(no extra metadata)` — it's accurate. **Decision (ships in the plan):** add `Meta: map[string]string{"Kind": "agent"}` per the NIT suggestion. Surfaces parity with other sections' metadata blocks.
+
+**D5. Greyed-tab style test.**
+
+- New test in `internal/tui/catalogflow/browser_test.go`: `TestBrowser_ZeroCountTabRendersMuted` — build a `BrowserStage` with an agent filter that yields `(0)` in at least one section, render the tab strip, assert the rendered output contains the muted ANSI escape sequence for `tui.ColorMuted` around the `(0)` suffix. Use `lipgloss.NewStyle().Foreground(tui.ColorMuted).Render("(0)")` as the reference substring OR assert the `(0)` cell is styled differently than the active-count cells via raw-ANSI substring comparison.
+
+**D6. Dead-code sweep post-`RenderFrame` routing.**
+
+- Plan 28 Phase 1 MINOR 3 routed the `View()` body through `Stage.RenderFrame`. Check `internal/tui/catalogflow/browser.go` for any remaining body-padding / truncation helpers that are unused now that `RenderFrame` does it. Run `go vet ./...` + manual grep for unreferenced exported funcs in the package. Drop anything unused.
+
+### Phase E — Verification
+
+Run in worktree after all phase commits land:
+
+```bash
+make build
+go test ./...
+./bonsai guide  # manual smoke test — tab through 4 topics, confirm instant switches
+./bonsai list   # manual smoke test — confirm no regressions
+./bonsai catalog # manual smoke test — confirm tab strip behaves
+./bonsai guide quickstart | head # non-TTY path — confirm unchanged static render
+```
+
+All must pass. Any failure is a blocker; fix in the same worktree before PR.
+
+## Dependencies
+
+None. No new Go modules, no schema changes, no cross-package API breaks (the one new exported method `Stage.ChromeHeights` is additive).
+
+## Security
+
+> [!warning]
+> Refer to [Playbook/Standards/SecurityStandards.md](../../Standards/SecurityStandards.md) for all security requirements.
+
+- **No new input surfaces.** All three commands are read-only (`list`, `catalog`, `guide` never write to disk or execute subprocesses). Plan-28 Phase 2's `filepath.Rel`-based escape guards are untouched.
+- **Goroutine safety (Phase A2):** the `preWarmCmd` MUST NOT mutate shared state. It constructs its own renderer locally, returns results as a `tea.Msg`, and Update writes to `s.rendered` on the single-threaded tea loop.
+- **No change to glamour style sourcing.** `WithAutoStyle` remains (terminal bg detection is the right UX).
+
+## Verification
+
+- [ ] `make build` — clean
+- [ ] `go test ./...` — all pass
+- [ ] Phase A tests present and green (4 new tests in `guideflow/viewer_test.go`)
+- [ ] Phase B NIT items resolved (chromeRows computed, labelFor/shortFor consistent, NewStage args trimmed)
+- [ ] Phase C `itoa` removed from both packages, two new tests in list package
+- [ ] Phase D `timeZero` removed, docstring fixed, `expanded: false` removed, Agents Meta added, greyed-tab test added
+- [ ] Manual smoke: `./bonsai guide` tab-switching feels instant (< 50ms perceived)
+- [ ] Manual smoke: `./bonsai guide quickstart | head` static render unchanged (non-TTY fallback)
+- [ ] No new dependencies in `go.mod`
+- [ ] `govulncheck ./...` clean
+- [ ] `golangci-lint run` (or Makefile `lint` target) clean
+
+## Rollback
+
+Single PR. If issues surface post-merge:
+- A1/A2 revert is a pure code swap (per-tab-switch render returns — regression is perf, not correctness).
+- B-D are cosmetic — revert any single phase independently via `git revert <phase-commit>` if it causes unexpected behaviour.


### PR DESCRIPTION
## Summary
Plan 30 — guide viewer perf (cached glamour renderer + pre-warm) + list/catalog/guide polish bundle (Plan-28 NITs).

## Changes
- `internal/tui/guideflow/` — renderer cache + pre-warm + 4 regression tests
- `internal/tui/initflow/` — new `Stage.ChromeHeights` accessor; drop `itoa`; drop `expanded: false`
- `internal/tui/listflow/` — swap to `strconv.Itoa`; new empty-workspace test
- `internal/tui/catalogflow/` — drop `timeZero`, fix docstring, drop `expanded: false`, add `Kind: agent` meta, new greyed-tab style test, dead-code sweep
- `cmd/list_test.go` — new empty-agents test

Non-TTY fallback note (Phase C C3): `TestRunList_NonTTYFallback` is skipped — `captureStdout` redirects os.Stdout to a pipe, so both existing happy-path and the new `TestRunList_NoAgents` tests already hit the non-isTerminal path.

## Plan
station/Playbook/Plans/Active/30-guide-perf-and-view-polish.md

## Verification
- [x] make build — passes
- [x] go test ./... — passes
- [x] ./bonsai guide — tab switches instant (manual smoke)
- [x] ./bonsai list — no regressions (manual smoke)
- [x] ./bonsai catalog — tab strip fine (manual smoke)
- [x] ./bonsai guide quickstart | head — static render unchanged (manual smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)