### PR TITLE
Plan 32 — wsvalidate extract + config validate + snapshot hardening

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LastStep/Bonsai/internal/tui/harness"
 	"github.com/LastStep/Bonsai/internal/tui/hints"
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
+	"github.com/LastStep/Bonsai/internal/wsvalidate"
 )
 
 func init() {
@@ -503,7 +504,7 @@ func buildAddGrowAction(
 		// lead overrides — its Ground stage auto-completed with DocsPath.
 		workspace, _ := prev[1].(string)
 		if workspace == "" {
-			workspace = addflow.NormaliseWorkspace(agentType + "/")
+			workspace = wsvalidate.Normalise(agentType + "/")
 		}
 		if agentType == "tech-lead" {
 			workspace = cfg.DocsPath

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,10 +1,21 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
+	"github.com/LastStep/Bonsai/internal/wsvalidate"
 	"gopkg.in/yaml.v3"
 )
+
+// forbiddenShellChars is the deny-list of characters that must never appear
+// in user-controlled strings emitted into shell scripts (sensor templates,
+// status-bar prompts, etc.). The set is intentionally small and explicit —
+// quote/backtick/dollar enable command substitution, backslash + newline
+// break out of single-line contexts, and the bracket/paren pairs guard
+// against array/process-substitution surprises in bash.
+var forbiddenShellChars = []rune{'"', '`', '$', '\\', '\n', ']', ')', '[', '('}
 
 // CustomItemMeta holds metadata for user-created custom items (parsed from frontmatter).
 type CustomItemMeta struct {
@@ -36,6 +47,73 @@ type ProjectConfig struct {
 	Agents      map[string]*InstalledAgent `yaml:"agents,omitempty"`
 }
 
+// Validate checks the project config for required fields, valid workspace
+// paths, and the absence of shell metacharacters in user-controlled strings.
+// Run after YAML unmarshalling so callers fail fast on hand-edited configs.
+//
+// Workspace + DocsPath are validated through wsvalidate (same rules as the
+// init/add TUI flows). The shell-metachar scan covers ProjectName, every
+// agent name (map key), every agent.Workspace, and DocsPath — these strings
+// flow into shell scripts via sensor templates, so a stray `"` or `$` would
+// either break the script or open a substitution channel.
+func (c *ProjectConfig) Validate() error {
+	if c.ProjectName == "" {
+		return errors.New("project_name is required")
+	}
+
+	for name, agent := range c.Agents {
+		if agent == nil {
+			continue
+		}
+		ws := wsvalidate.Normalise(agent.Workspace)
+		if reason := wsvalidate.InvalidReason(ws); reason != "" {
+			return fmt.Errorf("agent %q: workspace %q invalid: %s", name, agent.Workspace, reason)
+		}
+	}
+
+	if c.DocsPath != "" {
+		dp := wsvalidate.Normalise(c.DocsPath)
+		if reason := wsvalidate.InvalidReason(dp); reason != "" {
+			return fmt.Errorf("docs_path %q invalid: %s", c.DocsPath, reason)
+		}
+	}
+
+	if err := scanShellMetachars("project_name", c.ProjectName); err != nil {
+		return err
+	}
+	for name, agent := range c.Agents {
+		if err := scanShellMetachars("agent name", name); err != nil {
+			return err
+		}
+		if agent == nil {
+			continue
+		}
+		if err := scanShellMetachars(fmt.Sprintf("agent %q workspace", name), agent.Workspace); err != nil {
+			return err
+		}
+	}
+	if c.DocsPath != "" {
+		if err := scanShellMetachars("docs_path", c.DocsPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// scanShellMetachars returns an error on the first forbidden rune in v.
+// Field is the human-readable label included in the error message so the
+// caller can pinpoint which YAML key tripped the check.
+func scanShellMetachars(field, v string) error {
+	for _, r := range v {
+		for _, bad := range forbiddenShellChars {
+			if r == bad {
+				return fmt.Errorf("field %q contains forbidden character %q", field, string(r))
+			}
+		}
+	}
+	return nil
+}
+
 // Save writes the config to a YAML file.
 func (c *ProjectConfig) Save(path string) error {
 	data, err := yaml.Marshal(c)
@@ -57,6 +135,9 @@ func Load(path string) (*ProjectConfig, error) {
 	}
 	if cfg.Agents == nil {
 		cfg.Agents = make(map[string]*InstalledAgent)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("validate config: %w", err)
 	}
 	return &cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidate_OK checks that a well-formed config passes validation. Acts
+// as a baseline so regressions in the Validate rules surface immediately.
+func TestValidate_OK(t *testing.T) {
+	cfg := &ProjectConfig{
+		ProjectName: "demo",
+		DocsPath:    "docs",
+		Agents: map[string]*InstalledAgent{
+			"tech-lead": {AgentType: "tech-lead", Workspace: "station"},
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// TestValidate_RequiresProjectName — empty project_name is the most common
+// hand-edit mistake; check it errors with a stable message.
+func TestValidate_RequiresProjectName(t *testing.T) {
+	cfg := &ProjectConfig{}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate: want error for empty project_name, got nil")
+	}
+	if !strings.Contains(err.Error(), "project_name is required") {
+		t.Errorf("error = %q, want substring %q", err.Error(), "project_name is required")
+	}
+}
+
+// TestValidate_BadWorkspace_AbsolutePath — absolute workspace paths are
+// rejected and the agent name appears in the message so the caller knows
+// which agent stanza tripped the check.
+func TestValidate_BadWorkspace_AbsolutePath(t *testing.T) {
+	cfg := &ProjectConfig{
+		ProjectName: "demo",
+		Agents: map[string]*InstalledAgent{
+			"backend": {AgentType: "backend", Workspace: "/abs/path"},
+		},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate: want error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "backend") {
+		t.Errorf("error = %q, expected agent name 'backend'", msg)
+	}
+	if !strings.Contains(msg, "/abs/path") {
+		t.Errorf("error = %q, expected workspace value", msg)
+	}
+}
+
+// TestValidate_BadDocsPath — DocsPath uses the same wsvalidate rules; ".."
+// must escape detection.
+func TestValidate_BadDocsPath(t *testing.T) {
+	cfg := &ProjectConfig{
+		ProjectName: "demo",
+		DocsPath:    "..",
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "docs_path") {
+		t.Errorf("error = %q, expected docs_path mention", err.Error())
+	}
+}
+
+// TestValidate_ShellMetacharsInProjectName — table-driven scan of every
+// forbidden rune. Each must produce an error referencing the field and
+// the offending character.
+func TestValidate_ShellMetacharsInProjectName(t *testing.T) {
+	cases := []struct {
+		name string
+		ch   string
+	}{
+		{"double-quote", `"`},
+		{"backtick", "`"},
+		{"dollar", "$"},
+		{"backslash", `\`},
+		{"newline", "\n"},
+		{"close-bracket", "]"},
+		{"close-paren", ")"},
+		{"open-bracket", "["},
+		{"open-paren", "("},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &ProjectConfig{ProjectName: "demo" + tc.ch + "x"}
+			err := cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate: want error for %q, got nil", tc.ch)
+			}
+			if !strings.Contains(err.Error(), "project_name") {
+				t.Errorf("error = %q, expected field name 'project_name'", err.Error())
+			}
+		})
+	}
+}

--- a/internal/generate/catalog_snapshot.go
+++ b/internal/generate/catalog_snapshot.go
@@ -66,29 +66,19 @@ type RoutineEntry struct {
 	Frequency   string   `json:"frequency"`
 }
 
-// agentsToSlice converts an AgentCompat to a JSON-friendly slice. "all"
-// collapses to ["all"] so readers can branch on either exact-match or
-// presence of the "all" sentinel.
-func agentsToSlice(a catalog.AgentCompat) []string {
+// compatToSlice converts an AgentCompat into a JSON-friendly slice.
+// "all" collapses to ["all"]. When omitEmpty is true, an empty Names
+// list returns nil so JSON `omitempty` drops the field; when false,
+// it returns an empty slice (always-emit).
+func compatToSlice(a catalog.AgentCompat, omitEmpty bool) []string {
 	if a.All {
 		return []string{"all"}
 	}
 	if len(a.Names) == 0 {
+		if omitEmpty {
+			return nil
+		}
 		return []string{}
-	}
-	out := make([]string, len(a.Names))
-	copy(out, a.Names)
-	return out
-}
-
-// requiredToSlice converts an AgentCompat into a slice, returning nil when
-// no agent requires the ability (so the JSON `omitempty` tag drops it).
-func requiredToSlice(a catalog.AgentCompat) []string {
-	if a.All {
-		return []string{"all"}
-	}
-	if len(a.Names) == 0 {
-		return nil
 	}
 	out := make([]string, len(a.Names))
 	copy(out, a.Names)
@@ -125,8 +115,8 @@ func SerializeCatalog(cat *catalog.Catalog, version string) ([]byte, error) {
 			Name:        s.Name,
 			DisplayName: s.DisplayName,
 			Description: s.Description,
-			Agents:      agentsToSlice(s.Agents),
-			Required:    requiredToSlice(s.Required),
+			Agents:      compatToSlice(s.Agents, false),
+			Required:    compatToSlice(s.Required, true),
 		})
 	}
 	for _, w := range cat.Workflows {
@@ -134,8 +124,8 @@ func SerializeCatalog(cat *catalog.Catalog, version string) ([]byte, error) {
 			Name:        w.Name,
 			DisplayName: w.DisplayName,
 			Description: w.Description,
-			Agents:      agentsToSlice(w.Agents),
-			Required:    requiredToSlice(w.Required),
+			Agents:      compatToSlice(w.Agents, false),
+			Required:    compatToSlice(w.Required, true),
 		})
 	}
 	for _, p := range cat.Protocols {
@@ -143,8 +133,8 @@ func SerializeCatalog(cat *catalog.Catalog, version string) ([]byte, error) {
 			Name:        p.Name,
 			DisplayName: p.DisplayName,
 			Description: p.Description,
-			Agents:      agentsToSlice(p.Agents),
-			Required:    requiredToSlice(p.Required),
+			Agents:      compatToSlice(p.Agents, false),
+			Required:    compatToSlice(p.Required, true),
 		})
 	}
 	for _, s := range cat.Sensors {
@@ -152,8 +142,8 @@ func SerializeCatalog(cat *catalog.Catalog, version string) ([]byte, error) {
 			Name:        s.Name,
 			DisplayName: s.DisplayName,
 			Description: s.Description,
-			Agents:      agentsToSlice(s.Agents),
-			Required:    requiredToSlice(s.Required),
+			Agents:      compatToSlice(s.Agents, false),
+			Required:    compatToSlice(s.Required, true),
 			Event:       s.Event,
 			Matcher:     s.Matcher,
 		})
@@ -163,8 +153,8 @@ func SerializeCatalog(cat *catalog.Catalog, version string) ([]byte, error) {
 			Name:        r.Name,
 			DisplayName: r.DisplayName,
 			Description: r.Description,
-			Agents:      agentsToSlice(r.Agents),
-			Required:    requiredToSlice(r.Required),
+			Agents:      compatToSlice(r.Agents, false),
+			Required:    compatToSlice(r.Required, true),
 			Frequency:   r.Frequency,
 		})
 	}

--- a/internal/generate/catalog_snapshot.go
+++ b/internal/generate/catalog_snapshot.go
@@ -206,7 +206,7 @@ func WriteCatalogSnapshot(projectRoot string, version string, cat *catalog.Catal
 		return fmt.Errorf("write catalog.json: %w", err)
 	}
 	if _, err := f.Write(data); err != nil {
-		f.Close()
+		_ = f.Close()
 		return fmt.Errorf("write catalog.json: %w", err)
 	}
 	if err := f.Close(); err != nil {

--- a/internal/generate/catalog_snapshot.go
+++ b/internal/generate/catalog_snapshot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"syscall"
 
 	"github.com/LastStep/Bonsai/internal/catalog"
 )
@@ -196,7 +197,19 @@ func WriteCatalogSnapshot(projectRoot string, version string, cat *catalog.Catal
 		action = ActionUpdated
 	}
 
-	if err := os.WriteFile(absPath, data, 0644); err != nil {
+	// O_NOFOLLOW: refuse to follow a symlink at the target path. Defends
+	// against an attacker pre-planting a symlink at .bonsai/catalog.json
+	// pointing at e.g. ~/.ssh/authorized_keys; without the flag, OpenFile
+	// would follow the link and we'd overwrite the target.
+	f, err := os.OpenFile(absPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0644)
+	if err != nil {
+		return fmt.Errorf("write catalog.json: %w", err)
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		return fmt.Errorf("write catalog.json: %w", err)
+	}
+	if err := f.Close(); err != nil {
 		return fmt.Errorf("write catalog.json: %w", err)
 	}
 	result.Add(FileResult{RelPath: relPath, Action: action, Source: "generated:catalog-snapshot"})

--- a/internal/generate/catalog_snapshot_test.go
+++ b/internal/generate/catalog_snapshot_test.go
@@ -200,3 +200,61 @@ func containsAgent(agents []AgentEntry, name string) bool {
 	}
 	return false
 }
+
+// buildMinimalCatalog returns a 1-agent / 0-everything-else catalog for
+// tests that only need the snapshot scaffolding to exist.
+func buildMinimalCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	fsys := fstest.MapFS{
+		"agents/tech-lead/agent.yaml": &fstest.MapFile{Data: []byte("name: tech-lead\ndisplay_name: Tech Lead\ndescription: orchestrator\n")},
+	}
+	cat, err := catalog.New(fsys)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	return cat
+}
+
+// TestWriteCatalogSnapshot_TrailingNewline asserts that the on-disk
+// JSON ends with a single \n so the file is POSIX-friendly and diffs
+// cleanly across editors.
+func TestWriteCatalogSnapshot_TrailingNewline(t *testing.T) {
+	cat := buildMinimalCatalog(t)
+	tmpDir := t.TempDir()
+
+	var wr WriteResult
+	if err := WriteCatalogSnapshot(tmpDir, "v0.0.0", cat, &wr); err != nil {
+		t.Fatalf("WriteCatalogSnapshot: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".bonsai", "catalog.json"))
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		t.Errorf("snapshot does not end with \\n; last byte = %q", data[len(data)-1:])
+	}
+}
+
+// TestSerializeCatalog_VersionPassThrough verifies the version string is
+// emitted verbatim — empty, dev label, and tagged release all round-trip.
+func TestSerializeCatalog_VersionPassThrough(t *testing.T) {
+	cat := buildMinimalCatalog(t)
+
+	cases := []string{"", "dev", "v0.3.0"}
+	for _, version := range cases {
+		t.Run("version="+version, func(t *testing.T) {
+			data, err := SerializeCatalog(cat, version)
+			if err != nil {
+				t.Fatalf("SerializeCatalog: %v", err)
+			}
+			var snap CatalogSnapshot
+			if err := json.Unmarshal(data, &snap); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if snap.Version != version {
+				t.Errorf("snap.Version = %q, want %q", snap.Version, version)
+			}
+		})
+	}
+}

--- a/internal/generate/catalog_snapshot_test.go
+++ b/internal/generate/catalog_snapshot_test.go
@@ -236,6 +236,39 @@ func TestWriteCatalogSnapshot_TrailingNewline(t *testing.T) {
 	}
 }
 
+// TestWriteCatalogSnapshot_RefusesSymlink — pre-create a symlink at the
+// target path; the writer must error out (O_NOFOLLOW) and leave the link
+// intact so an attacker-planted symlink cannot be used to overwrite an
+// arbitrary file.
+func TestWriteCatalogSnapshot_RefusesSymlink(t *testing.T) {
+	cat := buildMinimalCatalog(t)
+	tmpDir := t.TempDir()
+
+	bonsaiDir := filepath.Join(tmpDir, ".bonsai")
+	if err := os.MkdirAll(bonsaiDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := filepath.Join(bonsaiDir, "catalog.json")
+	if err := os.Symlink("/dev/null", target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var wr WriteResult
+	err := WriteCatalogSnapshot(tmpDir, "v0.0.0", cat, &wr)
+	if err == nil {
+		t.Fatal("WriteCatalogSnapshot: want error for symlink target, got nil")
+	}
+
+	// Symlink must still be a symlink (Lstat, not Stat — Stat follows).
+	info, lerr := os.Lstat(target)
+	if lerr != nil {
+		t.Fatalf("lstat after refused write: %v", lerr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("target is no longer a symlink (mode=%v)", info.Mode())
+	}
+}
+
 // TestSerializeCatalog_VersionPassThrough verifies the version string is
 // emitted verbatim — empty, dev label, and tagged release all round-trip.
 func TestSerializeCatalog_VersionPassThrough(t *testing.T) {

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1569,18 +1570,6 @@ func buildAgentTemplateContext(agentDef *catalog.AgentDef, installed *config.Ins
 	return ctx
 }
 
-// hasAbility reports whether name appears in the haystack. Small helper used
-// by RefreshPeerAwareness to gate per-sensor refreshes on the agent actually
-// having the sensor installed.
-func hasAbility(haystack []string, name string) bool {
-	for _, h := range haystack {
-		if h == name {
-			return true
-		}
-	}
-	return false
-}
-
 // RefreshPeerAwareness re-renders the three OtherAgents-dependent files
 // (identity.md, scope-guard-files.sh, dispatch-guard.sh) for every installed
 // agent EXCEPT the one specified. Called after `bonsai add` so already-
@@ -1651,7 +1640,7 @@ func RefreshPeerAwareness(projectRoot string, excludeAgent string, cfg *config.P
 		}
 
 		// 2. scope-guard-files.sh — only if the peer has it installed.
-		if hasAbility(peer.Sensors, "scope-guard-files") {
+		if slices.Contains(peer.Sensors, "scope-guard-files") {
 			if sensor := cat.GetSensor("scope-guard-files"); sensor != nil {
 				content, err := renderContent(catFS, sensor.ContentPath, ctx)
 				if err != nil {
@@ -1665,7 +1654,7 @@ func RefreshPeerAwareness(projectRoot string, excludeAgent string, cfg *config.P
 		}
 
 		// 3. dispatch-guard.sh — only if the peer has it installed.
-		if hasAbility(peer.Sensors, "dispatch-guard") {
+		if slices.Contains(peer.Sensors, "dispatch-guard") {
 			if sensor := cat.GetSensor("dispatch-guard"); sensor != nil {
 				content, err := renderContent(catFS, sensor.ContentPath, ctx)
 				if err != nil {

--- a/internal/tui/addflow/conflicts_test.go
+++ b/internal/tui/addflow/conflicts_test.go
@@ -361,20 +361,22 @@ func TestConflicts_ViewportFollowsFocus(t *testing.T) {
 	s.focus = 8
 	out := s.renderList()
 	wantPath := s.files[8].RelPath
-	if !strings.Contains(out, shortName(wantPath)) {
+	if !strings.Contains(out, conflictsShortName(wantPath)) {
 		t.Fatalf("renderList missing focused row %q; got:\n%s", wantPath, out)
 	}
 	offTopPath := s.files[0].RelPath
-	if strings.Contains(out, shortName(offTopPath)) {
+	if strings.Contains(out, conflictsShortName(offTopPath)) {
 		t.Fatalf("renderList should not contain scrolled-off row %q; got:\n%s",
 			offTopPath, out)
 	}
 }
 
-// shortName strips the common "station/agent/Skills/" prefix so viewport
-// assertions tolerate the mid-path truncation that renderRow applies when
-// pathBudget is tight. The leading segment is what remains distinctive.
-func shortName(p string) string {
+// conflictsShortName strips the common "station/agent/Skills/" prefix so
+// viewport assertions tolerate the mid-path truncation that renderRow
+// applies when pathBudget is tight. The leading segment is what remains
+// distinctive. (Renamed from shortName to avoid shadowing concerns and to
+// disambiguate from any other test helpers.)
+func conflictsShortName(p string) string {
 	// Use the trailing "file-NN.md" fragment — the truncation keeps the
 	// tail when it elides, so the short name is stable either way.
 	if i := strings.LastIndex(p, "/"); i >= 0 {
@@ -384,9 +386,11 @@ func shortName(p string) string {
 }
 
 // TestConflicts_ColorTonesDifferPerAction verifies the per-row palette tone
-// actually differs between two actions — not just layout text. Renders
-// row 0 with Keep, captures, then flips to Overwrite and captures again;
-// the two strings must differ (ANSI codes + labels both change).
+// actually differs between actions — not just layout text. Renders row 0
+// with Keep, then with Overwrite, then with Backup; each pair must differ.
+// Adding the Keep-vs-Backup pair (alongside Keep-vs-Overwrite) catches a
+// regression where Backup's tone is silently equalised to one of the other
+// actions even though its label still differs.
 func TestConflicts_ColorTonesDifferPerAction(t *testing.T) {
 	s := newTestConflicts()
 	s.SetSize(100, 30)
@@ -396,9 +400,14 @@ func TestConflicts_ColorTonesDifferPerAction(t *testing.T) {
 	keep := s.renderRow(0)
 	s.action[key] = config.ConflictActionOverwrite
 	overwrite := s.renderRow(0)
+	s.action[key] = config.ConflictActionBackup
+	backup := s.renderRow(0)
 
 	if keep == overwrite {
 		t.Fatalf("Keep vs Overwrite renders are identical — palette tone is not driven by action")
+	}
+	if keep == backup {
+		t.Fatalf("Keep vs Backup renders are identical — palette tone is not driven by action")
 	}
 }
 

--- a/internal/tui/addflow/ground.go
+++ b/internal/tui/addflow/ground.go
@@ -2,7 +2,6 @@ package addflow
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/LastStep/Bonsai/internal/tui"
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
+	"github.com/LastStep/Bonsai/internal/wsvalidate"
 )
 
 // GroundStage collects the workspace directory for a new non-tech-lead
@@ -124,8 +124,8 @@ func (s *GroundStage) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				s.showError = true
 				return s, nil
 			}
-			norm := NormaliseWorkspace(v)
-			if reason := invalidWorkspaceReason(norm); reason != "" {
+			norm := wsvalidate.Normalise(v)
+			if reason := wsvalidate.InvalidReason(norm); reason != "" {
 				s.validateErr = reason
 				s.showError = true
 				return s, nil
@@ -254,7 +254,7 @@ func (s *GroundStage) Result() any {
 	if s.techLead {
 		return s.defaultWorkspace
 	}
-	return NormaliseWorkspace(s.input.Value())
+	return wsvalidate.Normalise(s.input.Value())
 }
 
 // Reset clears completion so re-entry doesn't auto-advance. Preserves the
@@ -262,42 +262,4 @@ func (s *GroundStage) Result() any {
 func (s *GroundStage) Reset() tea.Cmd {
 	s.ClearDone()
 	return nil
-}
-
-// NormaliseWorkspace applies the shared trim + filepath.Clean + trailing-
-// slash rule used by cmd/add.go. Duplicated here (not referenced via cmd/)
-// so addflow has no back-import into cmd. Phase 3 can drop the cmd copy.
-func NormaliseWorkspace(s string) string {
-	v := strings.TrimSpace(s)
-	if v == "" {
-		return ""
-	}
-	v = strings.TrimRight(filepath.Clean(v), "/") + "/"
-	return v
-}
-
-// invalidWorkspaceReason returns a user-facing error string when the
-// normalised workspace escapes the project root or is absolute. Returns
-// "" when the workspace is a safe project-relative path. Called by
-// GroundStage after NormaliseWorkspace cleans the input.
-//
-// Project-relative only. Defence against accidental writes outside the
-// project root when the user types "../..." or a rooted path. Not an
-// adversarial boundary — the user already has write access to their own
-// filesystem — but prevents silent surprises in test harnesses and
-// dogfooding sessions.
-func invalidWorkspaceReason(ws string) string {
-	// filepath.IsAbs catches "/etc/" on POSIX and "C:\..." on Windows.
-	if filepath.IsAbs(ws) {
-		return "workspace must be project-relative (no leading /)"
-	}
-	// After filepath.Clean, any remaining ".." component means the path
-	// escapes the project root. Split on "/" (NormaliseWorkspace always
-	// emits forward slashes) and check each segment.
-	for _, seg := range strings.Split(strings.TrimRight(ws, "/"), "/") {
-		if seg == ".." {
-			return "workspace must not escape project root (no ..)"
-		}
-	}
-	return ""
 }

--- a/internal/tui/addflow/ground_test.go
+++ b/internal/tui/addflow/ground_test.go
@@ -130,7 +130,6 @@ func TestGround_ResultNormalises(t *testing.T) {
 	}
 }
 
-
 // TestGround_ResetPreservesValue verifies Reset clears done but not the
 // entered value.
 func TestGround_ResetPreservesValue(t *testing.T) {

--- a/internal/tui/addflow/ground_test.go
+++ b/internal/tui/addflow/ground_test.go
@@ -130,22 +130,6 @@ func TestGround_ResultNormalises(t *testing.T) {
 	}
 }
 
-// TestNormaliseWorkspace covers the standalone helper.
-func TestNormaliseWorkspace(t *testing.T) {
-	cases := map[string]string{
-		"backend":    "backend/",
-		"backend/":   "backend/",
-		"./backend":  "backend/",
-		"  api  ":    "api/",
-		"":           "",
-		"nested/dir": "nested/dir/",
-	}
-	for in, want := range cases {
-		if got := NormaliseWorkspace(in); got != want {
-			t.Errorf("NormaliseWorkspace(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
 
 // TestGround_ResetPreservesValue verifies Reset clears done but not the
 // entered value.
@@ -175,8 +159,8 @@ func TestGround_RejectsAbsolutePath(t *testing.T) {
 	if s.Done() {
 		t.Fatal("absolute path should not advance")
 	}
-	if !strings.Contains(s.validateErr, "project-relative") {
-		t.Fatalf("validateErr = %q, want 'project-relative'", s.validateErr)
+	if !strings.Contains(s.validateErr, "absolute paths not allowed") {
+		t.Fatalf("validateErr = %q, want 'absolute paths not allowed'", s.validateErr)
 	}
 }
 

--- a/internal/tui/addflow/ground_test.go
+++ b/internal/tui/addflow/ground_test.go
@@ -191,3 +191,18 @@ func TestGround_RejectsHiddenParentEscape(t *testing.T) {
 		t.Fatalf("validateErr = %q, want 'escape'", s.validateErr)
 	}
 }
+
+// TestGround_AcceptsNestedRelative is the positive companion to the
+// rejects-* tests above. Verifies clean relative inputs (including ones
+// that Clean reduces to a safe nested path) advance the stage.
+func TestGround_AcceptsNestedRelative(t *testing.T) {
+	cases := []string{"./foo", "foo/../bar"}
+	for _, in := range cases {
+		s := newTestGround("backend", nil)
+		groundType(s, in)
+		groundPressKey(s, tea.KeyEnter)
+		if !s.Done() {
+			t.Errorf("input %q should advance — validateErr=%q", in, s.validateErr)
+		}
+	}
+}

--- a/internal/tui/initflow/vessel.go
+++ b/internal/tui/initflow/vessel.go
@@ -1,7 +1,6 @@
 package initflow
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -9,6 +8,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/wsvalidate"
 )
 
 // VesselStage collects the three project-identity fields (NAME, DESCRIPTION,
@@ -107,7 +107,8 @@ func (s *VesselStage) focusAt(idx int) tea.Cmd {
 // value. Used on ↵ to gate stage advancement. Rule: STATION rejects empty
 // or "/" — Vessel enforces inline so the user corrects without leaving the
 // stage. Empty STATION is treated as "use the default station/" rather than
-// an error.
+// an error. The shared wsvalidate.InvalidReason is the single source of
+// truth for IsAbs / backslash / parent-escape / pure-root rules.
 func (s *VesselStage) validate() bool {
 	if strings.TrimSpace(s.inputs[vesselIdxName].Value()) == "" {
 		return false
@@ -116,25 +117,8 @@ func (s *VesselStage) validate() bool {
 	if station == "" {
 		return true
 	}
-	if station == "/" {
-		return false
-	}
-	// After normalising to trailing slash, reject absolute + path-escape.
-	// Project-relative only — defence against accidental writes outside
-	// the project root when the user types "../..." or a rooted path.
-	norm := station
-	if !strings.HasSuffix(norm, "/") {
-		norm += "/"
-	}
-	if filepath.IsAbs(norm) {
-		return false
-	}
-	for _, seg := range strings.Split(strings.TrimRight(norm, "/"), "/") {
-		if seg == ".." {
-			return false
-		}
-	}
-	return true
+	norm := wsvalidate.Normalise(station)
+	return wsvalidate.InvalidReason(norm) == ""
 }
 
 // Update handles key input for focus cycling + Enter-to-advance.

--- a/internal/tui/initflow/vessel_test.go
+++ b/internal/tui/initflow/vessel_test.go
@@ -254,3 +254,18 @@ func TestVessel_RejectsParentEscapeStation(t *testing.T) {
 		t.Fatal("parent-escape STATION input should fail validate()")
 	}
 }
+
+// TestVessel_AcceptsCleanRelative is the positive companion to the
+// rejects-* tests above. Verifies that clean relative STATION inputs
+// (including ones that Clean reduces to a safe nested path) pass validate.
+func TestVessel_AcceptsCleanRelative(t *testing.T) {
+	cases := []string{"./foo", "foo/../bar"}
+	for _, in := range cases {
+		v := newTestVessel()
+		v.inputs[vesselIdxName].SetValue("proj")
+		v.inputs[vesselIdxStation].SetValue(in)
+		if !v.validate() {
+			t.Errorf("STATION = %q should pass validate()", in)
+		}
+	}
+}

--- a/internal/wsvalidate/wsvalidate.go
+++ b/internal/wsvalidate/wsvalidate.go
@@ -1,0 +1,52 @@
+// Package wsvalidate centralises workspace-path validation rules used by
+// addflow + initflow + cmd. Both flows previously duplicated the
+// trim/Clean/trailing-slash + IsAbs + ".." segment scan; this package is
+// the single source of truth so adding a defence (backslash, pure-root)
+// updates every caller at once.
+//
+// The package depends only on stdlib path/filepath + strings to keep it
+// importable from any TUI flow without cycles.
+package wsvalidate
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Normalise applies the shared trim + filepath.Clean + trailing-slash rule
+// used to canonicalise workspace strings before validation or storage.
+// Empty input returns "".
+func Normalise(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return ""
+	}
+	v = strings.TrimRight(filepath.Clean(v), "/") + "/"
+	return v
+}
+
+// InvalidReason returns a user-facing error string when the normalised
+// workspace escapes the project root or is absolute. Returns "" when the
+// workspace is a safe project-relative path. Called after Normalise has
+// cleaned the input.
+//
+// Project-relative only. Defence against accidental writes outside the
+// project root when the user types "../..." or a rooted path. Not an
+// adversarial boundary — the user already has write access to their own
+// filesystem — but prevents silent surprises in test harnesses and
+// dogfooding sessions.
+func InvalidReason(ws string) string {
+	// filepath.IsAbs catches "/etc/" on POSIX and "C:\..." on Windows.
+	if filepath.IsAbs(ws) {
+		return "absolute paths not allowed (no leading / or drive letter)"
+	}
+	// After filepath.Clean, any remaining ".." component means the path
+	// escapes the project root. Split on "/" (Normalise always emits
+	// forward slashes) and check each segment.
+	for _, seg := range strings.Split(strings.TrimRight(ws, "/"), "/") {
+		if seg == ".." {
+			return "workspace must not escape project root (no ..)"
+		}
+	}
+	return ""
+}

--- a/internal/wsvalidate/wsvalidate.go
+++ b/internal/wsvalidate/wsvalidate.go
@@ -26,8 +26,9 @@ func Normalise(v string) string {
 }
 
 // InvalidReason returns a user-facing error string when the normalised
-// workspace escapes the project root or is absolute. Returns "" when the
-// workspace is a safe project-relative path. Called after Normalise has
+// workspace escapes the project root, is absolute, contains a backslash,
+// or reduces to the project root itself. Returns "" when the workspace
+// is a safe project-relative subdirectory. Called after Normalise has
 // cleaned the input.
 //
 // Project-relative only. Defence against accidental writes outside the
@@ -40,6 +41,12 @@ func InvalidReason(ws string) string {
 	if filepath.IsAbs(ws) {
 		return "absolute paths not allowed (no leading / or drive letter)"
 	}
+	// Reject backslash explicitly — POSIX treats `\` as a legal literal in
+	// file names, so "foo\bar" sneaks past IsAbs but is almost certainly a
+	// user error (Windows-style separator) we don't want to silently accept.
+	if strings.ContainsRune(ws, '\\') {
+		return "backslash not allowed (use forward slash)"
+	}
 	// After filepath.Clean, any remaining ".." component means the path
 	// escapes the project root. Split on "/" (Normalise always emits
 	// forward slashes) and check each segment.
@@ -47,6 +54,12 @@ func InvalidReason(ws string) string {
 		if seg == ".." {
 			return "workspace must not escape project root (no ..)"
 		}
+	}
+	// Reject pure root — input that Cleans to "." (e.g. "", ".", "foo/..")
+	// would install at the project root, which is almost never intended.
+	// After Normalise the value is "./", so the trimmed form is ".".
+	if strings.TrimRight(ws, "/") == "." {
+		return "workspace cannot be project root"
 	}
 	return ""
 }

--- a/internal/wsvalidate/wsvalidate_test.go
+++ b/internal/wsvalidate/wsvalidate_test.go
@@ -1,0 +1,95 @@
+package wsvalidate
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestInvalidReason_RejectsAbsolute covers the POSIX IsAbs branch. Windows
+// drive-letter paths (e.g. `C:\foo`) are rejected by the backslash branch
+// on POSIX hosts and by IsAbs on Windows hosts — covered by the
+// RejectsBackslash test.
+func TestInvalidReason_RejectsAbsolute(t *testing.T) {
+	cases := []string{"/etc/foo/", "/var/"}
+	for _, in := range cases {
+		got := InvalidReason(Normalise(in))
+		if !strings.Contains(got, "absolute paths not allowed") {
+			t.Errorf("InvalidReason(%q) = %q, want 'absolute paths not allowed' substring", in, got)
+		}
+	}
+}
+
+// TestInvalidReason_RejectsBackslash verifies "foo\bar" (POSIX-legal but
+// almost-certainly Windows-confusion) is rejected with the
+// "backslash not allowed" reason. "C:\foo" is caught by the IsAbs branch
+// first on Windows and by the backslash branch here on POSIX — either is
+// fine; we only assert that the reason is non-empty for both.
+func TestInvalidReason_RejectsBackslash(t *testing.T) {
+	cases := []string{`foo\bar`, `nested\path`}
+	for _, in := range cases {
+		got := InvalidReason(Normalise(in))
+		if got == "" {
+			t.Errorf("InvalidReason(%q) = empty, want non-empty rejection", in)
+		}
+		if !strings.Contains(got, "backslash") {
+			t.Errorf("InvalidReason(%q) = %q, want 'backslash' substring", in, got)
+		}
+	}
+}
+
+// TestInvalidReason_RejectsPureRoot verifies inputs that Clean to "."
+// (i.e. would install at the project root) are rejected.
+func TestInvalidReason_RejectsPureRoot(t *testing.T) {
+	cases := []string{"./", ".", "foo/.."}
+	for _, in := range cases {
+		got := InvalidReason(Normalise(in))
+		if !strings.Contains(got, "cannot be project root") {
+			t.Errorf("InvalidReason(%q) = %q, want 'cannot be project root' substring", in, got)
+		}
+	}
+}
+
+// TestInvalidReason_RejectsParentEscape verifies any ".." segment surviving
+// Normalise is rejected — the existing rule, retained as a regression guard
+// alongside the new defences.
+func TestInvalidReason_RejectsParentEscape(t *testing.T) {
+	cases := []string{"../foo", "nested/../..", "../../bar"}
+	for _, in := range cases {
+		got := InvalidReason(Normalise(in))
+		if !strings.Contains(got, "escape project root") {
+			t.Errorf("InvalidReason(%q) = %q, want 'escape project root' substring", in, got)
+		}
+	}
+}
+
+// TestInvalidReason_AcceptsNestedRelative verifies a clean nested relative
+// path is accepted (returns empty reason). Positive companion to the
+// rejection tests above.
+func TestInvalidReason_AcceptsNestedRelative(t *testing.T) {
+	cases := []string{"nested/path/", "./foo/", "foo/../bar/"}
+	for _, in := range cases {
+		got := InvalidReason(Normalise(in))
+		if got != "" {
+			t.Errorf("InvalidReason(%q) = %q, want empty (accepted)", in, got)
+		}
+	}
+}
+
+// TestNormalise_TrimsAndAddsTrailingSlash verifies the canonicalisation
+// rule shared by every caller: trim → Clean → trailing slash. Empty stays
+// empty (callers treat empty as "use default").
+func TestNormalise_TrimsAndAddsTrailingSlash(t *testing.T) {
+	cases := map[string]string{
+		"backend":    "backend/",
+		"backend/":   "backend/",
+		"./backend":  "backend/",
+		"  api  ":    "api/",
+		"":           "",
+		"nested/dir": "nested/dir/",
+	}
+	for in, want := range cases {
+		if got := Normalise(in); got != want {
+			t.Errorf("Normalise(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Plan 32 follow-up bundle from Plan 29 + Plan 31 review backlog — 6 commits, file-disjoint refactors and hardening.

- **Phase A** (`20a8f76`) — extract `internal/wsvalidate/` package; migrate `addflow/ground.go` + `initflow/vessel.go` to shared validator
- **Phase B** (`7c792c1`) — reject backslash + pure-root in `wsvalidate.InvalidReason` (closes Plan-29-sec-hardening 2 + 3)
- **Phase C** (`053c6bc`) — strengthen `TestConflicts_ColorTonesDifferPerAction` (Keep-vs-Backup), positive companions for vessel + ground (`AcceptsCleanRelative`, `AcceptsNestedRelative`), rename `shortName` → `conflictsShortName`
- **Phase D** (`d7b6fde`) — collapse `hasAbility` → `slices.Contains`; collapse `agentsToSlice` + `requiredToSlice` → `compatToSlice`
- **Phase E** (`12707d0`) — `TestWriteCatalogSnapshot_TrailingNewline` + `TestSerializeCatalog_VersionPassThrough`
- **Phase F** (`42252b4`) — `ProjectConfig.Validate()` chokepoint (wired into `Load()`); `O_NOFOLLOW` symlink-resistant write at `WriteCatalogSnapshot`

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` all green (cached)
- [x] `TestWriteCatalogSnapshot_RefusesSymlink` exercises O_NOFOLLOW
- [x] `TestValidate_*` covers required field, bad workspace, bad docs_path, all 9 forbidden shell metachars
- [x] Rebased clean onto `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)