### PR TITLE
feat(cmd): add explicit `completion` subcommand for bash/zsh/fish/powershell (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,36 @@ sudo mv bonsai /usr/local/bin/
 go install github.com/LastStep/Bonsai/cmd/bonsai@latest
 ```
 
+### Shell completion
+
+Generate completion scripts with `bonsai completion [bash|zsh|fish|powershell]`.
+
+**Bash:**
+
+```bash
+# current session
+source <(bonsai completion bash)
+# persist (Linux)
+bonsai completion bash > /etc/bash_completion.d/bonsai
+# persist (macOS, Homebrew bash-completion)
+bonsai completion bash > $(brew --prefix)/etc/bash_completion.d/bonsai
+```
+
+**Zsh:**
+
+```bash
+# current session
+source <(bonsai completion zsh)
+# persist (with `autoload -U compinit && compinit` in ~/.zshrc)
+bonsai completion zsh > "${fpath[1]}/_bonsai"
+```
+
+**Fish:**
+
+```bash
+bonsai completion fish > ~/.config/fish/completions/bonsai.fish
+```
+
 ---
 
 ## Quick Start

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	// Replace Cobra's auto-generated `completion` command with an
+	// explicit one so the help text names the install snippets and
+	// the subcommand shows up in `bonsai --help`. The hide flag in
+	// root.go init() must stay in sync — without it, both this
+	// command and the auto-generated one would register, and Cobra
+	// rejects duplicate child names at startup.
+	rootCmd.AddCommand(completionCmd)
+}
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion script",
+	Long: `Generate shell completion script for bonsai.
+
+To enable completions for the current shell session, source the script
+directly. To make completions persistent, append the script to your
+shell's startup file or drop it in the location your shell scans for
+completion modules.
+
+Bash:
+  $ source <(bonsai completion bash)
+  # persist:
+  $ bonsai completion bash > /etc/bash_completion.d/bonsai           # Linux
+  $ bonsai completion bash > $(brew --prefix)/etc/bash_completion.d/bonsai  # macOS
+
+Zsh:
+  $ source <(bonsai completion zsh)
+  # persist (with completions enabled, e.g. via 'autoload -U compinit && compinit'):
+  $ bonsai completion zsh > "${fpath[1]}/_bonsai"
+
+Fish:
+  $ bonsai completion fish | source
+  # persist:
+  $ bonsai completion fish > ~/.config/fish/completions/bonsai.fish
+
+PowerShell:
+  PS> bonsai completion powershell | Out-String | Invoke-Expression
+  # persist: append the same line to your $PROFILE.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,9 +37,11 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().Bool("no-color", false, "Disable colored output")
-	// Hide Cobra's auto-generated `completion` subcommand from `bonsai --help`.
-	// The command remains functional for users who invoke it directly.
-	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+	// The explicit `completion` command lives in cmd/completion.go and
+	// supersedes Cobra's auto-generated one. DisableDefaultCmd suppresses
+	// the auto-generated default so AddCommand("completion") in
+	// completion.go is the only registered child with that name.
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }
 
 func loadCatalog() *catalog.Catalog {


### PR DESCRIPTION
Closes #54.

Adds \`cmd/completion.go\` with an explicit \`bonsai completion [bash|zsh|fish|powershell]\` subcommand. The \`Long\` help names the install snippets per shell so users can copy-paste without leaving the terminal.

Switched \`root.go\` from \`CompletionOptions.HiddenDefaultCmd\` to \`DisableDefaultCmd\` so the auto-generated completion command does not register at all — otherwise \`AddCommand(\"completion\")\` in \`completion.go\` would conflict with it. README \"Install\" gains a \"Shell completion\" subsection mirroring the per-shell install snippets.

Out of scope per the issue: completion handlers for \`bonsai add <skill>\` ability-name arguments — that needs a follow-up issue.

### Verified

- \`go build ./...\` + \`go vet ./...\` clean
- \`go test ./cmd/...\` (21 passed)
- \`./bonsai --help\` lists \`completion\` between \`catalog\` and \`guide\`
- \`./bonsai completion bash | head\` prints a valid completion script
- \`./bonsai completion --help\` shows the per-shell install snippets