### PR TITLE
Plan 31 PR1 — correctness + agent-readable foundation

### DIFF
--- a/catalog/agents/tech-lead/agent.yaml
+++ b/catalog/agents/tech-lead/agent.yaml
@@ -7,6 +7,7 @@ defaults:
     - issue-classification
     - dispatch
     - review-checklist
+    - bonsai-model
   workflows:
     - issue-to-implementation
     - planning

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -466,6 +466,12 @@ func buildAddGrowAction(
 			errs = append(errs, generate.PathScopedRulesForAgent(cwd, installedAgent, cfg, cat, lock, wr, false))
 			errs = append(errs, generate.WorkflowSkillsForAgent(cwd, installedAgent, cfg, cat, lock, wr, false))
 			errs = append(errs, generate.SettingsJSONForAgent(cwd, installedAgent, cfg, cat, lock, wr, false))
+			// Plan 31 Phase A: re-render peers' OtherAgents-dependent files so
+			// already-installed agents' scope-guard / dispatch-guard / identity
+			// reflect the newly-augmented agent. No-op on the add-items branch
+			// because cfg.Agents set is unchanged here — but kept for symmetry
+			// and defence in depth; peers' render is a cheap no-diff write.
+			errs = append(errs, generate.RefreshPeerAwareness(cwd, installedAgent.AgentType, cfg, cat, lock, wr, false))
 			if joined := errors.Join(errs...); joined != nil {
 				outcome.SpinnerErr = joined
 				return joined
@@ -518,6 +524,12 @@ func buildAddGrowAction(
 		errs = append(errs, generate.PathScopedRulesForAgent(cwd, installed, cfg, cat, lock, wr, false))
 		errs = append(errs, generate.WorkflowSkillsForAgent(cwd, installed, cfg, cat, lock, wr, false))
 		errs = append(errs, generate.SettingsJSONForAgent(cwd, installed, cfg, cat, lock, wr, false))
+		// Plan 31 Phase A: re-render peers' OtherAgents-dependent files
+		// (identity.md, scope-guard-files.sh, dispatch-guard.sh) so existing
+		// sibling agents pick up the new agent in their awareness lists.
+		// Without this, tech-lead's scope-guard has no block for the newly
+		// added backend/ workspace and silently fails open — see plan §Phase A.
+		errs = append(errs, generate.RefreshPeerAwareness(cwd, installed.AgentType, cfg, cat, lock, wr, false))
 		if joined := errors.Join(errs...); joined != nil {
 			outcome.SpinnerErr = joined
 			return joined

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -472,6 +472,8 @@ func buildAddGrowAction(
 			// because cfg.Agents set is unchanged here — but kept for symmetry
 			// and defence in depth; peers' render is a cheap no-diff write.
 			errs = append(errs, generate.RefreshPeerAwareness(cwd, installedAgent.AgentType, cfg, cat, lock, wr, false))
+			// Plan 31 Phase C: refresh .bonsai/catalog.json snapshot.
+			errs = append(errs, generate.WriteCatalogSnapshot(cwd, Version, cat, wr))
 			if joined := errors.Join(errs...); joined != nil {
 				outcome.SpinnerErr = joined
 				return joined
@@ -530,6 +532,8 @@ func buildAddGrowAction(
 		// Without this, tech-lead's scope-guard has no block for the newly
 		// added backend/ workspace and silently fails open — see plan §Phase A.
 		errs = append(errs, generate.RefreshPeerAwareness(cwd, installed.AgentType, cfg, cat, lock, wr, false))
+		// Plan 31 Phase C: refresh .bonsai/catalog.json snapshot.
+		errs = append(errs, generate.WriteCatalogSnapshot(cwd, Version, cat, wr))
 		if joined := errors.Join(errs...); joined != nil {
 			outcome.SpinnerErr = joined
 			return joined

--- a/cmd/init_flow.go
+++ b/cmd/init_flow.go
@@ -270,6 +270,9 @@ func buildGenerateAction(
 		errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, wr, false))
 		errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, wr, false))
 		errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, wr, false))
+		// Plan 31 Phase C: write .bonsai/catalog.json — filesystem-discoverable
+		// catalog listing for agent consumption (pi-style convention).
+		errs = append(errs, generate.WriteCatalogSnapshot(cwd, Version, cat, wr))
 		return errors.Join(errs...)
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -137,6 +137,8 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 			errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false))
 			errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false))
 			errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false))
+			// Plan 31 Phase C: refresh .bonsai/catalog.json snapshot.
+			errs = append(errs, generate.WriteCatalogSnapshot(cwd, Version, cat, &wr))
 			return errors.Join(errs...)
 		}),
 

--- a/internal/generate/bonsai_reference_test.go
+++ b/internal/generate/bonsai_reference_test.go
@@ -1,0 +1,146 @@
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// buildBonsaiRefTestCatalog creates a minimal catalog adequate for exercising
+// WorkspaceClaudeMD's Bonsai Reference block rendering (Plan 31 Phase D).
+func buildBonsaiRefTestCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"core/memory.md.tmpl":         &fstest.MapFile{Data: []byte("mem")},
+		"core/self-awareness.md":      &fstest.MapFile{Data: []byte("sa")},
+		"core/identity.md.tmpl":       &fstest.MapFile{Data: []byte("id {{ .AgentDisplayName }}")},
+		"agents/tech-lead/agent.yaml": &fstest.MapFile{Data: []byte("name: tech-lead\ndisplay_name: Tech Lead\ndescription: lead\n")},
+		"agents/backend/agent.yaml":   &fstest.MapFile{Data: []byte("name: backend\ndisplay_name: Backend\ndescription: backend\n")},
+	}
+	cat, err := catalog.New(fsys)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	return cat
+}
+
+// TestBonsaiReference_TechLeadWorkspace — for tech-lead, bonsai-model path
+// resolves to "agent/Skills/bonsai-model.md" (workspace-local) and
+// catalog.json resolves to "../.bonsai/catalog.json".
+func TestBonsaiReference_TechLeadWorkspace(t *testing.T) {
+	cat := buildBonsaiRefTestCatalog(t)
+	tmpDir := t.TempDir()
+
+	installed := &config.InstalledAgent{
+		AgentType: "tech-lead",
+		Workspace: "station/",
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "Test",
+		DocsPath:    "station/",
+		Agents:      map[string]*config.InstalledAgent{"tech-lead": installed},
+	}
+	lock := config.NewLockFile()
+	var wr WriteResult
+
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("tech-lead"), installed, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("AgentWorkspace: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "station", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read CLAUDE.md: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "## Bonsai Reference") {
+		t.Errorf("CLAUDE.md missing Bonsai Reference heading:\n%s", content)
+	}
+	// Tech-lead's own workspace-relative path.
+	if !strings.Contains(content, "agent/Skills/bonsai-model.md") {
+		t.Errorf("CLAUDE.md missing bonsai-model path:\n%s", content)
+	}
+	// .bonsai/catalog.json — from station/ to project root's .bonsai/ → ../.bonsai/catalog.json
+	if !strings.Contains(content, "../.bonsai/catalog.json") {
+		t.Errorf("CLAUDE.md missing expected ../.bonsai/catalog.json:\n%s", content)
+	}
+	if !strings.Contains(content, "../.bonsai.yaml") {
+		t.Errorf("CLAUDE.md missing ../.bonsai.yaml:\n%s", content)
+	}
+}
+
+// TestBonsaiReference_NonTechLeadPointsToTechLead — non-tech-lead agents'
+// CLAUDE.md points to tech-lead's workspace for bonsai-model.md.
+func TestBonsaiReference_NonTechLeadPointsToTechLead(t *testing.T) {
+	cat := buildBonsaiRefTestCatalog(t)
+	tmpDir := t.TempDir()
+
+	techLead := &config.InstalledAgent{AgentType: "tech-lead", Workspace: "station/"}
+	backend := &config.InstalledAgent{AgentType: "backend", Workspace: "backend/"}
+	cfg := &config.ProjectConfig{
+		ProjectName: "Test",
+		DocsPath:    "station/",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": techLead,
+			"backend":   backend,
+		},
+	}
+	lock := config.NewLockFile()
+	var wr WriteResult
+
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("backend"), backend, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("backend workspace: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "backend", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read backend/CLAUDE.md: %v", err)
+	}
+	content := string(data)
+
+	// Backend's CLAUDE.md should reference ../station/agent/Skills/bonsai-model.md
+	if !strings.Contains(content, "../station/agent/Skills/bonsai-model.md") {
+		t.Errorf("backend CLAUDE.md missing pointer to tech-lead's bonsai-model:\n%s", content)
+	}
+}
+
+// TestBonsaiReference_OrderedBeforeQuickTriggers — the Bonsai Reference block
+// must come after Core nav table and before Quick Triggers so agents load it
+// in the natural reading order.
+func TestBonsaiReference_OrderedBeforeQuickTriggers(t *testing.T) {
+	cat := buildBonsaiRefTestCatalog(t)
+	tmpDir := t.TempDir()
+
+	installed := &config.InstalledAgent{AgentType: "tech-lead", Workspace: "station/"}
+	cfg := &config.ProjectConfig{
+		ProjectName: "Test",
+		DocsPath:    "station/",
+		Agents:      map[string]*config.InstalledAgent{"tech-lead": installed},
+	}
+	lock := config.NewLockFile()
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("tech-lead"), installed, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "station", "CLAUDE.md"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	content := string(data)
+
+	coreIdx := strings.Index(content, "### Core (load first")
+	bonsaiIdx := strings.Index(content, "## Bonsai Reference")
+	qtIdx := strings.Index(content, "### Quick Triggers")
+	if coreIdx < 0 || bonsaiIdx < 0 || qtIdx < 0 {
+		t.Fatalf("missing one of core/bonsai/quick-triggers: core=%d bonsai=%d qt=%d", coreIdx, bonsaiIdx, qtIdx)
+	}
+	if !(coreIdx < bonsaiIdx && bonsaiIdx < qtIdx) {
+		t.Errorf("order wrong: core=%d bonsai=%d qt=%d (want core < bonsai < qt)", coreIdx, bonsaiIdx, qtIdx)
+	}
+}

