### PR TITLE
Plan 33 — website concept-page rewrite

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
       plugins: [
         starlightLlmsTxt({
           projectName: 'Bonsai',
-          description: `Bonsai is a CLI tool for scaffolding Claude Code agent workspaces. It generates structured instruction files — identity, memory, protocols, skills, workflows, sensors, and routines — so AI agents work like teammates, not tools.`,
+          description: `Bonsai is a CLI tool that generates Claude Code agent workspaces. It writes a workspace under station/ plus per-agent workspaces, wires Claude Code hooks (SessionStart, PreToolUse, Stop) to enforce scope and inject context, and tracks generated files with content hashes so user edits are never silently overwritten.`,
           details: `- Install: \`go install github.com/LastStep/Bonsai@latest\` or \`brew install LastStep/tap/bonsai\`
 - 6 agent types: tech-lead, backend, frontend, fullstack, devops, security
 - Abilities are modular: skills (reference), workflows (multi-step), protocols (rules), sensors (hooks), routines (periodic)`,

--- a/website/src/content/docs/concepts/how-bonsai-works.mdx
+++ b/website/src/content/docs/concepts/how-bonsai-works.mdx
@@ -1,36 +1,33 @@
 ---
 title: How Bonsai Works
-description: The mental model — stations, agents, the instruction stack, and how everything connects.
+description: What bonsai init generates, how the pieces fit together, and how the Tech Lead orchestrates code agents.
 ---
 
 import { FileTree, Aside } from '@astrojs/starlight/components';
 
-Bonsai is a **generator**, not a runtime. It runs once to set up the instruction layer that Claude Code agents read when they work in your project. After that, the agents operate using the files it created.
+Bonsai is a CLI generator, not a runtime. It runs once to write a workspace under `station/` plus per-agent workspaces, then Claude Code agents read those files via hooks at session start and during tool use.
 
-| Generated layer | Purpose |
-|:----------------|:--------|
-| **Identity + Memory** | Who the agent is, what it remembers from last session |
-| **Protocols** | Hard rules — security, scope boundaries, startup sequence |
-| **Workflows** | Step-by-step procedures — planning, code review, reporting |
-| **Skills** | Domain knowledge — coding standards, API design, auth patterns |
-| **Sensors** | Shell scripts wired into Claude Code hooks — auto-enforce boundaries |
-| **Routines** | Periodic maintenance with a tracked dashboard (Tech Lead only) |
-| **Scaffolding** | Shared docs — status tracker, roadmap, plans, decision log, reports |
+## What `bonsai init` generates
+
+| Generated artifact | What it does |
+|:-------------------|:-------------|
+| `agent/Core/identity.md` + `agent/Core/memory.md` | Who the agent is and what it carries forward between sessions |
+| `agent/Protocols/` (`security.md`, `scope-boundaries.md`, `session-start.md`) | Hard rules read at the top of every session |
+| `agent/Workflows/` | Step-by-step procedures (planning, code review, PR review, audits) loaded on demand |
+| `agent/Skills/` | Domain knowledge (standards, checklists, templates) referenced during work |
+| `agent/Sensors/*.sh` | Shell scripts wired into Claude Code hooks (`SessionStart`, `PreToolUse`, `Stop`) |
+| `agent/Routines/` + `agent/Core/routines.md` | Periodic maintenance procedures with a tracked dashboard (Tech Lead only) |
+| `station/Playbook/`, `station/Logs/`, `station/Reports/` | Shared scaffolding — status, roadmap, plans, decisions, reports — referenced by every agent |
 
 <Aside>
-Claude Code agents are only as good as the instructions they have access to. Bonsai gives them a structured, layered instruction set so they behave consistently, stay in scope, and coordinate with each other.
+Every generated file is tracked in `.bonsai-lock.yaml` with a content hash. Re-running `bonsai init` or `bonsai add` detects user edits and prompts before overwriting them.
 </Aside>
 
-## The Station
+## The station
 
-Every Bonsai project has a **station** — a single directory (default `station/`) that serves as the command center. It contains:
+`station/` is the Tech Lead's workspace and the shared scaffolding every code agent's plans, status, and decisions reference. Code agents (backend, frontend, devops, security) get their own `<agent>/` workspaces, but they all link back to `station/Playbook/Status.md`, `station/Playbook/Plans/Active/`, and `station/Logs/KeyDecisionLog.md` so coordination lives in one place under version control.
 
-- **Project scaffolding** — status tracker, roadmap, plans, logs, reports
-- **Tech Lead agent** — the primary agent that orchestrates everything
-
-The station is where all coordination happens. Code agents (backend, frontend, etc.) get their own separate workspaces, but they all reference the station for plans, status, and standards.
-
-## The Instruction Stack
+## The instruction stack
 
 Each agent's instructions are layered, from foundational to automated:
 
@@ -43,18 +40,13 @@ Each agent's instructions are layered, from foundational to automated:
   Layer 1 │ Core          │ Identity + memory + self-awareness
 ```
 
-| Layer | Loaded when | Can override? |
-|:------|:-----------|:-------------|
-| **Core** | Every session, first thing | No — this is the foundation |
-| **Protocols** | Every session, via startup | No — non-negotiable rules |
-| **Workflows** | When performing a specific task | Agent follows the procedure |
-| **Skills** | Referenced as needed during work | Knowledge, not instructions |
-| **Routines** | Flagged at session start if overdue | Tech Lead runs on request |
-| **Sensors** | Automatically, on Claude Code events | Agent can't bypass them |
+<Aside>
+Layers exist because they load at different times. Core and Protocols load every session via the `session-context` sensor on `SessionStart` — identity, memory, and the non-negotiable rules are always in scope. Workflows and Skills are pulled in on demand when the agent starts a matching task. Sensors fire automatically on Claude Code tool-use events: `PreToolUse` to block writes outside an agent's workspace, `PostToolUse` to checklist a dispatched agent's output, `Stop` to refresh the status bar after every reply.
+</Aside>
 
-## How It Works
+## How it works
 
-`bonsai init` sets up the station with the Tech Lead. You talk to the Tech Lead; it plans, orchestrates, and reviews. Code agents execute.
+`bonsai init` sets up the station with the Tech Lead. You talk to the Tech Lead; it plans, dispatches, and reviews. Code agents execute.
 
 ```
   You (human)
@@ -73,9 +65,9 @@ The Tech Lead **never writes application code**. It creates plans, dispatches th
 You don't have to go through the Tech Lead for everything. Quick fixes and small tasks work fine directly with a code agent. The Tech Lead shines when work needs planning, coordination, or cross-agent review.
 </Aside>
 
-## What Gets Generated
+## What gets generated
 
-After `bonsai init` + `bonsai add` (backend agent):
+After `bonsai init` followed by `bonsai add backend`:
 
 <FileTree>
 

--- a/website/src/content/docs/why-bonsai.mdx
+++ b/website/src/content/docs/why-bonsai.mdx
@@ -1,19 +1,19 @@
 ---
 title: Why Bonsai
-description: The problem Bonsai solves and how it structures agent instructions as a layered system.
+description: What problem Bonsai solves and what it gives your coding agent that a single CLAUDE.md doesn't.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';
 
-## The Problem
+## The problem
 
-Claude Code is powerful out of the box. But the moment you need agents to **coordinate**, **stay consistent across sessions**, or **follow your team's standards** — you're writing walls of markdown by hand. Every project rediscovers the same patterns: identity files, memory protocols, security rules, scope boundaries, review checklists.
+Claude Code out of the box gets you a smart assistant. The moment you want it to (a) pick up where it left off last week, (b) stay inside scope across sessions, or (c) follow your team's standards without re-briefing every time — a single `CLAUDE.md` hits its ceiling. You end up writing walls of markdown by hand and rediscovering the same patterns in every project: identity files, memory protocols, security rules, scope boundaries, review checklists.
 
-And if you want multiple agents working in the same codebase? You're maintaining parallel instruction sets that drift apart.
+And once multiple agents are working in the same codebase, the parallel instruction sets drift apart — backend's plan template doesn't match frontend's, security's review checklist doesn't match the Tech Lead's, and there's no shared source of truth for what "done" looks like.
 
-## What Bonsai Does
+## What Bonsai gives you
 
-Bonsai gives your coding agent a **workspace** — not a pile of markdown files, but a layered system with clear semantics:
+Bonsai generates a workspace under `station/` plus per-agent workspaces, plus the Claude Code hook wiring that enforces them.
 
 ```
   Layer 6 │ Sensors       │ Automated enforcement via Claude Code hooks
@@ -24,20 +24,18 @@ Bonsai gives your coding agent a **workspace** — not a pile of markdown files,
   Layer 1 │ Core          │ Identity, memory, self-awareness
 ```
 
-You pick the components. Bonsai generates a complete, wired-up workspace — with cross-linked navigation, auto-enforced hooks, and a shared project scaffold that keeps every agent on the same page.
+The mechanisms underneath: a `SessionStart` hook injects identity, memory, active plans, and overdue routines before the agent's first reply; `PreToolUse` scope guards block edits outside an agent's workspace at the tool call; `.bonsai-lock.yaml` tracks every generated file with a content hash so user edits are never silently overwritten; protocols and standards live in version-controlled markdown so changes show up in `git log` instead of vanishing into a prompt.
 
-One binary. No runtime. Works with any project.
-
-## Who It's For
+## Who it's for
 
 <CardGrid>
   <Card title="Solo developers" icon="laptop">
-    Want your Claude Code agent to behave consistently, remember context between sessions, and follow project-specific standards.
+    Want their agent to remember context across sessions, follow project standards, and stay inside scope without re-briefing.
   </Card>
   <Card title="Teams" icon="group">
-    Coordinating multiple agents across a codebase — backend, frontend, devops — with a shared source of truth.
+    Coordinating multiple agents (backend, frontend, devops) across one codebase — with shared plans, status, and standards in version control.
   </Card>
   <Card title="Anyone tired of copy-pasting" icon="document">
-    Stop copying agent instructions between projects. Bonsai generates everything from a catalog of battle-tested components.
+    Stop copying agent instructions between projects. Bonsai generates a workspace from a catalog you pick from.
   </Card>
 </CardGrid>


### PR DESCRIPTION
## Summary

Plan 33 — website concept-page rewrite. Pivots `concepts/how-bonsai-works.mdx`, `why-bonsai.mdx`, and the `starlightLlmsTxt` LLM description away from the remaining "structured language / structured instruction files" framing left over from pre-v0.2.0 docs. Voice now matches the README's audience-first mechanism-led register established in Plan 25. Copy-only PR, zero code change.

> Plan was originally numbered 32 and renumbered to 33 mid-session due to a plan-number collision with a parallel session's `32-followup-bundle.md` (Go code review-followup bundle). Scopes are file-disjoint — both can ship in parallel without conflict.

## Changes

- `website/src/content/docs/concepts/how-bonsai-works.mdx` — full rewrite per Plan 33 Step 1 (7 sections, preserved all JSX components + FileTree).
- `website/src/content/docs/why-bonsai.mdx` — body rewrite per Plan 33 Step 2 (3 sections, preserved CardGrid + Card components).
- `website/astro.config.mjs` — single-field rewrite of `starlightLlmsTxt` `description:` per Plan 33 Step 3.

## Plan

`station/Playbook/Plans/Active/33-website-concept-page-rewrite.md`

## Verification

- [x] `cd website && npm run build` — exits 0, no broken-link warnings (45 pages, starlight-links-validator clean)
- [x] Banned-phrase grep returns zero matches across the 3 files
- [x] `git diff --name-status origin/main...HEAD` shows exactly the 3 expected paths, all `M` (no adds, no deletes)
