### PR TITLE
Plan 34 — fix custom-ability discovery bug bundle

### DIFF
--- a/catalog/skills/bonsai-model/bonsai-model.md
+++ b/catalog/skills/bonsai-model/bonsai-model.md
@@ -76,7 +76,7 @@ Inspect the live catalog:
 
 Two files track project state:
 
-- **`.bonsai.yaml`** — user-owned config. Lists which agents exist + which abilities each has installed. Edit-safe.
+- **`.bonsai.yaml`** — config Bonsai writes for you. Lists which agents exist + which abilities each has installed. **Read-only for agents** — never hand-edit the `skills/workflows/protocols/sensors/routines` lists or `custom_items` map; let `bonsai update` register custom files.
 - **`.bonsai-lock.yaml`** — content-hash tracking. Detects user-modified generated files. Not edited by hand.
 
 Read `.bonsai.yaml` to know what the user already chose. Don't overwrite it.
@@ -124,6 +124,9 @@ type: skill
 ---
 ```
 Then runs `bonsai update`. Bonsai detects the file, prompts the user to confirm tracking, and adds it to `.bonsai.yaml` under that agent's Skills list. Lock-tracked from then on.
+
+> [!warning]
+> **Do not manually register custom abilities in `.bonsai.yaml`.** If you add a name to `skills:` (or any other list) without `bonsai update` discovering it, the file is never lock-tracked and `custom_items[name]` is never populated — CLAUDE.md will render the row with an empty description and the file will silently desync from the lockfile. Always: drop file with frontmatter, then `bonsai update`.
 
 Use for: project-specific standards, team-specific workflows, anything that wouldn't generalize.
 
@@ -198,7 +201,7 @@ When the user asks you to customize their Bonsai workspace, walk this decision t
 - Don't edit `.bonsai-lock.yaml` by hand — Bonsai owns it.
 - Don't edit generated files without understanding `bonsai update`'s conflict flow.
 - Don't run `bonsai remove` or `bonsai add` without confirming scope with the user.
-- Don't create shadow configuration outside `.bonsai.yaml` — if it's Bonsai state, it belongs in `.bonsai.yaml`.
+- Don't create shadow configuration outside `.bonsai.yaml` — but don't hand-edit `.bonsai.yaml` either. Bonsai state belongs in `.bonsai.yaml`, and **only `bonsai` commands write it**.
 - Don't add custom files without frontmatter — they won't be detected by `bonsai update`.
 - Don't reason about Bonsai from this doc alone when the live catalog is authoritative. This doc is a model; `bonsai catalog --json` is truth.
 

--- a/internal/generate/frontmatter.go
+++ b/internal/generate/frontmatter.go
@@ -10,12 +10,30 @@ import (
 
 // ParseFrontmatter extracts YAML frontmatter from file content.
 // Returns nil if no frontmatter is found.
+//
+// Two delimiter styles are accepted:
+//
+//  1. Markdown-style — content begins with `---\n` (or `---\r\n`),
+//     closes with `\n---`. Used by .md ability files.
+//  2. Bash-comment style — content optionally begins with a `#!` shebang,
+//     then a `# ---` (or `#---`) opener, comment-prefixed YAML body, and
+//     a `# ---` (or `#---`) closer. Used by sensor `.sh` files where
+//     byte 0 must be the shebang for the file to be executable.
 func ParseFrontmatter(data []byte) (*config.CustomItemMeta, error) {
 	content := string(data)
-	if !strings.HasPrefix(content, "---\n") && !strings.HasPrefix(content, "---\r\n") {
-		return nil, fmt.Errorf("no frontmatter found")
+
+	// Markdown-style fast path — keeps the existing behaviour for .md
+	// files unchanged.
+	if strings.HasPrefix(content, "---\n") || strings.HasPrefix(content, "---\r\n") {
+		return parseMarkdownFrontmatter(content)
 	}
 
+	// Bash-comment path — used for sensor .sh files.
+	return parseBashCommentFrontmatter(content)
+}
+
+// parseMarkdownFrontmatter handles the `---\n...---\n` delimiter style.
+func parseMarkdownFrontmatter(content string) (*config.CustomItemMeta, error) {
 	// Skip opening delimiter (handle both \n and \r\n line endings)
 	skip := strings.Index(content, "\n") + 1
 	rest := content[skip:]
@@ -34,4 +52,73 @@ func ParseFrontmatter(data []byte) (*config.CustomItemMeta, error) {
 	}
 
 	return &meta, nil
+}
+
+// parseBashCommentFrontmatter handles `# ---` opener / `# ---` closer
+// with comment-prefixed YAML body. Optional `#!` shebang at byte 0 is
+// skipped. Returns an error when no opener is found or no closer matches.
+func parseBashCommentFrontmatter(content string) (*config.CustomItemMeta, error) {
+	// Normalise line endings for line-by-line scanning. The original
+	// content is not mutated in place — we operate on a slice of lines.
+	normalised := strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(normalised, "\n")
+
+	idx := 0
+
+	// Optional shebang on line 0.
+	if idx < len(lines) && strings.HasPrefix(lines[idx], "#!") {
+		idx++
+	}
+
+	// Skip blank lines until the opener.
+	for idx < len(lines) && strings.TrimSpace(lines[idx]) == "" {
+		idx++
+	}
+
+	if idx >= len(lines) || !isBashFrontmatterDelim(lines[idx]) {
+		return nil, fmt.Errorf("no frontmatter found")
+	}
+	idx++ // past opener
+
+	// Read body until closer.
+	var body []string
+	closed := false
+	for ; idx < len(lines); idx++ {
+		line := lines[idx]
+		if isBashFrontmatterDelim(line) {
+			closed = true
+			break
+		}
+		body = append(body, stripBashCommentPrefix(line))
+	}
+
+	if !closed {
+		return nil, fmt.Errorf("unterminated frontmatter")
+	}
+
+	var meta config.CustomItemMeta
+	if err := yaml.Unmarshal([]byte(strings.Join(body, "\n")), &meta); err != nil {
+		return nil, fmt.Errorf("invalid frontmatter YAML: %w", err)
+	}
+	return &meta, nil
+}
+
+// isBashFrontmatterDelim reports whether line is `# ---` or `#---`
+// (trimmed). Trailing whitespace is tolerated.
+func isBashFrontmatterDelim(line string) bool {
+	t := strings.TrimRight(line, " \t")
+	return t == "# ---" || t == "#---"
+}
+
+// stripBashCommentPrefix removes the leading `# ` or `#` from a comment
+// line. Lines without a leading `#` are returned as-is so YAML parsing
+// can flag them rather than this function silently swallowing the issue.
+func stripBashCommentPrefix(line string) string {
+	if strings.HasPrefix(line, "# ") {
+		return line[2:]
+	}
+	if strings.HasPrefix(line, "#") {
+		return line[1:]
+	}
+	return line
 }

--- a/internal/generate/frontmatter_test.go
+++ b/internal/generate/frontmatter_test.go
@@ -102,6 +102,72 @@ description: End-of-session verification
 	}
 }
 