--- a/internal/generate/bonsai_reference_test.go
+++ b/internal/generate/bonsai_reference_test.go
@@ -144,3 +144,28 @@ func TestBonsaiReference_OrderedBeforeQuickTriggers(t *testing.T) {
 		t.Errorf("order wrong: core=%d bonsai=%d qt=%d (want core < bonsai < qt)", coreIdx, bonsaiIdx, qtIdx)
 	}
 }
+
+// TestBonsaiReferenceLines_EmptyDocsPathDegrades locks the degrade-don't-
+// crash contract after the empty-DocsPath fallback was removed from
+// bonsaiReferenceLines. cmd/init_flow.go:233 normalises DocsPath to non-
+// empty + trailing "/" before saving cfg, so an empty DocsPath here means
+// an invariant was already broken upstream — the renderer must still
+// produce output (degenerate but non-crashing), not panic.
+func TestBonsaiReferenceLines_EmptyDocsPathDegrades(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		ProjectName: "Test",
+		DocsPath:    "", // violates the init_flow invariant on purpose
+	}
+
+	// Call the unexported helper directly — same contract as via
+	// WorkspaceClaudeMD, without requiring a full template render setup.
+	lines := bonsaiReferenceLines("/proj", "/proj/station", cfg)
+
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "## Bonsai Reference") {
+		t.Errorf("expected Bonsai Reference heading even with empty DocsPath:\n%s", joined)
+	}
+	if !strings.Contains(joined, "bonsai-model.md") {
+		t.Errorf("expected bonsai-model.md row even with empty DocsPath:\n%s", joined)
+	}
+}

--- a/internal/generate/catalog_snapshot.go
+++ b/internal/generate/catalog_snapshot.go
@@ -1,0 +1,214 @@
+package generate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+)
+
+// CatalogSnapshot is the stable JSON shape written to .bonsai/catalog.json.
+// Agent-consumable — provides a filesystem-discoverable listing of every
+// agent/skill/workflow/protocol/sensor/routine that the installed Bonsai
+// binary ships.
+//
+// This shape is deliberately decoupled from the internal catalog types in
+// internal/catalog — those may evolve. The JSON schema here is a stable
+// contract for downstream agent readers.
+type CatalogSnapshot struct {
+	Version   string         `json:"version"`
+	Agents    []AgentEntry   `json:"agents"`
+	Skills    []AbilityEntry `json:"skills"`
+	Workflows []AbilityEntry `json:"workflows"`
+	Protocols []AbilityEntry `json:"protocols"`
+	Sensors   []SensorEntry  `json:"sensors"`
+	Routines  []RoutineEntry `json:"routines"`
+}
+
+// AgentEntry describes an agent type shipped in the catalog.
+type AgentEntry struct {
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+}
+
+// AbilityEntry describes a skill, workflow, or protocol. Agents is the list
+// of agent types the ability is compatible with ("all" or specific names);
+// Required is the subset the ability is forcibly installed on.
+type AbilityEntry struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name"`
+	Description string   `json:"description"`
+	Agents      []string `json:"agents"`
+	Required    []string `json:"required,omitempty"`
+}
+
+// SensorEntry extends AbilityEntry with event + matcher fields unique to sensors.
+type SensorEntry struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name"`
+	Description string   `json:"description"`
+	Agents      []string `json:"agents"`
+	Required    []string `json:"required,omitempty"`
+	Event       string   `json:"event"`
+	Matcher     string   `json:"matcher,omitempty"`
+}
+
+// RoutineEntry extends AbilityEntry with the frequency field.
+type RoutineEntry struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name"`
+	Description string   `json:"description"`
+	Agents      []string `json:"agents"`
+	Required    []string `json:"required,omitempty"`
+	Frequency   string   `json:"frequency"`
+}
+
+// agentsToSlice converts an AgentCompat to a JSON-friendly slice. "all"
+// collapses to ["all"] so readers can branch on either exact-match or
+// presence of the "all" sentinel.
+func agentsToSlice(a catalog.AgentCompat) []string {
+	if a.All {
+		return []string{"all"}
+	}
+	if len(a.Names) == 0 {
+		return []string{}
+	}
+	out := make([]string, len(a.Names))
+	copy(out, a.Names)
+	return out
+}
+
+// requiredToSlice converts an AgentCompat into a slice, returning nil when
+// no agent requires the ability (so the JSON `omitempty` tag drops it).
+func requiredToSlice(a catalog.AgentCompat) []string {
+	if a.All {
+		return []string{"all"}
+	}
+	if len(a.Names) == 0 {
+		return nil
+	}
+	out := make([]string, len(a.Names))
+	copy(out, a.Names)
+	return out
+}
+
+// SerializeCatalog builds a CatalogSnapshot from the in-memory catalog and
+// returns its JSON representation (2-space indented). Single source of truth
+// for both WriteCatalogSnapshot (on-disk) and `bonsai catalog --json` (stdout,
+// PR2).
+func SerializeCatalog(cat *catalog.Catalog, version string) ([]byte, error) {
+	if cat == nil {
+		return nil, fmt.Errorf("nil catalog")
+	}
+	snap := CatalogSnapshot{
+		Version:   version,
+		Agents:    make([]AgentEntry, 0, len(cat.Agents)),
+		Skills:    make([]AbilityEntry, 0, len(cat.Skills)),
+		Workflows: make([]AbilityEntry, 0, len(cat.Workflows)),
+		Protocols: make([]AbilityEntry, 0, len(cat.Protocols)),
+		Sensors:   make([]SensorEntry, 0, len(cat.Sensors)),
+		Routines:  make([]RoutineEntry, 0, len(cat.Routines)),
+	}
+
+	for _, a := range cat.Agents {
+		snap.Agents = append(snap.Agents, AgentEntry{
+			Name:        a.Name,
+			DisplayName: a.DisplayName,
+			Description: a.Description,
+		})
+	}
+	for _, s := range cat.Skills {
+		snap.Skills = append(snap.Skills, AbilityEntry{
+			Name:        s.Name,
+			DisplayName: s.DisplayName,
+			Description: s.Description,
+			Agents:      agentsToSlice(s.Agents),
+			Required:    requiredToSlice(s.Required),
+		})
+	}
+	for _, w := range cat.Workflows {
+		snap.Workflows = append(snap.Workflows, AbilityEntry{
+			Name:        w.Name,
+			DisplayName: w.DisplayName,
+			Description: w.Description,
+			Agents:      agentsToSlice(w.Agents),
+			Required:    requiredToSlice(w.Required),
+		})
+	}
+	for _, p := range cat.Protocols {
+		snap.Protocols = append(snap.Protocols, AbilityEntry{
+			Name:        p.Name,
+			DisplayName: p.DisplayName,
+			Description: p.Description,
+			Agents:      agentsToSlice(p.Agents),
+			Required:    requiredToSlice(p.Required),
+		})
+	}
+	for _, s := range cat.Sensors {
+		snap.Sensors = append(snap.Sensors, SensorEntry{
+			Name:        s.Name,
+			DisplayName: s.DisplayName,
+			Description: s.Description,
+			Agents:      agentsToSlice(s.Agents),
+			Required:    requiredToSlice(s.Required),
+			Event:       s.Event,
+			Matcher:     s.Matcher,
+		})
+	}
+	for _, r := range cat.Routines {
+		snap.Routines = append(snap.Routines, RoutineEntry{
+			Name:        r.Name,
+			DisplayName: r.DisplayName,
+			Description: r.Description,
+			Agents:      agentsToSlice(r.Agents),
+			Required:    requiredToSlice(r.Required),
+			Frequency:   r.Frequency,
+		})
+	}
+
+	return json.MarshalIndent(snap, "", "  ")
+}
+
+// WriteCatalogSnapshot serializes the catalog to .bonsai/catalog.json at the
+// project root. Creates the .bonsai/ directory (mode 0755) if missing. The
+// file is written with mode 0644 and terminated with a trailing newline.
+//
+// NOT lock-tracked — the snapshot is regenerated on every init/add/update
+// and is agent-read-only; no user edits are expected. A path outcome is
+// appended to result (ActionCreated for fresh writes, ActionUpdated when
+// content differed from an existing snapshot, ActionUnchanged otherwise)
+// so callers can display it alongside other generated files.
+func WriteCatalogSnapshot(projectRoot string, version string, cat *catalog.Catalog, result *WriteResult) error {
+	data, err := SerializeCatalog(cat, version)
+	if err != nil {
+		return fmt.Errorf("serialize catalog: %w", err)
+	}
+	data = append(data, '\n')
+
+	bonsaiDir := filepath.Join(projectRoot, ".bonsai")
+	if err := os.MkdirAll(bonsaiDir, 0755); err != nil {
+		return fmt.Errorf("create .bonsai/: %w", err)
+	}
+
+	relPath := filepath.Join(".bonsai", "catalog.json")
+	absPath := filepath.Join(projectRoot, relPath)
+
+	// Short-circuit to Unchanged if the on-disk content already matches.
+	action := ActionCreated
+	if existing, rerr := os.ReadFile(absPath); rerr == nil {
+		if string(existing) == string(data) {
+			result.Add(FileResult{RelPath: relPath, Action: ActionUnchanged, Source: "generated:catalog-snapshot"})
+			return nil
+		}
+		action = ActionUpdated
+	}
+
+	if err := os.WriteFile(absPath, data, 0644); err != nil {
+		return fmt.Errorf("write catalog.json: %w", err)
+	}
+	result.Add(FileResult{RelPath: relPath, Action: action, Source: "generated:catalog-snapshot"})
+	return nil
+}

--- a/internal/generate/catalog_snapshot_test.go
+++ b/internal/generate/catalog_snapshot_test.go
@@ -20,10 +20,10 @@ func buildSnapshotTestCatalog(t *testing.T) *catalog.Catalog {
 		"agents/tech-lead/agent.yaml": &fstest.MapFile{Data: []byte("name: tech-lead\ndisplay_name: Tech Lead\ndescription: orchestrator\n")},
 		"agents/backend/agent.yaml":   &fstest.MapFile{Data: []byte("name: backend\ndisplay_name: Backend\ndescription: backend dev\n")},
 		// Skills
-		"skills/planning-template/meta.yaml":   &fstest.MapFile{Data: []byte("name: planning-template\ndescription: writing plans\nagents:\n  - tech-lead\nrequired:\n  - tech-lead\n")},
-		"skills/planning-template/content.md":  &fstest.MapFile{Data: []byte("content")},
-		"skills/coding-standards/meta.yaml":    &fstest.MapFile{Data: []byte("name: coding-standards\ndescription: code style\nagents: all\n")},
-		"skills/coding-standards/content.md":   &fstest.MapFile{Data: []byte("content")},
+		"skills/planning-template/meta.yaml":  &fstest.MapFile{Data: []byte("name: planning-template\ndescription: writing plans\nagents:\n  - tech-lead\nrequired:\n  - tech-lead\n")},
+		"skills/planning-template/content.md": &fstest.MapFile{Data: []byte("content")},
+		"skills/coding-standards/meta.yaml":   &fstest.MapFile{Data: []byte("name: coding-standards\ndescription: code style\nagents: all\n")},
+		"skills/coding-standards/content.md":  &fstest.MapFile{Data: []byte("content")},
 		// Workflows
 		"workflows/code-review/meta.yaml":  &fstest.MapFile{Data: []byte("name: code-review\ndescription: reviewing code\nagents: all\n")},
 		"workflows/code-review/content.md": &fstest.MapFile{Data: []byte("c")},
@@ -31,10 +31,10 @@ func buildSnapshotTestCatalog(t *testing.T) *catalog.Catalog {
 		"protocols/security/meta.yaml":  &fstest.MapFile{Data: []byte("name: security\ndescription: security protocol\nagents: all\n")},
 		"protocols/security/content.md": &fstest.MapFile{Data: []byte("c")},
 		// Sensors
-		"sensors/scope-guard-files/meta.yaml":         &fstest.MapFile{Data: []byte("name: scope-guard-files\ndescription: scope guard\nevent: PreToolUse\nmatcher: Edit|Write\nagents: all\n")},
+		"sensors/scope-guard-files/meta.yaml":                 &fstest.MapFile{Data: []byte("name: scope-guard-files\ndescription: scope guard\nevent: PreToolUse\nmatcher: Edit|Write\nagents: all\n")},
 		"sensors/scope-guard-files/scope-guard-files.sh.tmpl": &fstest.MapFile{Data: []byte("#!/bin/bash\n")},
 		// Routines
-		"routines/backlog-hygiene/meta.yaml":            &fstest.MapFile{Data: []byte("name: backlog-hygiene\ndescription: groom backlog\nfrequency: 7 days\nagents:\n  - tech-lead\n")},
+		"routines/backlog-hygiene/meta.yaml":               &fstest.MapFile{Data: []byte("name: backlog-hygiene\ndescription: groom backlog\nfrequency: 7 days\nagents:\n  - tech-lead\n")},
 		"routines/backlog-hygiene/backlog-hygiene.md.tmpl": &fstest.MapFile{Data: []byte("c")},
 	}
 	cat, err := catalog.New(fsys)

--- a/internal/generate/catalog_snapshot_test.go
+++ b/internal/generate/catalog_snapshot_test.go
@@ -1,0 +1,202 @@
+package generate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+)
+
+// buildSnapshotTestCatalog returns a small but realistic catalog covering
+// every category so the snapshot test exercises all branches of the
+// serializer.
+func buildSnapshotTestCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	fsys := fstest.MapFS{
+		// Agents
+		"agents/tech-lead/agent.yaml": &fstest.MapFile{Data: []byte("name: tech-lead\ndisplay_name: Tech Lead\ndescription: orchestrator\n")},
+		"agents/backend/agent.yaml":   &fstest.MapFile{Data: []byte("name: backend\ndisplay_name: Backend\ndescription: backend dev\n")},
+		// Skills
+		"skills/planning-template/meta.yaml":   &fstest.MapFile{Data: []byte("name: planning-template\ndescription: writing plans\nagents:\n  - tech-lead\nrequired:\n  - tech-lead\n")},
+		"skills/planning-template/content.md":  &fstest.MapFile{Data: []byte("content")},
+		"skills/coding-standards/meta.yaml":    &fstest.MapFile{Data: []byte("name: coding-standards\ndescription: code style\nagents: all\n")},
+		"skills/coding-standards/content.md":   &fstest.MapFile{Data: []byte("content")},
+		// Workflows
+		"workflows/code-review/meta.yaml":  &fstest.MapFile{Data: []byte("name: code-review\ndescription: reviewing code\nagents: all\n")},
+		"workflows/code-review/content.md": &fstest.MapFile{Data: []byte("c")},
+		// Protocols
+		"protocols/security/meta.yaml":  &fstest.MapFile{Data: []byte("name: security\ndescription: security protocol\nagents: all\n")},
+		"protocols/security/content.md": &fstest.MapFile{Data: []byte("c")},
+		// Sensors
+		"sensors/scope-guard-files/meta.yaml":         &fstest.MapFile{Data: []byte("name: scope-guard-files\ndescription: scope guard\nevent: PreToolUse\nmatcher: Edit|Write\nagents: all\n")},
+		"sensors/scope-guard-files/scope-guard-files.sh.tmpl": &fstest.MapFile{Data: []byte("#!/bin/bash\n")},
+		// Routines
+		"routines/backlog-hygiene/meta.yaml":            &fstest.MapFile{Data: []byte("name: backlog-hygiene\ndescription: groom backlog\nfrequency: 7 days\nagents:\n  - tech-lead\n")},
+		"routines/backlog-hygiene/backlog-hygiene.md.tmpl": &fstest.MapFile{Data: []byte("c")},
+	}
+	cat, err := catalog.New(fsys)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	return cat
+}
+
+// TestWriteCatalogSnapshot_RoundTrip ensures that the written JSON can be
+// round-tripped back into a CatalogSnapshot with all category entries intact.
+func TestWriteCatalogSnapshot_RoundTrip(t *testing.T) {
+	cat := buildSnapshotTestCatalog(t)
+	tmpDir := t.TempDir()
+
+	var wr WriteResult
+	if err := WriteCatalogSnapshot(tmpDir, "test-1.0", cat, &wr); err != nil {
+		t.Fatalf("WriteCatalogSnapshot: %v", err)
+	}
+
+	// File exists under .bonsai/
+	path := filepath.Join(tmpDir, ".bonsai", "catalog.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+
+	var snap CatalogSnapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if snap.Version != "test-1.0" {
+		t.Errorf("version = %q, want test-1.0", snap.Version)
+	}
+
+	// Agents — tech-lead must be present.
+	if !containsAgent(snap.Agents, "tech-lead") {
+		t.Errorf("snap.agents missing tech-lead: %+v", snap.Agents)
+	}
+
+	// Skills — planning-template present with required + agents fields.
+	var planningFound bool
+	for _, s := range snap.Skills {
+		if s.Name == "planning-template" {
+			planningFound = true
+			if len(s.Agents) == 0 || s.Agents[0] != "tech-lead" {
+				t.Errorf("planning-template agents = %v, want [tech-lead]", s.Agents)
+			}
+			if len(s.Required) == 0 || s.Required[0] != "tech-lead" {
+				t.Errorf("planning-template required = %v, want [tech-lead]", s.Required)
+			}
+			break
+		}
+	}
+	if !planningFound {
+		t.Errorf("skills missing planning-template: %+v", snap.Skills)
+	}
+
+	// Routines — backlog-hygiene with frequency populated.
+	var routineFound bool
+	for _, r := range snap.Routines {
+		if r.Name == "backlog-hygiene" {
+			routineFound = true
+			if r.Frequency != "7 days" {
+				t.Errorf("backlog-hygiene frequency = %q, want 7 days", r.Frequency)
+			}
+			break
+		}
+	}
+	if !routineFound {
+		t.Errorf("routines missing backlog-hygiene: %+v", snap.Routines)
+	}
+
+	// Sensor event + matcher populated.
+	var sensorFound bool
+	for _, s := range snap.Sensors {
+		if s.Name == "scope-guard-files" {
+			sensorFound = true
+			if s.Event != "PreToolUse" {
+				t.Errorf("sensor event = %q, want PreToolUse", s.Event)
+			}
+			if s.Matcher != "Edit|Write" {
+				t.Errorf("sensor matcher = %q, want Edit|Write", s.Matcher)
+			}
+			break
+		}
+	}
+	if !sensorFound {
+		t.Errorf("sensors missing scope-guard-files: %+v", snap.Sensors)
+	}
+
+	// WriteResult — should contain one Created action for the snapshot.
+	var snapshotTracked bool
+	for _, f := range wr.Files {
+		if f.RelPath == filepath.Join(".bonsai", "catalog.json") {
+			snapshotTracked = true
+			if f.Action != ActionCreated {
+				t.Errorf("snapshot action = %v, want ActionCreated", f.Action)
+			}
+			break
+		}
+	}
+	if !snapshotTracked {
+		t.Errorf(".bonsai/catalog.json not tracked in WriteResult: %+v", wr.Files)
+	}
+}
+
+// TestWriteCatalogSnapshot_Idempotent — re-writing with identical content
+// emits ActionUnchanged, not another Created/Updated.
+func TestWriteCatalogSnapshot_Idempotent(t *testing.T) {
+	cat := buildSnapshotTestCatalog(t)
+	tmpDir := t.TempDir()
+
+	var wr1 WriteResult
+	if err := WriteCatalogSnapshot(tmpDir, "test-1.0", cat, &wr1); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	var wr2 WriteResult
+	if err := WriteCatalogSnapshot(tmpDir, "test-1.0", cat, &wr2); err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+
+	if len(wr2.Files) != 1 {
+		t.Fatalf("want 1 tracked file, got %d", len(wr2.Files))
+	}
+	if wr2.Files[0].Action != ActionUnchanged {
+		t.Errorf("second write action = %v, want ActionUnchanged", wr2.Files[0].Action)
+	}
+}
+
+// TestWriteCatalogSnapshot_CreatesDir — .bonsai/ dir does not pre-exist; the
+// write call creates it with mode 0755 (parent-observable).
+func TestWriteCatalogSnapshot_CreatesDir(t *testing.T) {
+	cat := buildSnapshotTestCatalog(t)
+	tmpDir := t.TempDir()
+
+	// Sanity: no .bonsai/ yet.
+	if _, err := os.Stat(filepath.Join(tmpDir, ".bonsai")); !os.IsNotExist(err) {
+		t.Fatalf("precondition: .bonsai/ should not exist, err=%v", err)
+	}
+
+	var wr WriteResult
+	if err := WriteCatalogSnapshot(tmpDir, "v1", cat, &wr); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(tmpDir, ".bonsai"))
+	if err != nil {
+		t.Fatalf(".bonsai/ missing after write: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf(".bonsai/ is not a directory")
+	}
+}
+
+func containsAgent(agents []AgentEntry, name string) bool {
+	for _, a := range agents {
+		if a.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -626,6 +626,58 @@ func howToWorkLines(agentName string, docsPrefix string, hasRoutines bool, hasWo
 	return lines
 }
 
+// bonsaiReferenceLines builds the "Bonsai Reference" block rendered after
+// the Core navigation table in every agent's workspace CLAUDE.md. Points to:
+//
+//   - bonsai-model.md — the mental-model skill (tech-lead-only; for non-
+//     tech-lead agents, path resolves into tech-lead's workspace via
+//     cfg.DocsPath, which is tech-lead's workspace by convention).
+//   - .bonsai/catalog.json — filesystem-discoverable catalog snapshot
+//     (written by WriteCatalogSnapshot on every init/add/update).
+//   - .bonsai.yaml — project config (installed-state source of truth).
+//
+// All paths are computed relative to workspaceRoot using filepath.Rel so the
+// block renders correctly from any workspace depth (e.g. "station/" one
+// level deep, or "services/backend/" two levels deep). Plan 31 Phase D.
+func bonsaiReferenceLines(projectRoot, workspaceRoot string, cfg *config.ProjectConfig) []string {
+	// relFromWorkspace resolves a project-root-relative path into one that's
+	// relative to the workspace root (where CLAUDE.md lives). Falls back to
+	// the input if Rel fails — no broken link, just a less-friendly path.
+	relFromWorkspace := func(fromProjectRoot string) string {
+		abs := filepath.Join(projectRoot, fromProjectRoot)
+		rel, err := filepath.Rel(workspaceRoot, abs)
+		if err != nil {
+			return fromProjectRoot
+		}
+		return filepath.ToSlash(rel)
+	}
+
+	// bonsai-model.md lives in the tech-lead workspace (cfg.DocsPath).
+	// For tech-lead itself, DocsPath == installed.Workspace so the path
+	// resolves to "agent/Skills/bonsai-model.md" (same as quick-triggers
+	// refs). For non-tech-lead agents, it resolves to something like
+	// "../station/agent/Skills/bonsai-model.md".
+	docsPath := cfg.DocsPath
+	if docsPath == "" {
+		docsPath = "station/"
+	}
+	bonsaiModelRel := relFromWorkspace(filepath.Join(docsPath, "agent", "Skills", "bonsai-model.md"))
+	catalogJSONRel := relFromWorkspace(filepath.Join(".bonsai", "catalog.json"))
+	bonsaiYAMLRel := relFromWorkspace(".bonsai.yaml")
+
+	return []string{
+		"---", "",
+		"## Bonsai Reference", "",
+		"> Read these when reasoning about Bonsai itself — what catalog items exist, how to customize, what `bonsai add`/`remove`/`update` do.", "",
+		"| Need | Read |",
+		"|------|------|",
+		fmt.Sprintf("| Bonsai mental model — catalog shape, customization, decisions | [%s](%s) |", bonsaiModelRel, bonsaiModelRel),
+		fmt.Sprintf("| Available abilities (all catalog items) | [%s](%s) |", catalogJSONRel, catalogJSONRel),
+		fmt.Sprintf("| Current installed state | [%s](%s) |", bonsaiYAMLRel, bonsaiYAMLRel),
+		"",
+	}
+}
+
 func quickTriggersLines(installed *config.InstalledAgent, cat *catalog.Catalog) []string {
 	var lines []string
 	lines = append(lines,
@@ -688,6 +740,16 @@ func WorkspaceClaudeMD(projectRoot string, workspaceRoot string, agentDef *catal
 		"| [agent/Core/memory.md](agent/Core/memory.md) | Working memory — flags, work state, notes |",
 		"| [agent/Core/self-awareness.md](agent/Core/self-awareness.md) | Context monitoring, hard thresholds |", "",
 	)
+
+	// Bonsai Reference block (Plan 31 Phase D) — pi-style pointer so the
+	// user's agent knows where to find the Bonsai mental model + catalog
+	// snapshot without being hand-fed docs. Every agent points to tech-lead's
+	// copy of bonsai-model.md (the skill is tech-lead-only; project-level
+	// knowledge, not per-agent). Paths are computed relative to the workspace
+	// root (where CLAUDE.md lives) so they resolve correctly from any
+	// workspace depth.
+	bonsaiRefLines := bonsaiReferenceLines(projectRoot, workspaceRoot, cfg)
+	lines = append(lines, bonsaiRefLines...)
 
 	// Quick Triggers reference
 	qt := quickTriggersLines(installed, cat)

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -1494,3 +1494,152 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 	// 8. Workspace CLAUDE.md
 	return WorkspaceClaudeMD(projectRoot, workspaceRoot, agentDef, installed, cfg, cat, lock, result, force)
 }
+
+// buildAgentTemplateContext constructs the TemplateContext used to render
+// OtherAgents-dependent files (identity.md, scope-guard-files.sh,
+// dispatch-guard.sh). Extracted from AgentWorkspace so RefreshPeerAwareness
+// can reuse the exact same build path — the only per-agent variation is the
+// installed ability lists, which the caller passes via agentDef + installed.
+//
+// Deterministic OtherAgents ordering is enforced identically to AgentWorkspace
+// so a render from this path produces bit-identical bytes to the full pipeline
+// for the same (agentDef, installed, cfg) tuple.
+func buildAgentTemplateContext(agentDef *catalog.AgentDef, installed *config.InstalledAgent, cfg *config.ProjectConfig) *TemplateContext {
+	ctx := &TemplateContext{
+		ProjectName:        cfg.ProjectName,
+		ProjectDescription: cfg.Description,
+		AgentName:          agentDef.Name,
+		AgentDisplayName:   agentDef.DisplayName,
+		AgentDescription:   agentDef.Description,
+		Workspace:          installed.Workspace,
+		DocsPath:           cfg.DocsPath,
+		Protocols:          installed.Protocols,
+		Skills:             installed.Skills,
+		Workflows:          installed.Workflows,
+		Routines:           installed.Routines,
+	}
+	for name, a := range cfg.Agents {
+		if name != agentDef.Name {
+			ctx.OtherAgents = append(ctx.OtherAgents, OtherAgent{
+				AgentType: a.AgentType,
+				Workspace: a.Workspace,
+			})
+		}
+	}
+	sort.Slice(ctx.OtherAgents, func(i, j int) bool {
+		return ctx.OtherAgents[i].AgentType < ctx.OtherAgents[j].AgentType
+	})
+	return ctx
+}
+
+// hasAbility reports whether name appears in the haystack. Small helper used
+// by RefreshPeerAwareness to gate per-sensor refreshes on the agent actually
+// having the sensor installed.
+func hasAbility(haystack []string, name string) bool {
+	for _, h := range haystack {
+		if h == name {
+			return true
+		}
+	}
+	return false
+}
+
+// RefreshPeerAwareness re-renders the three OtherAgents-dependent files
+// (identity.md, scope-guard-files.sh, dispatch-guard.sh) for every installed
+// agent EXCEPT the one specified. Called after `bonsai add` so already-
+// installed peers pick up the newly-added agent in their awareness blocks
+// (identity table rows, scope-guard per-peer block entries, dispatch-guard
+// workspace→agent map).
+//
+// Lock-aware via the shared writeFile path — user-edited copies trigger the
+// standard conflict resolver. Agents without scope-guard-files or
+// dispatch-guard installed skip those files silently; identity.md always
+// re-renders because every agent has one (shared catalog/core/ layered with
+// agents/<type>/core/identity.md.tmpl overrides per AgentWorkspace).
+//
+// Per peer, a fresh TemplateContext is built via buildAgentTemplateContext —
+// no context leaks across peers. See Plan 31 Phase A for motivation; without
+// this call sibling peers' OtherAgents lists go stale after `bonsai add` and
+// scope-guard silently fails open on the newly-added workspace.
+func RefreshPeerAwareness(projectRoot string, excludeAgent string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
+	if cfg == nil || cat == nil {
+		return nil
+	}
+	catFS := cat.FS()
+
+	// Deterministic iteration order so test assertions and write-result diffs
+	// do not depend on Go map iteration ordering.
+	peerNames := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		if name == excludeAgent {
+			continue
+		}
+		peerNames = append(peerNames, name)
+	}
+	sort.Strings(peerNames)
+
+	for _, name := range peerNames {
+		peer := cfg.Agents[name]
+		if peer == nil {
+			continue
+		}
+		agentDef := cat.GetAgent(peer.AgentType)
+		if agentDef == nil {
+			continue
+		}
+
+		ctx := buildAgentTemplateContext(agentDef, peer, cfg)
+		workspaceRoot := filepath.Join(projectRoot, peer.Workspace)
+
+		// 1. identity.md — always re-render. Resolve override (agent-specific
+		//    vs shared core) identically to AgentWorkspace so we don't
+		//    accidentally write a stale shared copy when the agent ships its
+		//    own identity template.
+		identitySrc := ""
+		agentIdentity := agentDef.CoreDir + "/identity.md.tmpl"
+		sharedIdentity := catalog.SharedCoreDir + "/identity.md.tmpl"
+		if _, err := fs.Stat(catFS, agentIdentity); err == nil {
+			identitySrc = agentIdentity
+		} else if _, err := fs.Stat(catFS, sharedIdentity); err == nil {
+			identitySrc = sharedIdentity
+		}
+		if identitySrc != "" {
+			content, err := renderContent(catFS, identitySrc, ctx)
+			if err != nil {
+				return fmt.Errorf("refresh identity for %s: %w", name, err)
+			}
+			relPath, _ := filepath.Rel(projectRoot, filepath.Join(workspaceRoot, "agent", "Core", "identity.md"))
+			r := writeFile(projectRoot, relPath, content, "catalog:core/identity.md", lock, force)
+			result.Add(r)
+		}
+
+		// 2. scope-guard-files.sh — only if the peer has it installed.
+		if hasAbility(peer.Sensors, "scope-guard-files") {
+			if sensor := cat.GetSensor("scope-guard-files"); sensor != nil {
+				content, err := renderContent(catFS, sensor.ContentPath, ctx)
+				if err != nil {
+					return fmt.Errorf("refresh scope-guard-files for %s: %w", name, err)
+				}
+				destName := strings.TrimSuffix(filepath.Base(sensor.ContentPath), ".tmpl")
+				relPath, _ := filepath.Rel(projectRoot, filepath.Join(workspaceRoot, "agent", "Sensors", destName))
+				r := writeFileChmod(projectRoot, relPath, content, "catalog:sensors/scope-guard-files", lock, force, 0755)
+				result.Add(r)
+			}
+		}
+
+		// 3. dispatch-guard.sh — only if the peer has it installed.
+		if hasAbility(peer.Sensors, "dispatch-guard") {
+			if sensor := cat.GetSensor("dispatch-guard"); sensor != nil {
+				content, err := renderContent(catFS, sensor.ContentPath, ctx)
+				if err != nil {
+					return fmt.Errorf("refresh dispatch-guard for %s: %w", name, err)
+				}
+				destName := strings.TrimSuffix(filepath.Base(sensor.ContentPath), ".tmpl")
+				relPath, _ := filepath.Rel(projectRoot, filepath.Join(workspaceRoot, "agent", "Sensors", destName))
+				r := writeFileChmod(projectRoot, relPath, content, "catalog:sensors/dispatch-guard", lock, force, 0755)
+				result.Add(r)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -657,11 +657,12 @@ func bonsaiReferenceLines(projectRoot, workspaceRoot string, cfg *config.Project
 	// resolves to "agent/Skills/bonsai-model.md" (same as quick-triggers
 	// refs). For non-tech-lead agents, it resolves to something like
 	// "../station/agent/Skills/bonsai-model.md".
-	docsPath := cfg.DocsPath
-	if docsPath == "" {
-		docsPath = "station/"
-	}
-	bonsaiModelRel := relFromWorkspace(filepath.Join(docsPath, "agent", "Skills", "bonsai-model.md"))
+	//
+	// cmd/init_flow.go:233 enforces non-empty DocsPath (with trailing "/")
+	// before saving cfg, so no fallback needed here — if DocsPath ever is
+	// empty, the path degrades (e.g. "agent/Skills/bonsai-model.md" from the
+	// project root) but does not panic.
+	bonsaiModelRel := relFromWorkspace(filepath.Join(cfg.DocsPath, "agent", "Skills", "bonsai-model.md"))
 	catalogJSONRel := relFromWorkspace(filepath.Join(".bonsai", "catalog.json"))
 	bonsaiYAMLRel := relFromWorkspace(".bonsai.yaml")
 
@@ -1359,29 +1360,17 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 	agentDir := filepath.Join(workspaceRoot, "agent")
 	catFS := cat.FS()
 
-	ctx := &TemplateContext{
-		ProjectName:        cfg.ProjectName,
-		ProjectDescription: cfg.Description,
-		AgentName:          agentDef.Name,
-		AgentDisplayName:   agentDef.DisplayName,
-		AgentDescription:   agentDef.Description,
-	}
-
-	for name, a := range cfg.Agents {
-		if name != agentDef.Name {
-			ctx.OtherAgents = append(ctx.OtherAgents, OtherAgent{
-				AgentType: a.AgentType,
-				Workspace: a.Workspace,
-			})
-		}
-	}
-	// Sort for deterministic template output. Map iteration order is randomised
-	// per process, so without this every re-render of templates that range over
-	// OtherAgents (agent identities, scope-guard, dispatch-guard) emits a
-	// different byte order and the lockfile flags every file as Updated.
-	sort.Slice(ctx.OtherAgents, func(i, j int) bool {
-		return ctx.OtherAgents[i].AgentType < ctx.OtherAgents[j].AgentType
-	})
+	// Single context build shared with RefreshPeerAwareness via
+	// buildAgentTemplateContext. Previously AgentWorkspace maintained two
+	// inline ctx builds (a narrow one for Core templates and a full one for
+	// Skills/Sensors/Routines). That divergence was a correctness trap: if an
+	// identity.md.tmpl started referencing Workspace/DocsPath/Skills/etc. the
+	// initial render (core ctx) and peer refresh (full ctx via
+	// buildAgentTemplateContext) would produce different bytes and flip every
+	// refresh to ActionUpdated. Using the full ctx unconditionally is safe —
+	// Go text/template silently ignores unused fields, so templates that
+	// don't reference the new fields render byte-identical output.
+	ctx := buildAgentTemplateContext(agentDef, installed, cfg)
 
 	// 1. Core files (layered: shared defaults from catalog/core/, agent overrides from agent core/)
 	coreDir := filepath.Join(agentDir, "Core")
@@ -1446,29 +1435,15 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 		result.Add(r)
 	}
 
-	// Full template context — used by skills, sensors, and routines that have .tmpl files
-	fullCtx := &TemplateContext{
-		ProjectName:        cfg.ProjectName,
-		ProjectDescription: cfg.Description,
-		AgentName:          agentDef.Name,
-		AgentDisplayName:   agentDef.DisplayName,
-		AgentDescription:   agentDef.Description,
-		Workspace:          installed.Workspace,
-		DocsPath:           cfg.DocsPath,
-		Protocols:          installed.Protocols,
-		Skills:             installed.Skills,
-		Workflows:          installed.Workflows,
-		Routines:           installed.Routines,
-		OtherAgents:        ctx.OtherAgents,
-	}
-
-	// 2. Skills (rendered through templates if .tmpl, otherwise copied as-is)
+	// 2. Skills (rendered through templates if .tmpl, otherwise copied as-is).
+	// Uses the same ctx as Core — buildAgentTemplateContext already includes
+	// Workspace/DocsPath/Protocols/Skills/Workflows/Routines.
 	for _, skillName := range installed.Skills {
 		item := cat.GetSkill(skillName)
 		if item == nil {
 			continue
 		}
-		content, err := renderContent(catFS, item.ContentPath, fullCtx)
+		content, err := renderContent(catFS, item.ContentPath, ctx)
 		if err != nil {
 			return fmt.Errorf("skill %s: %w", skillName, err)
 		}
@@ -1521,7 +1496,7 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 		if sensor == nil {
 			continue
 		}
-		content, err := renderContent(catFS, sensor.ContentPath, fullCtx)
+		content, err := renderContent(catFS, sensor.ContentPath, ctx)
 		if err != nil {
 			return fmt.Errorf("sensor %s: %w", sensorName, err)
 		}
@@ -1537,7 +1512,7 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 		if routine == nil {
 			continue
 		}
-		content, err := renderContent(catFS, routine.ContentPath, fullCtx)
+		content, err := renderContent(catFS, routine.ContentPath, ctx)
 		if err != nil {
 			return fmt.Errorf("routine %s: %w", routineName, err)
 		}
@@ -1557,15 +1532,15 @@ func AgentWorkspace(projectRoot string, agentDef *catalog.AgentDef, installed *c
 	return WorkspaceClaudeMD(projectRoot, workspaceRoot, agentDef, installed, cfg, cat, lock, result, force)
 }
 
-// buildAgentTemplateContext constructs the TemplateContext used to render
-// OtherAgents-dependent files (identity.md, scope-guard-files.sh,
-// dispatch-guard.sh). Extracted from AgentWorkspace so RefreshPeerAwareness
-// can reuse the exact same build path — the only per-agent variation is the
-// installed ability lists, which the caller passes via agentDef + installed.
+// buildAgentTemplateContext constructs the single TemplateContext used by
+// both AgentWorkspace (initial render) and RefreshPeerAwareness (peer
+// re-render). Single source of truth guarantees both paths produce
+// bit-identical bytes for identical inputs, so lockfile writes on refresh
+// stay at ActionUnchanged when no OtherAgents change has occurred.
 //
-// Deterministic OtherAgents ordering is enforced identically to AgentWorkspace
-// so a render from this path produces bit-identical bytes to the full pipeline
-// for the same (agentDef, installed, cfg) tuple.
+// OtherAgents ordering is deterministic via sort on AgentType; without this
+// Go map iteration would randomise byte output across processes and the
+// lockfile would flag every re-render as Updated.
 func buildAgentTemplateContext(agentDef *catalog.AgentDef, installed *config.InstalledAgent, cfg *config.ProjectConfig) *TemplateContext {
 	ctx := &TemplateContext{
 		ProjectName:        cfg.ProjectName,
@@ -1624,7 +1599,7 @@ func hasAbility(haystack []string, name string) bool {
 // this call sibling peers' OtherAgents lists go stale after `bonsai add` and
 // scope-guard silently fails open on the newly-added workspace.
 func RefreshPeerAwareness(projectRoot string, excludeAgent string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, result *WriteResult, force bool) error {
-	if cfg == nil || cat == nil {
+	if cfg == nil || cat == nil || result == nil {
 		return nil
 	}
 	catFS := cat.FS()

--- a/internal/generate/refresh_peer_awareness_test.go
+++ b/internal/generate/refresh_peer_awareness_test.go
@@ -43,13 +43,13 @@ Peers:
 `
 
 	fsys := fstest.MapFS{
-		"core/memory.md.tmpl":                  &fstest.MapFile{Data: []byte("memory")},
-		"core/self-awareness.md":               &fstest.MapFile{Data: []byte("sa")},
-		"core/identity.md.tmpl":                &fstest.MapFile{Data: []byte(identity)},
-		"agents/lead/agent.yaml":               &fstest.MapFile{Data: []byte("name: lead\ndescription: lead agent\n")},
-		"agents/peer-a/agent.yaml":             &fstest.MapFile{Data: []byte("name: peer-a\ndescription: peer a\n")},
-		"agents/peer-b/agent.yaml":             &fstest.MapFile{Data: []byte("name: peer-b\ndescription: peer b\n")},
-		"sensors/scope-guard-files/meta.yaml":  &fstest.MapFile{Data: []byte("name: scope-guard-files\ndescription: scope guard\nevent: PreToolUse\nmatcher: Edit\nagents: all\n")},
+		"core/memory.md.tmpl":                                 &fstest.MapFile{Data: []byte("memory")},
+		"core/self-awareness.md":                              &fstest.MapFile{Data: []byte("sa")},
+		"core/identity.md.tmpl":                               &fstest.MapFile{Data: []byte(identity)},
+		"agents/lead/agent.yaml":                              &fstest.MapFile{Data: []byte("name: lead\ndescription: lead agent\n")},
+		"agents/peer-a/agent.yaml":                            &fstest.MapFile{Data: []byte("name: peer-a\ndescription: peer a\n")},
+		"agents/peer-b/agent.yaml":                            &fstest.MapFile{Data: []byte("name: peer-b\ndescription: peer b\n")},
+		"sensors/scope-guard-files/meta.yaml":                 &fstest.MapFile{Data: []byte("name: scope-guard-files\ndescription: scope guard\nevent: PreToolUse\nmatcher: Edit\nagents: all\n")},
 		"sensors/scope-guard-files/scope-guard-files.sh.tmpl": &fstest.MapFile{Data: []byte(scopeGuard)},
 		"sensors/dispatch-guard/meta.yaml":                    &fstest.MapFile{Data: []byte("name: dispatch-guard\ndescription: dispatch guard\nevent: PreToolUse\nmatcher: Agent\nagents: all\n")},
 		"sensors/dispatch-guard/dispatch-guard.sh.tmpl":       &fstest.MapFile{Data: []byte(dispatchGuard)},

--- a/internal/generate/refresh_peer_awareness_test.go
+++ b/internal/generate/refresh_peer_awareness_test.go
@@ -265,3 +265,95 @@ func TestRefreshPeerAwareness_TracksInWriteResult(t *testing.T) {
 		}
 	}
 }
+
+// TestRefreshPeerAwareness_NoNewAgentProducesAllUnchanged — mirrors the
+// add-items branch in cmd/add.go where RefreshPeerAwareness is called with
+// excludeAgent set to an already-installed agent (not a newly-added one).
+// Since cfg.Agents is unchanged, every re-rendered file should match the
+// on-disk copy and produce ActionUnchanged. This locks the "cheap no-diff
+// write" contract documented in cmd/add.go:469-474.
+func TestRefreshPeerAwareness_NoNewAgentProducesAllUnchanged(t *testing.T) {
+	cat, cfg, lock, tmpDir := setupPeerFixture(t)
+
+	// Add peer-b through the full pipeline so we have 3 peers on disk all in
+	// mutual awareness sync. After this, a refresh should produce no diffs.
+	peerB := &config.InstalledAgent{
+		AgentType: "peer-b",
+		Workspace: "peer-b/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	cfg.Agents["peer-b"] = peerB
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("peer-b"), peerB, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("peer-b workspace: %v", err)
+	}
+	// Prime lead + peer-a with the post-peer-b awareness so all 3 workspaces
+	// are in sync before the no-op refresh under test.
+	var primeWR WriteResult
+	if err := RefreshPeerAwareness(tmpDir, "peer-b", cfg, cat, lock, &primeWR, false); err != nil {
+		t.Fatalf("prime refresh: %v", err)
+	}
+
+	// Exercise: refresh excluding an already-installed agent (lead) — the
+	// add-items branch behaviour where no new agent was just added.
+	var refreshWR WriteResult
+	if err := RefreshPeerAwareness(tmpDir, "lead", cfg, cat, lock, &refreshWR, false); err != nil {
+		t.Fatalf("RefreshPeerAwareness: %v", err)
+	}
+
+	// Every re-rendered file should be ActionUnchanged (byte-identical) —
+	// no diffs, no conflicts, no updates.
+	for _, f := range refreshWR.Files {
+		if f.Action != ActionUnchanged {
+			t.Errorf("expected ActionUnchanged for %q, got %v", f.RelPath, f.Action)
+		}
+	}
+}
+
+// TestRefreshPeerAwareness_UserEditedPeerFileTriggersConflict — simulates
+// user drift by editing a peer's scope-guard-files.sh on disk WITHOUT
+// updating the lockfile hash. The refresh path should funnel the drift
+// through the same conflict resolver writeFile uses everywhere else and
+// emit an ActionConflict entry for that file.
+func TestRefreshPeerAwareness_UserEditedPeerFileTriggersConflict(t *testing.T) {
+	cat, cfg, lock, tmpDir := setupPeerFixture(t)
+
+	// Add peer-b so there's a reason for the refresh (OtherAgents change).
+	peerB := &config.InstalledAgent{
+		AgentType: "peer-b",
+		Workspace: "peer-b/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	cfg.Agents["peer-b"] = peerB
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("peer-b"), peerB, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("peer-b workspace: %v", err)
+	}
+
+	// Simulate user drift on lead's scope-guard-files.sh — write arbitrary
+	// content to disk, do NOT re-track. IsModified will now return
+	// modified=true because the disk hash no longer matches the lock hash.
+	leadGuardPath := filepath.Join(tmpDir, "station", "agent", "Sensors", "scope-guard-files.sh")
+	if err := os.WriteFile(leadGuardPath, []byte("#!/usr/bin/env bash\n# user edit\n"), 0755); err != nil {
+		t.Fatalf("simulate user edit: %v", err)
+	}
+
+	// Exercise: refresh with the standard non-force path — user drift should
+	// be detected and surface as ActionConflict.
+	var refreshWR WriteResult
+	if err := RefreshPeerAwareness(tmpDir, "peer-b", cfg, cat, lock, &refreshWR, false); err != nil {
+		t.Fatalf("RefreshPeerAwareness: %v", err)
+	}
+
+	leadGuardRel := filepath.Join("station", "agent", "Sensors", "scope-guard-files.sh")
+	var found bool
+	for _, f := range refreshWR.Files {
+		if f.RelPath == leadGuardRel && f.Action == ActionConflict {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ActionConflict for %q in WriteResult, got:\n%+v", leadGuardRel, refreshWR.Files)
+	}
+}

--- a/internal/generate/refresh_peer_awareness_test.go
+++ b/internal/generate/refresh_peer_awareness_test.go
@@ -1,0 +1,267 @@
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// buildPeerTestCatalog creates an in-memory catalog with two agent types
+// (lead, peer-a, peer-b) plus scope-guard-files and dispatch-guard sensors
+// whose templates range over OtherAgents. identity.md.tmpl is shared.
+func buildPeerTestCatalog() (*catalog.Catalog, error) {
+	scopeGuard := `#!/usr/bin/env bash
+# Blocks {{ .AgentDisplayName }} from editing files outside {{ .Workspace }}
+input=$(cat)
+{{ range .OtherAgents }}
+# Block writes to {{ .Workspace }}
+if [[ "$file_path" == *"{{ .Workspace }}"* ]]; then
+  echo "BLOCKED: {{ $.AgentDisplayName }} cannot modify {{ .Workspace }}"
+  exit 2
+fi
+{{ end }}
+exit 0
+`
+	dispatchGuard := `#!/usr/bin/env bash
+# Dispatch guard for {{ .AgentDisplayName }}
+declare -A workspaces
+{{ range .OtherAgents }}
+workspaces["{{ .Workspace }}"]="{{ .AgentType }}"
+{{ end }}
+exit 0
+`
+	identity := `# {{ .AgentDisplayName }}
+Peers:
+{{ range .OtherAgents }}
+- {{ .AgentType }} @ {{ .Workspace }}
+{{ end }}
+`
+
+	fsys := fstest.MapFS{
+		"core/memory.md.tmpl":                  &fstest.MapFile{Data: []byte("memory")},
+		"core/self-awareness.md":               &fstest.MapFile{Data: []byte("sa")},
+		"core/identity.md.tmpl":                &fstest.MapFile{Data: []byte(identity)},
+		"agents/lead/agent.yaml":               &fstest.MapFile{Data: []byte("name: lead\ndescription: lead agent\n")},
+		"agents/peer-a/agent.yaml":             &fstest.MapFile{Data: []byte("name: peer-a\ndescription: peer a\n")},
+		"agents/peer-b/agent.yaml":             &fstest.MapFile{Data: []byte("name: peer-b\ndescription: peer b\n")},
+		"sensors/scope-guard-files/meta.yaml":  &fstest.MapFile{Data: []byte("name: scope-guard-files\ndescription: scope guard\nevent: PreToolUse\nmatcher: Edit\nagents: all\n")},
+		"sensors/scope-guard-files/scope-guard-files.sh.tmpl": &fstest.MapFile{Data: []byte(scopeGuard)},
+		"sensors/dispatch-guard/meta.yaml":                    &fstest.MapFile{Data: []byte("name: dispatch-guard\ndescription: dispatch guard\nevent: PreToolUse\nmatcher: Agent\nagents: all\n")},
+		"sensors/dispatch-guard/dispatch-guard.sh.tmpl":       &fstest.MapFile{Data: []byte(dispatchGuard)},
+	}
+	return catalog.New(fsys)
+}
+
+// setupPeerFixture installs two agents (lead + peer-a) through the full
+// AgentWorkspace pipeline so the filesystem reflects a real multi-agent
+// project. Returns the catalog, cfg, lock, and tmpDir for test bodies.
+func setupPeerFixture(t *testing.T) (*catalog.Catalog, *config.ProjectConfig, *config.LockFile, string) {
+	t.Helper()
+	cat, err := buildPeerTestCatalog()
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	tmpDir := t.TempDir()
+
+	lead := &config.InstalledAgent{
+		AgentType: "lead",
+		Workspace: "station/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	peerA := &config.InstalledAgent{
+		AgentType: "peer-a",
+		Workspace: "peer-a/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "Test",
+		Agents: map[string]*config.InstalledAgent{
+			"lead":   lead,
+			"peer-a": peerA,
+		},
+	}
+	lock := config.NewLockFile()
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("lead"), lead, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("lead workspace: %v", err)
+	}
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("peer-a"), peerA, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("peer-a workspace: %v", err)
+	}
+	return cat, cfg, lock, tmpDir
+}
+
+// TestRefreshPeerAwareness_UpdatesSiblingScopeGuard — install lead + peer-a,
+// then add peer-b to cfg and call Refresh excluding peer-b. Asserts the lead
+// and peer-a scope-guard scripts now reference peer-b's workspace.
+func TestRefreshPeerAwareness_UpdatesSiblingScopeGuard(t *testing.T) {
+	cat, cfg, lock, tmpDir := setupPeerFixture(t)
+
+	// Simulate `bonsai add peer-b`: register in cfg, run AgentWorkspace for it,
+	// then call Refresh. Before the refresh, lead's scope-guard does NOT yet
+	// reference peer-b/ (because AgentWorkspace only renders peer-b's own files).
+	peerB := &config.InstalledAgent{
+		AgentType: "peer-b",
+		Workspace: "peer-b/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	cfg.Agents["peer-b"] = peerB
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("peer-b"), peerB, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("peer-b workspace: %v", err)
+	}
+
+	// Sanity: lead's scope-guard currently references peer-a/ but NOT peer-b/.
+	leadGuardPath := filepath.Join(tmpDir, "station", "agent", "Sensors", "scope-guard-files.sh")
+	before, err := os.ReadFile(leadGuardPath)
+	if err != nil {
+		t.Fatalf("read lead guard: %v", err)
+	}
+	if !strings.Contains(string(before), "peer-a/") {
+		t.Fatalf("lead guard should reference peer-a/ before refresh: %s", before)
+	}
+	if strings.Contains(string(before), "peer-b/") {
+		t.Fatalf("lead guard should NOT reference peer-b/ before refresh: %s", before)
+	}
+
+	// Exercise: Refresh peers (excluding peer-b — the newly-added agent).
+	if err := RefreshPeerAwareness(tmpDir, "peer-b", cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("RefreshPeerAwareness: %v", err)
+	}
+
+	after, err := os.ReadFile(leadGuardPath)
+	if err != nil {
+		t.Fatalf("read lead guard after: %v", err)
+	}
+	if !strings.Contains(string(after), "peer-b/") {
+		t.Errorf("lead guard missing peer-b/ after refresh: %s", after)
+	}
+
+	peerAGuardPath := filepath.Join(tmpDir, "peer-a", "agent", "Sensors", "scope-guard-files.sh")
+	peerAAfter, err := os.ReadFile(peerAGuardPath)
+	if err != nil {
+		t.Fatalf("read peer-a guard: %v", err)
+	}
+	if !strings.Contains(string(peerAAfter), "peer-b/") {
+		t.Errorf("peer-a guard missing peer-b/ after refresh: %s", peerAAfter)
+	}
+}
+
+// TestRefreshPeerAwareness_SkipsExcludedAgent — the excluded agent's files
+// are NOT touched by the refresh pass. Verifies by checking WriteResult does
+// not include any entries under the excluded workspace.
+func TestRefreshPeerAwareness_SkipsExcludedAgent(t *testing.T) {
+	cat, cfg, lock, tmpDir := setupPeerFixture(t)
+
+	peerB := &config.InstalledAgent{
+		AgentType: "peer-b",
+		Workspace: "peer-b/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	cfg.Agents["peer-b"] = peerB
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("peer-b"), peerB, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("peer-b workspace: %v", err)
+	}
+
+	var refreshWR WriteResult
+	if err := RefreshPeerAwareness(tmpDir, "peer-b", cfg, cat, lock, &refreshWR, false); err != nil {
+		t.Fatalf("RefreshPeerAwareness: %v", err)
+	}
+
+	for _, f := range refreshWR.Files {
+		if strings.HasPrefix(f.RelPath, "peer-b/") {
+			t.Errorf("excluded agent should not appear in refresh WriteResult: %q", f.RelPath)
+		}
+	}
+}
+
+// TestRefreshPeerAwareness_SkipsAgentsMissingSensor — a peer without
+// dispatch-guard installed does not crash or emit a FileResult for that sensor.
+func TestRefreshPeerAwareness_SkipsAgentsMissingSensor(t *testing.T) {
+	cat, err := buildPeerTestCatalog()
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	tmpDir := t.TempDir()
+
+	// peer-a has scope-guard-files but NOT dispatch-guard.
+	lead := &config.InstalledAgent{
+		AgentType: "lead",
+		Workspace: "station/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	peerA := &config.InstalledAgent{
+		AgentType: "peer-a",
+		Workspace: "peer-a/",
+		Sensors:   []string{"scope-guard-files"}, // no dispatch-guard
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "Test",
+		Agents: map[string]*config.InstalledAgent{
+			"lead":   lead,
+			"peer-a": peerA,
+		},
+	}
+	lock := config.NewLockFile()
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("lead"), lead, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("lead: %v", err)
+	}
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("peer-a"), peerA, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("peer-a: %v", err)
+	}
+
+	var refreshWR WriteResult
+	if err := RefreshPeerAwareness(tmpDir, "lead", cfg, cat, lock, &refreshWR, false); err != nil {
+		t.Fatalf("RefreshPeerAwareness: %v", err)
+	}
+
+	// Peer-a should have its identity.md + scope-guard refreshed but NOT a
+	// dispatch-guard file — that sensor was never installed.
+	peerADispatchPath := filepath.Join("peer-a", "agent", "Sensors", "dispatch-guard.sh")
+	for _, f := range refreshWR.Files {
+		if f.RelPath == peerADispatchPath {
+			t.Errorf("peer-a should not have dispatch-guard refreshed (not installed): %+v", f)
+		}
+	}
+}
+
+// TestRefreshPeerAwareness_TracksInWriteResult — refreshed files appear in
+// result.Files with an Updated/Unchanged/Created action (not conflict).
+func TestRefreshPeerAwareness_TracksInWriteResult(t *testing.T) {
+	cat, cfg, lock, tmpDir := setupPeerFixture(t)
+
+	// Add peer-b so lead/peer-a see fresh OtherAgents.
+	peerB := &config.InstalledAgent{
+		AgentType: "peer-b",
+		Workspace: "peer-b/",
+		Sensors:   []string{"scope-guard-files", "dispatch-guard"},
+	}
+	cfg.Agents["peer-b"] = peerB
+	var wr WriteResult
+	if err := AgentWorkspace(tmpDir, cat.GetAgent("peer-b"), peerB, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("peer-b: %v", err)
+	}
+
+	var refreshWR WriteResult
+	if err := RefreshPeerAwareness(tmpDir, "peer-b", cfg, cat, lock, &refreshWR, false); err != nil {
+		t.Fatalf("RefreshPeerAwareness: %v", err)
+	}
+
+	// We expect refreshes for lead + peer-a. Each has 3 files: identity.md,
+	// scope-guard-files.sh, dispatch-guard.sh = 6 total entries.
+	if len(refreshWR.Files) != 6 {
+		t.Errorf("expected 6 file results, got %d: %+v", len(refreshWR.Files), refreshWR.Files)
+	}
+	for _, f := range refreshWR.Files {
+		if f.Action == ActionConflict {
+			t.Errorf("unexpected conflict on unmodified refresh: %+v", f)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Plan 31 PR1 — four phases landing v0.3 correctness + agent-readable groundwork. Per-phase commit in this branch.

### Phase A — Peer-Awareness Silent Refresh (correctness bug fix)

Silent correctness bug: `bonsai add` only re-rendered the newly-added agent's workspace, leaving already-installed peers' `OtherAgents`-dependent files (`identity.md`, `scope-guard-files.sh`, `dispatch-guard.sh`) stale. After `bonsai add backend`, tech-lead's scope-guard had no `# Block writes to backend/` entry and silently failed open.

- New `generate.RefreshPeerAwareness` re-renders the three affected files for every installed agent except the newly-added one.
- Lock-aware via the existing `writeFile` path — user-edited copies still trigger the conflict resolver.
- Called from both `cmd/add.go` branches (add-items + new-agent).
- 4 unit tests covering sibling refresh, excluded-agent isolation, missing-sensor skip, WriteResult tracking.

### Phase B — `bonsai-model` Skill Registration

- Adds `bonsai-model` to `catalog/agents/tech-lead/agent.yaml` `defaults.skills`.
- Skill content already committed pre-PR at `catalog/skills/bonsai-model/`.
- Agent-scoped to `tech-lead` only — other agent types reference via `{{ .DocsPath }}agent/Skills/bonsai-model.md`.

### Phase C — `.bonsai/catalog.json` On-Disk Snapshot

Filesystem-discoverable catalog listing — agent can read available abilities without invoking CLI. Pi-style convention.

- `internal/generate/catalog_snapshot.go`: stable JSON schema decoupled from internal catalog types. `SerializeCatalog` is the single source of truth (reused by `bonsai catalog --json` in PR2). `WriteCatalogSnapshot` creates `.bonsai/` with 0755 and writes `catalog.json` with 0644, idempotent.
- Called from `cmd/init_flow.go`, both `cmd/add.go` branches, `cmd/update.go` after existing `generate.*` calls.
- 3 unit tests: round-trip, idempotency, directory creation.

### Phase D — Generated CLAUDE.md "Bonsai Reference" Block

Pi-style pointer block in every agent's workspace `CLAUDE.md`, rendered between Core nav and Quick Triggers.

- New `bonsaiReferenceLines` helper in `internal/generate/generate.go`.
- Paths computed relative to the workspace root via `filepath.Rel` so they resolve from any workspace depth.
- 3 unit tests: tech-lead self-reference, non-tech-lead cross-reference (`../station/agent/Skills/bonsai-model.md`), ordering invariant.

## Commits

1. `d4c8f92` — plan-31 phase-a: fix peer-awareness staleness on bonsai add
2. `17700fc` — plan-31 phase-b: register bonsai-model as tech-lead default skill
3. `d72a195` — plan-31 phase-c: write .bonsai/catalog.json snapshot on init/add/update
4. `5c78232` — plan-31 phase-d: add Bonsai Reference block to generated CLAUDE.md

## Files Changed

- `cmd/add.go`, `cmd/init_flow.go`, `cmd/update.go` — call sites
- `catalog/agents/tech-lead/agent.yaml` — default skill registration
- `internal/generate/generate.go` — RefreshPeerAwareness, buildAgentTemplateContext, bonsaiReferenceLines; WorkspaceClaudeMD splice
- `internal/generate/catalog_snapshot.go` — new (CatalogSnapshot + SerializeCatalog + WriteCatalogSnapshot)
- 3 new test files (10 tests total)

## Test plan

- [x] `make build` green
- [x] `go test ./...` green (all previous tests + 10 new)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] End-to-end smoke exercised via an internal throwaway test: fresh init → `.bonsai/catalog.json` valid JSON + `station/CLAUDE.md` has Bonsai Reference + `bonsai-model.md` installed; `add backend` → tech-lead scope-guard lists `backend/`; `add devops` → both tech-lead AND backend scope-guards list `devops/`.
- [ ] 6 CI checks (test/lint/Analyze-Go/govulncheck/CodeQL/GitGuardian)

🤖 Generated with [Claude Code](https://claude.com/claude-code)