+func TestParseFrontmatter_BashShebang(t *testing.T) {
+	input := []byte(`#!/usr/bin/env bash
+# ---
+# description: shebang sensor test
+# event: SessionStart
+# matcher: PreToolUse
+# ---
+echo hi
+`)
+	meta, err := ParseFrontmatter(input)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if meta.Description != "shebang sensor test" {
+		t.Errorf("description = %q", meta.Description)
+	}
+	if meta.Event != "SessionStart" {
+		t.Errorf("event = %q, want SessionStart", meta.Event)
+	}
+	if meta.Matcher != "PreToolUse" {
+		t.Errorf("matcher = %q, want PreToolUse", meta.Matcher)
+	}
+}
+
+func TestParseFrontmatter_BashNoShebang(t *testing.T) {
+	input := []byte(`# ---
+# description: bar
+# event: Stop
+# ---
+echo hi
+`)
+	meta, err := ParseFrontmatter(input)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if meta.Description != "bar" {
+		t.Errorf("description = %q, want bar", meta.Description)
+	}
+	if meta.Event != "Stop" {
+		t.Errorf("event = %q, want Stop", meta.Event)
+	}
+}
+
+// TestParseFrontmatter_RegularMd is a regression check that the
+// markdown-delimited style still parses unchanged after the bash-comment
+// extension landed.
+func TestParseFrontmatter_RegularMd(t *testing.T) {
+	input := []byte(`---
+description: Regular markdown frontmatter
+display_name: Regular
+---
+
+# Body
+`)
+	meta, err := ParseFrontmatter(input)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if meta.Description != "Regular markdown frontmatter" {
+		t.Errorf("description = %q", meta.Description)
+	}
+	if meta.DisplayName != "Regular" {
+		t.Errorf("display_name = %q", meta.DisplayName)
+	}
+}
+
 func TestParseFrontmatterMinimal(t *testing.T) {
 	input := []byte(`---
 description: Just a description

--- a/internal/generate/scan.go
+++ b/internal/generate/scan.go
@@ -10,11 +10,12 @@ import (
 
 // DiscoveredFile represents a custom file found in a workspace that isn't tracked by Bonsai.
 type DiscoveredFile struct {
-	Name    string                 // kebab-case name derived from filename
-	Type    string                 // "skill", "workflow", "protocol", "sensor", "routine"
-	RelPath string                 // relative path from project root
-	Meta    *config.CustomItemMeta // parsed frontmatter (nil if parsing failed)
-	Error   string                 // validation error, if any
+	Name     string                 // kebab-case name derived from filename
+	Type     string                 // "skill", "workflow", "protocol", "sensor", "routine"
+	RelPath  string                 // relative path from project root
+	Meta     *config.CustomItemMeta // parsed frontmatter (nil if parsing failed)
+	Error    string                 // validation error, if any
+	Orphaned bool                   // true when the name is already in the installed list but the file isn't lock-tracked (manual registration recovery)
 }
 
 // ScanCustomFiles finds untracked custom files in an agent's workspace directories.
@@ -61,14 +62,15 @@ func ScanCustomFiles(projectRoot string, installed *config.InstalledAgent, lock 
 			}
 
 			name := strings.TrimSuffix(entry.Name(), info.ext)
-			if known[name] {
-				continue // already tracked in config
-			}
-
 			relPath, _ := filepath.Rel(projectRoot, filepath.Join(dirPath, entry.Name()))
 
-			// Skip if already in lock file (tracked but somehow not in config — be safe)
-			if _, tracked := lock.Files[relPath]; tracked {
+			_, tracked := lock.Files[relPath]
+			inInstalled := known[name]
+
+			// Skip only when fully tracked: name in installed list AND
+			// relPath in lock. Either-only state means user-orphaned
+			// registration (manual edit) or stale lock — surface for re-track.
+			if inInstalled && tracked {
 				continue
 			}
 
@@ -81,10 +83,11 @@ func ScanCustomFiles(projectRoot string, installed *config.InstalledAgent, lock 
 			meta, _ := ParseFrontmatter(data)
 
 			df := DiscoveredFile{
-				Name:    name,
-				Type:    itemType,
-				RelPath: relPath,
-				Meta:    meta,
+				Name:     name,
+				Type:     itemType,
+				RelPath:  relPath,
+				Meta:     meta,
+				Orphaned: inInstalled && !tracked,
 			}
 
 			// Validate

--- a/internal/generate/scan_test.go
+++ b/internal/generate/scan_test.go
@@ -88,6 +88,51 @@ Just content.
 	}
 }
 
+// TestScanCustomFiles_OrphanedRegistration covers the case where the
+// agent has the name listed under installed.Skills (e.g. from a manual
+// edit to .bonsai.yaml) but the file is not yet lock-tracked. The scan
+// must re-discover it so the auto-promote path can register it
+// idempotently.
+func TestScanCustomFiles_OrphanedRegistration(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	skillsDir := filepath.Join(tmpDir, "ws", "agent", "Skills")
+	_ = os.MkdirAll(skillsDir, 0755)
+
+	_ = os.WriteFile(filepath.Join(skillsDir, "foo.md"), []byte(`---
+description: orphan recovery test
+---
+
+# Body
+`), 0644)
+
+	installed := &config.InstalledAgent{
+		AgentType: "tech-lead",
+		Workspace: "ws/",
+		Skills:    []string{"foo"}, // name in installed list (manual edit)
+	}
+
+	lock := config.NewLockFile() // file NOT in lock
+
+	discovered, err := ScanCustomFiles(tmpDir, installed, lock)
+	if err != nil {
+		t.Fatalf("ScanCustomFiles: %v", err)
+	}
+
+	if len(discovered) != 1 {
+		t.Fatalf("expected 1 discovered file, got %d", len(discovered))
+	}
+	if discovered[0].Name != "foo" {
+		t.Errorf("Name = %q, want foo", discovered[0].Name)
+	}
+	if !discovered[0].Orphaned {
+		t.Error("Orphaned should be true when name in installed list but not in lock")
+	}
+	if discovered[0].Error != "" {
+		t.Errorf("Error should be empty, got %q", discovered[0].Error)
+	}
+}
+
 func TestScanCustomSensorMissingEvent(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/tui/updateflow/run.go
+++ b/internal/tui/updateflow/run.go
@@ -184,10 +184,16 @@ func Run(cwd string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *conf
 // runs the sync pipeline, and surfaces conflicts as a returned error
 // (no interactive picker). The caller handles persistence identically to
 // the interactive path based on the returned Result.
+//
+// Invalid discoveries (frontmatter missing/malformed) are surfaced as
+// `warning: <relPath> — <Error>` lines on stderr — they don't fail the
+// run, but CI/non-TTY callers get the signal that's otherwise dropped
+// silently from RunStatic's filter loop.
 func RunStatic(cwd string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, version string) (Result, error) {
 	// Scan — same logic as DiscoverStage.scan but inlined so RunStatic
 	// has zero TUI dependency.
 	var discoveries []AgentDiscoveries
+	var invalid []generate.DiscoveredFile
 	agentNames := sortedAgentNames(cfg)
 	for _, agentName := range agentNames {
 		installed := cfg.Agents[agentName]
@@ -199,6 +205,8 @@ func RunStatic(cwd string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock
 		for _, d := range found {
 			if d.Error == "" {
 				valid = append(valid, d)
+			} else {
+				invalid = append(invalid, d)
 			}
 		}
 		if len(valid) > 0 {
@@ -208,6 +216,14 @@ func RunStatic(cwd string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock
 				Valid:     valid,
 			})
 		}
+	}
+
+	// Emit one warning per invalid file. Stderr (not stdout) — this
+	// path is the non-TTY fallback so the signal must survive being
+	// piped through a script's stdout capture. tui.Warning writes to
+	// stdout and would be wrong here.
+	for _, d := range invalid {
+		fmt.Fprintf(os.Stderr, "warning: %s — %s\n", d.RelPath, d.Error)
 	}
 
 	var wr generate.WriteResult


### PR DESCRIPTION
## Summary

Plan 34 — four fixes for the silent-skip bug chain user hit on 2026-05-04. All small, all in adjacent code/docs.

- **scan.go** — `ScanCustomFiles` now skips only when the name is in the installed list **and** the file is in the lockfile. Either-only state (manual `.bonsai.yaml` edit, stale lock from a deleted file) is re-discovered with new `DiscoveredFile.Orphaned=true` flag; the existing `applyCustomFileSelection` path lock-tracks + populates `custom_items` idempotently.
- **frontmatter.go** — accept bash-comment frontmatter (`# ---` delimiter) with optional `#!` shebang at byte 0, in addition to the existing markdown `---\n` style. Sensor `.sh` files can now carry frontmatter and stay executable.
- **updateflow/run.go** — `RunStatic` collects invalid discoveries (frontmatter missing/malformed) and prints `warning: <relPath> — <Error>` to stderr per file. Doesn't fail the run. Non-TTY/CI callers no longer drop the signal silently.
- **catalog/bonsai-model.md** — drop "edit-safe" framing on `.bonsai.yaml`; add explicit do-not-hand-edit warning. Previous copy invited the orphan state above.

## Test plan

- [x] `make build` succeeds
- [x] `go test ./...` passes (added `TestScanCustomFiles_OrphanedRegistration`, `TestParseFrontmatter_BashShebang`, `TestParseFrontmatter_BashNoShebang`, `TestParseFrontmatter_RegularMd`)
- [x] Sandbox repro 1 (orphan recovery): name in `.bonsai.yaml skills:`, file in `agent/Skills/`, no lock entry → `bonsai update </dev/null` lock-tracks file and populates `custom_items[name].description`
- [x] Sandbox repro 2 (sensor shebang frontmatter): `agent/Sensors/foo.sh` with `#!/usr/bin/env bash` + `# ---` frontmatter → discovered, lock-tracked, hook entry added to `.claude/settings.json`
- [x] Sandbox repro 3 (non-TTY warning): `agent/Skills/bad.md` with no frontmatter → `bonsai update </dev/null 2>err.log` emits `warning: ...` line to stderr
- [x] `grep -n "Edit-safe\|edit-safe" catalog/skills/bonsai-model/bonsai-model.md` returns nothing

## Plan reference

`station/Playbook/Plans/Active/34-custom-ability-discovery-bug-bundle.md`

## Out of scope

- Subdirectory walking in `ScanCustomFiles` (separate decision)
- Case-insensitive directory matching
- `bonsai validate` command (Backlog candidate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)