### PR TITLE
Plan 35 — bonsai validate command (v0.4 headline)

### DIFF
--- a/catalog/skills/bonsai-model/bonsai-model.md
+++ b/catalog/skills/bonsai-model/bonsai-model.md
@@ -81,6 +81,8 @@ Two files track project state:
 
 Read `.bonsai.yaml` to know what the user already chose. Don't overwrite it.
 
+> **Workspace looks off?** Run `bonsai validate` first — read-only audit that surfaces orphaned registrations, stale lock entries, untracked custom files, and frontmatter problems. Use `bonsai validate --json` for machine-readable output. Then run `bonsai update` to fix what it finds.
+
 ---
 
 ## Key commands
@@ -91,6 +93,7 @@ Read `.bonsai.yaml` to know what the user already chose. Don't overwrite it.
 | `bonsai add` | Adds a new agent OR adds abilities to an existing agent. Interactive. |
 | `bonsai remove <agent\|skill\|...>` | Removes an agent or a specific ability. Interactive. |
 | `bonsai update` | Detects user-dropped custom files, re-renders abilities against latest catalog, resolves conflicts. |
+| `bonsai validate` | Read-only audit — detect orphaned registrations, stale lock entries, untracked custom files, frontmatter problems. JSON via `--json`. |
 | `bonsai list` | Shows installed agents + their abilities. |
 | `bonsai catalog` | Browses what's available (add `--json` for stdout). |
 | `bonsai guide` | Reads bundled onboarding docs. |
@@ -213,6 +216,7 @@ When the user asks you to customize their Bonsai workspace, walk this decision t
 |-------------------|-----------|
 | What catalog items exist | `bonsai catalog --json` or `.bonsai/catalog.json` |
 | What's installed in this project | `.bonsai.yaml` or `bonsai list` |
+| Whether the workspace is in a consistent state | `bonsai validate` (or `bonsai validate --json`) |
 | What a specific skill does | `cat <workspace>/agent/Skills/<name>.md` |
 | What a sensor enforces | `cat <workspace>/agent/Sensors/<name>.sh` |
 | What routines are active and their last-run dates | `<workspace>/agent/Core/routines.md` |

--- a/catalog/skills/workspace-guide/workspace-guide.md.tmpl
+++ b/catalog/skills/workspace-guide/workspace-guide.md.tmpl
@@ -131,6 +131,7 @@ The workspace is managed by the `bonsai` CLI:
 | `bonsai add` | Install new agents or add abilities (skills, workflows, protocols, sensors, routines) to existing agents |
 | `bonsai remove` | Remove agents or individual abilities |
 | `bonsai update` | Sync workspace after creating custom files with YAML frontmatter |
+| `bonsai validate` | Read-only audit — detect orphaned registrations, stale lock entries, untracked custom files, and frontmatter problems (add `--json` for machine output) |
 | `bonsai guide` | View the custom files guide for creating your own abilities |
 | `bonsai list` | See what's installed in the current project |
 | `bonsai catalog` | Browse all available abilities |

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/tui"
+	"github.com/LastStep/Bonsai/internal/validate"
+)
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+	validateCmd.Flags().StringP("agent", "a", "", "Restrict check to a single installed agent")
+	validateCmd.Flags().Bool("json", false, "Emit issues as JSON (one Report object) — non-interactive")
+}
+
+var validateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Audit ability state — detect orphaned registrations, stale lock entries, untracked custom files, and frontmatter problems.",
+	Long: "Read-only audit. Checks .bonsai.yaml + .bonsai-lock.yaml + agent/ workspace " +
+		"for inconsistencies. Exit 0 = clean, 1 = issues found, 2 = internal error. " +
+		"Run `bonsai update` to fix orphans/untracked. JSON output via --json.",
+	RunE: runValidate,
+}
+
+// runValidate is the validate command entry point.
+//
+// Exit-code contract (drives os.Exit calls — Cobra's RunE-returns-nil
+// path is reserved for the clean case):
+//   - 0: no issues
+//   - 1: at least one issue (any severity)
+//   - 2: internal error (config load failure, validate.Run error, etc.)
+//
+// JSON mode short-circuits text rendering and emits a single Report
+// object. The text mode groups issues by agent and renders a small
+// CatalogTable per agent + a one-line footer.
+func runValidate(cmd *cobra.Command, args []string) error {
+	cwd := mustCwd()
+	cfg, err := requireConfig(filepath.Join(cwd, configFile))
+	if err != nil {
+		// requireConfig already calls FatalPanel on missing config and
+		// won't return; this branch only fires on YAML parse / Validate
+		// errors. Surface them and exit 2.
+		fmt.Fprintf(os.Stderr, "validate: %s\n", err.Error())
+		os.Exit(2)
+	}
+	cat := loadCatalog()
+	lock, _ := config.LoadLockFile(cwd)
+	if lock == nil {
+		// LoadLockFile returns an empty file when missing, so this is
+		// belt-and-braces against future signature drift.
+		lock = config.NewLockFile()
+	}
+
+	agentFilter, _ := cmd.Flags().GetString("agent")
+	jsonOut, _ := cmd.Flags().GetBool("json")
+
+	report, err := validate.Run(cwd, cfg, cat, lock, agentFilter)
+	if err != nil {
+		if jsonOut {
+			fmt.Fprintf(os.Stderr, "validate error: %s\n", err.Error())
+		} else {
+			tui.Error("validate: " + err.Error())
+		}
+		os.Exit(2)
+	}
+
+	if jsonOut {
+		if err := renderValidateJSON(report); err != nil {
+			fmt.Fprintf(os.Stderr, "validate: %s\n", err.Error())
+			os.Exit(2)
+		}
+	} else {
+		renderValidateText(report)
+	}
+
+	if report.HasIssues() {
+		os.Exit(1)
+	}
+	return nil
+}
+
+// renderValidateJSON marshals the report to indent-2 JSON and prints it
+// to stdout. Returns the error rather than os.Exit-ing so the caller can
+// consolidate exit-code handling.
+func renderValidateJSON(report *validate.Report) error {
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	fmt.Println(string(data))
+	return nil
+}
+
+// renderValidateText prints the human-readable audit summary. When
+// report has no issues, prints a Success line + the count of agents
+// scanned. Otherwise groups issues by agent and renders a small table
+// per agent, then a footer counting errors + warnings.
+//
+// Per-agent grouping keeps output readable in multi-agent projects;
+// rendering one giant cross-agent table would force the user to mentally
+// re-group rows by the AgentName column. The small header per agent
+// gives immediate orientation.
+func renderValidateText(report *validate.Report) {
+	if !report.HasIssues() {
+		tui.Success(fmt.Sprintf("No issues found. (%d agent(s) scanned)", len(report.AgentsScanned)))
+		return
+	}
+
+	// Group issues by agent name. Preserve a sorted agent list for
+	// deterministic output.
+	byAgent := make(map[string][]validate.Issue)
+	for _, iss := range report.Issues {
+		byAgent[iss.AgentName] = append(byAgent[iss.AgentName], iss)
+	}
+	agents := make([]string, 0, len(byAgent))
+	for n := range byAgent {
+		agents = append(agents, n)
+	}
+	sort.Strings(agents)
+
+	for _, agent := range agents {
+		label := agent
+		if label == "" {
+			label = "(unscoped)"
+		}
+		tui.SectionHeader("agent: " + label)
+		var rows [][]string
+		for _, iss := range byAgent[agent] {
+			rows = append(rows, []string{
+				string(iss.Severity),
+				string(iss.Category),
+				iss.AbilityType,
+				iss.Name,
+				iss.Path,
+				iss.Detail,
+			})
+		}
+		tui.CatalogTable([]string{"Severity", "Category", "Type", "Name", "Path", "Detail"}, rows)
+	}
+
+	// Footer: total count split by severity.
+	var errs, warns int
+	for _, iss := range report.Issues {
+		switch iss.Severity {
+		case validate.SeverityError:
+			errs++
+		case validate.SeverityWarning:
+			warns++
+		}
+	}
+	tui.Blank()
+	tui.Warning(fmt.Sprintf("%d issue(s): %d error(s), %d warning(s) — run `bonsai update` to fix orphans/untracked",
+		len(report.Issues), errs, warns))
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/validate"
+)
+
+// TestValidate_RenderText_NoIssues verifies the human-readable renderer's
+// clean-state branch. Assertion is on the user-facing "No issues found"
+// + the agent-count breadcrumb.
+func TestValidate_RenderText_NoIssues(t *testing.T) {
+	report := &validate.Report{
+		Issues:        nil,
+		AgentsScanned: []string{"tech-lead", "backend"},
+	}
+	out := captureStdout(t, func() { renderValidateText(report) })
+	if !strings.Contains(out, "No issues found") {
+		t.Fatalf("expected 'No issues found' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2 agent") {
+		t.Fatalf("expected '2 agent' breadcrumb, got:\n%s", out)
+	}
+}
+
+// TestValidate_JSONOutput_Shape exercises renderValidateJSON end-to-end:
+// build a Report with one orphan issue, marshal, parse the stdout back
+// through encoding/json, and assert the stable schema. Locks the
+// public JSON shape that downstream agents will rely on.
+func TestValidate_JSONOutput_Shape(t *testing.T) {
+	report := &validate.Report{
+		AgentsScanned: []string{"tech-lead"},
+		Issues: []validate.Issue{
+			{
+				Category:    validate.CategoryOrphanedRegistration,
+				Severity:    validate.SeverityError,
+				AgentName:   "tech-lead",
+				AbilityType: "skill",
+				Name:        "foo",
+				Path:        "station/agent/Skills/foo.md",
+				Detail:      "registered but lock entry missing — run `bonsai update` to recover",
+			},
+		},
+	}
+	out := captureStdout(t, func() {
+		if err := renderValidateJSON(report); err != nil {
+			t.Fatalf("renderValidateJSON: %v", err)
+		}
+	})
+
+	var snapshot struct {
+		Issues []struct {
+			Category    string `json:"category"`
+			Severity    string `json:"severity"`
+			Agent       string `json:"agent"`
+			AbilityType string `json:"ability_type"`
+			Name        string `json:"name"`
+			Path        string `json:"path"`
+			Detail      string `json:"detail"`
+		} `json:"issues"`
+		AgentsScanned []string `json:"agents_scanned"`
+	}
+	if err := json.Unmarshal([]byte(out), &snapshot); err != nil {
+		t.Fatalf("parse JSON: %v\n%s", err, out)
+	}
+	if len(snapshot.Issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(snapshot.Issues))
+	}
+	got := snapshot.Issues[0]
+	if got.Category != "orphaned_registration" || got.Severity != "error" ||
+		got.Agent != "tech-lead" || got.AbilityType != "skill" || got.Name != "foo" {
+		t.Fatalf("issue payload mismatch: %+v", got)
+	}
+	if len(snapshot.AgentsScanned) != 1 || snapshot.AgentsScanned[0] != "tech-lead" {
+		t.Fatalf("agents_scanned = %v, want [tech-lead]", snapshot.AgentsScanned)
+	}
+}
+
+// TestValidate_E2E_OrphanProject is a thin smoke test that wires
+// validate.Run through a temp project. Mirrors the sandbox `orphan`
+// scenario from the plan's Verification section. Ensures the package
+// composes correctly: config.Load → validate.Run → Report.HasIssues.
+func TestValidate_E2E_OrphanProject(t *testing.T) {
+	tmp := t.TempDir()
+	for _, sub := range []string{"agent/Skills", "agent/Workflows", "agent/Protocols", "agent/Sensors", "agent/Routines"} {
+		if err := os.MkdirAll(filepath.Join(tmp, "station", sub), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	// Drop a custom skill with valid frontmatter but DO NOT register it
+	// in the lock or custom_items — Plan 34's repro pattern.
+	body := "---\ndescription: orphan skill\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(tmp, "station/agent/Skills/foo.md"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": {
+				AgentType: "tech-lead",
+				Workspace: "station",
+				Skills:    []string{"foo"},
+			},
+		},
+	}
+	if err := cfg.Save(filepath.Join(tmp, configFile)); err != nil {
+		t.Fatalf("save cfg: %v", err)
+	}
+
+	loaded, err := config.Load(filepath.Join(tmp, configFile))
+	if err != nil {
+		t.Fatalf("load cfg: %v", err)
+	}
+	report, err := validate.Run(tmp, loaded, nil, config.NewLockFile(), "")
+	if err != nil {
+		t.Fatalf("validate.Run: %v", err)
+	}
+	if !report.HasIssues() {
+		t.Fatalf("expected issues for orphan project, got none")
+	}
+	if !report.HasErrors() {
+		t.Fatalf("expected an error-level issue (orphan)")
+	}
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,476 @@
+// Package validate audits a Bonsai project for inconsistencies between
+// .bonsai.yaml, .bonsai-lock.yaml, and the agent/ workspace files. It is
+// strictly read-only — fixes happen through bonsai update.
+//
+// The audit runs six detection categories per installed agent. See the
+// Category constants for the list. Run returns a Report containing all
+// issues; callers translate that into exit codes / human / JSON output.
+//
+// Dependencies are intentionally limited to internal/config,
+// internal/catalog, and internal/generate (only ParseFrontmatter). No TUI
+// dependency — this package has to stay CI-safe so `bonsai validate
+// --json` works in headless contexts.
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
+)
+
+// Severity classifies an Issue's actionability. Errors block clean state
+// (exit 1); warnings flag drift the user should be aware of but doesn't
+// strictly break anything (also exit 1 — any issue is non-zero).
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Category is the machine-readable issue kind. Stable identifiers — agents
+// reading --json output match against these strings.
+type Category string
+
+const (
+	// CategoryOrphanedRegistration: name appears in installed.<Cat>, file
+	// exists, but lock entry is missing OR custom_items[name] is missing /
+	// has empty Description. Plan 34's repro pattern.
+	CategoryOrphanedRegistration Category = "orphaned_registration"
+	// CategoryMissingFile: name appears in installed.<Cat> but the
+	// expected file under agent/<Dir>/ does not exist on disk.
+	CategoryMissingFile Category = "missing_file"
+	// CategoryStaleLockEntry: lock.Files[relPath] references a custom
+	// source but the file itself was deleted.
+	CategoryStaleLockEntry Category = "stale_lock_entry"
+	// CategoryUntrackedCustomFile: file under agent/<Dir>/ has valid
+	// frontmatter but is not in installed.<Cat> and not in the lock.
+	// User dropped the file but never ran bonsai update.
+	CategoryUntrackedCustomFile Category = "untracked_custom_file"
+	// CategoryInvalidFrontmatter: file under agent/<Dir>/ has missing or
+	// malformed frontmatter (e.g. missing description, sensor missing
+	// event, routine missing frequency).
+	CategoryInvalidFrontmatter Category = "invalid_frontmatter"
+	// CategoryWrongExtension: a file is the wrong extension for its
+	// category dir (.md in Sensors, .sh in Skills/Workflows/Protocols/
+	// Routines). Top-level only — subdirs ignored to match
+	// generate.ScanCustomFiles.
+	CategoryWrongExtension Category = "wrong_extension_in_category"
+)
+
+// Issue is a single audit finding. JSON tag layout is the stable contract
+// downstream agents depend on; do not rename without bumping a major.
+type Issue struct {
+	Category    Category `json:"category"`
+	Severity    Severity `json:"severity"`
+	AgentName   string   `json:"agent,omitempty"`
+	AbilityType string   `json:"ability_type,omitempty"` // skill|workflow|protocol|sensor|routine
+	Name        string   `json:"name,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	Detail      string   `json:"detail"`
+}
+
+// Report is the full audit result. Issues is the flat list across all
+// scanned agents; AgentsScanned records the agent set the audit covered
+// so callers can verify --agent filtering applied.
+type Report struct {
+	Issues        []Issue  `json:"issues"`
+	AgentsScanned []string `json:"agents_scanned"`
+}
+
+// HasIssues reports whether at least one Issue was recorded — used by the
+// command layer to drive exit code 1.
+func (r *Report) HasIssues() bool { return len(r.Issues) > 0 }
+
+// HasErrors reports whether any Issue.Severity == SeverityError. Useful
+// for callers that want to distinguish hard breakage from drift warnings.
+func (r *Report) HasErrors() bool {
+	for _, iss := range r.Issues {
+		if iss.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// categoryDef captures the per-ability-type wiring shared with
+// generate.ScanCustomFiles. Duplicated locally rather than re-exported
+// from internal/generate to keep the validate package's import surface
+// small. The shape is intentionally tiny so drift is easy to spot.
+type categoryDef struct {
+	dir   string // workspace subdir under agent/
+	ext   string // expected file extension (with leading dot)
+	items func(*config.InstalledAgent) []string
+}
+
+// orderedCategories returns the ability-type wiring in a deterministic
+// order. Iteration order matters for test stability — Go map iteration
+// is intentionally randomised, so a slice is used instead.
+func orderedCategories() []struct {
+	itemType string
+	def      categoryDef
+} {
+	return []struct {
+		itemType string
+		def      categoryDef
+	}{
+		{"skill", categoryDef{dir: "Skills", ext: ".md", items: func(ia *config.InstalledAgent) []string { return ia.Skills }}},
+		{"workflow", categoryDef{dir: "Workflows", ext: ".md", items: func(ia *config.InstalledAgent) []string { return ia.Workflows }}},
+		{"protocol", categoryDef{dir: "Protocols", ext: ".md", items: func(ia *config.InstalledAgent) []string { return ia.Protocols }}},
+		{"sensor", categoryDef{dir: "Sensors", ext: ".sh", items: func(ia *config.InstalledAgent) []string { return ia.Sensors }}},
+		{"routine", categoryDef{dir: "Routines", ext: ".md", items: func(ia *config.InstalledAgent) []string { return ia.Routines }}},
+	}
+}
+
+// wrongExtFor returns the "wrong" extension for a category dir — the one
+// that should never appear there. Used by the wrong-extension scan.
+// Empty string means no specific wrong extension to flag.
+func wrongExtFor(itemType string) string {
+	switch itemType {
+	case "sensor":
+		return ".md" // sensors are .sh; .md here is misplaced
+	case "skill", "workflow", "protocol", "routine":
+		return ".sh" // these are .md; .sh here is misplaced
+	}
+	return ""
+}
+
+// Run audits the project at projectRoot. cfg + cat + lock should already
+// be loaded by the caller (cmd/validate.go calls config.Load,
+// catalog.New, and config.LoadLockFile). When agentFilter is non-empty
+// only that agent is scanned; an unknown agent name returns an error so
+// callers can surface a clear message.
+func Run(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Catalog, lock *config.LockFile, agentFilter string) (*Report, error) {
+	_ = cat // catalog isn't required for any current detection — kept in
+	// the signature so future categories (e.g. catalog drift) can use it
+	// without breaking the public Run signature.
+
+	if cfg == nil {
+		return nil, errors.New("validate: nil project config")
+	}
+	if lock == nil {
+		// LoadLockFile already returns an empty lock when the file is
+		// absent; defend against direct callers that pass nil.
+		lock = config.NewLockFile()
+	}
+
+	report := &Report{Issues: []Issue{}, AgentsScanned: []string{}}
+
+	// Build deterministic agent list (filter to one if requested).
+	names := make([]string, 0, len(cfg.Agents))
+	for n := range cfg.Agents {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	if agentFilter != "" {
+		if _, ok := cfg.Agents[agentFilter]; !ok {
+			return nil, fmt.Errorf("validate: agent %q not installed", agentFilter)
+		}
+		names = []string{agentFilter}
+	}
+
+	for _, agentName := range names {
+		installed := cfg.Agents[agentName]
+		if installed == nil {
+			continue
+		}
+		report.AgentsScanned = append(report.AgentsScanned, agentName)
+		auditAgent(projectRoot, agentName, installed, lock, report)
+	}
+
+	return report, nil
+}
+
+// auditAgent runs the six detection categories against a single agent
+// and appends any issues to report.Issues. Operates only on top-level
+// files under agent/<Dir>/ — subdirs are ignored, matching ScanCustomFiles.
+func auditAgent(projectRoot, agentName string, installed *config.InstalledAgent, lock *config.LockFile, report *Report) {
+	workspaceRoot := filepath.Join(projectRoot, installed.Workspace)
+	agentDir := filepath.Join(workspaceRoot, "agent")
+
+	cats := orderedCategories()
+
+	// Track per-category seen-on-disk paths so the stale-lock pass can
+	// distinguish "file gone" from "file present, just in another category".
+	for _, c := range cats {
+		dirPath := filepath.Join(agentDir, c.def.dir)
+		items := c.def.items(installed)
+
+		// Sort installed names so issue output is deterministic — random
+		// map order from CustomItems shouldn't leak into the report.
+		sortedItems := append([]string(nil), items...)
+		sort.Strings(sortedItems)
+
+		// 1. Orphan + missing checks for each name in installed.<Cat>.
+		for _, name := range sortedItems {
+			rel := relPath(projectRoot, dirPath, name+c.def.ext)
+			abs := filepath.Join(dirPath, name+c.def.ext)
+
+			fi, err := os.Stat(abs)
+			fileExists := err == nil && !fi.IsDir()
+
+			if !fileExists {
+				report.Issues = append(report.Issues, Issue{
+					Category:    CategoryMissingFile,
+					Severity:    SeverityError,
+					AgentName:   agentName,
+					AbilityType: c.itemType,
+					Name:        name,
+					Path:        rel,
+					Detail:      fmt.Sprintf("registered in installed.%s but file does not exist on disk", strings.ToLower(c.def.dir)),
+				})
+				continue
+			}
+
+			// File exists — check tracking.
+			_, tracked := lock.Files[rel]
+			meta, hasMeta := installed.CustomItems[name]
+			isCustomMissing := !tracked || !hasMeta || meta == nil || meta.Description == ""
+			// Catalog-shipped items have lock entries with Source like
+			// "skills/foo" (not "custom:..."). Custom items are tagged
+			// "custom:<type>s/<name>". An orphan only applies to custom
+			// items that should have lock + custom_items both populated.
+			// Heuristic: if the lock entry exists but is non-custom, the
+			// item is catalog-tracked and orphan logic doesn't apply
+			// (catalog drift is a separate, out-of-scope concern).
+			if tracked {
+				entry := lock.Files[rel]
+				if entry != nil && !strings.HasPrefix(entry.Source, "custom:") {
+					// Catalog-tracked. Skip orphan check — even an empty
+					// custom_items entry is expected for catalog items.
+					continue
+				}
+			}
+			if isCustomMissing {
+				detail := "registered but lock entry missing"
+				if tracked && (!hasMeta || meta == nil || meta.Description == "") {
+					detail = "registered but custom_items[name] missing or has empty description"
+				}
+				report.Issues = append(report.Issues, Issue{
+					Category:    CategoryOrphanedRegistration,
+					Severity:    SeverityError,
+					AgentName:   agentName,
+					AbilityType: c.itemType,
+					Name:        name,
+					Path:        rel,
+					Detail:      detail + " — run `bonsai update` to recover",
+				})
+			}
+		}
+
+		// 2. Disk scan: untracked custom files, invalid frontmatter, wrong extension.
+		entries, err := os.ReadDir(dirPath)
+		if err != nil {
+			// directory might not exist — that's fine, just skip
+			continue
+		}
+
+		known := make(map[string]bool, len(items))
+		for _, n := range items {
+			known[n] = true
+		}
+
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue // top-level only
+			}
+			fname := entry.Name()
+			ext := filepath.Ext(fname)
+			rel := relPath(projectRoot, dirPath, fname)
+			abs := filepath.Join(dirPath, fname)
+
+			// Wrong-extension check fires regardless of tracking — a
+			// stray .md in Sensors/ is always misplaced.
+			if wrong := wrongExtFor(c.itemType); wrong != "" && ext == wrong {
+				report.Issues = append(report.Issues, Issue{
+					Category:    CategoryWrongExtension,
+					Severity:    SeverityWarning,
+					AgentName:   agentName,
+					AbilityType: c.itemType,
+					Name:        strings.TrimSuffix(fname, ext),
+					Path:        rel,
+					Detail:      fmt.Sprintf("%s file in %s/ — expected %s", ext, c.def.dir, c.def.ext),
+				})
+				continue
+			}
+
+			if ext != c.def.ext {
+				continue // not a candidate for this category — ignore
+			}
+
+			name := strings.TrimSuffix(fname, ext)
+			_, tracked := lock.Files[rel]
+			inInstalled := known[name]
+
+			// Fully tracked — already covered by the orphan loop above.
+			// Don't re-flag.
+			if inInstalled && tracked {
+				continue
+			}
+			// Orphaned (in installed, not in lock) — already flagged in
+			// the orphan loop. Don't re-flag here.
+			if inInstalled {
+				continue
+			}
+
+			// Untracked candidate. Read + parse frontmatter to decide
+			// between invalid_frontmatter (error) and untracked_custom_file
+			// (warning).
+			data, readErr := os.ReadFile(abs)
+			if readErr != nil {
+				// Read failure is rare — treat as invalid since we
+				// can't validate it.
+				report.Issues = append(report.Issues, Issue{
+					Category:    CategoryInvalidFrontmatter,
+					Severity:    SeverityError,
+					AgentName:   agentName,
+					AbilityType: c.itemType,
+					Name:        name,
+					Path:        rel,
+					Detail:      "could not read file: " + readErr.Error(),
+				})
+				continue
+			}
+
+			meta, _ := generate.ParseFrontmatter(data)
+			problem := frontmatterProblem(c.itemType, meta)
+			if problem != "" {
+				report.Issues = append(report.Issues, Issue{
+					Category:    CategoryInvalidFrontmatter,
+					Severity:    SeverityError,
+					AgentName:   agentName,
+					AbilityType: c.itemType,
+					Name:        name,
+					Path:        rel,
+					Detail:      problem,
+				})
+				continue
+			}
+
+			// Valid frontmatter, not registered — warn.
+			report.Issues = append(report.Issues, Issue{
+				Category:    CategoryUntrackedCustomFile,
+				Severity:    SeverityWarning,
+				AgentName:   agentName,
+				AbilityType: c.itemType,
+				Name:        name,
+				Path:        rel,
+				Detail:      "valid custom file present but not registered — run `bonsai update`",
+			})
+		}
+	}
+
+	// 3. Stale lock check: lock entries that reference a custom file
+	// belonging to this agent's workspace, where the file is gone.
+	auditStaleLockEntries(projectRoot, agentName, installed, lock, report)
+}
+
+// auditStaleLockEntries walks lock.Files and flags any custom: entry
+// whose path is under this agent's workspace but no longer exists. The
+// agent-scoping prevents a stale entry from being reported once per
+// scanned agent in a multi-agent project.
+func auditStaleLockEntries(projectRoot, agentName string, installed *config.InstalledAgent, lock *config.LockFile, report *Report) {
+	// Normalise the workspace prefix once. Use forward slashes since
+	// lockfile paths are stored in forward-slash form (filepath.Rel on
+	// POSIX produces these; the lock format does the same on Windows
+	// elsewhere in the codebase).
+	wsPrefix := filepath.ToSlash(filepath.Join(installed.Workspace, "agent")) + "/"
+
+	// Sort relPaths for deterministic output.
+	relPaths := make([]string, 0, len(lock.Files))
+	for p := range lock.Files {
+		relPaths = append(relPaths, p)
+	}
+	sort.Strings(relPaths)
+
+	for _, rel := range relPaths {
+		entry := lock.Files[rel]
+		if entry == nil {
+			continue
+		}
+		if !strings.HasPrefix(entry.Source, "custom:") {
+			continue // catalog-tracked entries are out of scope
+		}
+		if !strings.HasPrefix(filepath.ToSlash(rel), wsPrefix) {
+			continue // not in this agent's workspace
+		}
+		abs := filepath.Join(projectRoot, rel)
+		if _, err := os.Stat(abs); err == nil {
+			continue
+		}
+		// File is gone — derive the type/name from the source string for
+		// cleaner reporting. Source format: "custom:<type>s/<name>".
+		abilityType, name := parseCustomSource(entry.Source)
+		report.Issues = append(report.Issues, Issue{
+			Category:    CategoryStaleLockEntry,
+			Severity:    SeverityWarning,
+			AgentName:   agentName,
+			AbilityType: abilityType,
+			Name:        name,
+			Path:        rel,
+			Detail:      "lock entry references custom file but file is missing — run `bonsai update`",
+		})
+	}
+}
+
+// parseCustomSource extracts (type, name) from a "custom:<type>s/<name>"
+// source string. Returns ("", "") if the format doesn't match — defensive
+// against future source-string changes.
+func parseCustomSource(src string) (string, string) {
+	rest := strings.TrimPrefix(src, "custom:")
+	slash := strings.Index(rest, "/")
+	if slash < 0 {
+		return "", ""
+	}
+	plural := rest[:slash]
+	name := rest[slash+1:]
+	// Strip trailing "s" to get singular type — matches updateflow's
+	// "custom:"+d.Type+"s/" format.
+	abilityType := strings.TrimSuffix(plural, "s")
+	return abilityType, name
+}
+
+// frontmatterProblem returns a non-empty description of the frontmatter
+// failure for an ability of the given type, or "" if the meta is valid.
+// Mirrors the validation rules in generate.ScanCustomFiles so untracked
+// files are flagged consistently between scan and validate.
+func frontmatterProblem(itemType string, meta *config.CustomItemMeta) string {
+	if meta == nil {
+		return "missing or unparseable frontmatter"
+	}
+	if meta.Description == "" {
+		return "missing required frontmatter field: description"
+	}
+	switch itemType {
+	case "sensor":
+		if meta.Event == "" {
+			return "sensor missing required frontmatter field: event"
+		}
+	case "routine":
+		if meta.Frequency == "" {
+			return "routine missing required frontmatter field: frequency"
+		}
+	}
+	return ""
+}
+
+// relPath returns the project-relative slash-form path for a file at
+// dirPath/name. Errors collapse to the joined path so the report can
+// still cite something — RelPath shouldn't fail here in practice since
+// projectRoot is the same root that produced dirPath.
+func relPath(projectRoot, dirPath, name string) string {
+	abs := filepath.Join(dirPath, name)
+	rel, err := filepath.Rel(projectRoot, abs)
+	if err != nil {
+		return filepath.ToSlash(abs)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,445 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// projectFixture is the canonical test scaffold — it materialises a temp
+// directory with a tech-lead workspace tree (agent/Skills/Workflows/...)
+// and returns the project root + a minimally populated InstalledAgent.
+// Each subtest layers its own failure mode on top via direct file writes
+// and config.InstalledAgent edits.
+type projectFixture struct {
+	root    string
+	cfg     *config.ProjectConfig
+	lock    *config.LockFile
+	tlAgent *config.InstalledAgent
+}
+
+func newFixture(t *testing.T) *projectFixture {
+	t.Helper()
+	root := t.TempDir()
+	for _, sub := range []string{"agent/Skills", "agent/Workflows", "agent/Protocols", "agent/Sensors", "agent/Routines"} {
+		if err := os.MkdirAll(filepath.Join(root, "station", sub), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	tl := &config.InstalledAgent{
+		AgentType:   "tech-lead",
+		Workspace:   "station",
+		CustomItems: map[string]*config.CustomItemMeta{},
+	}
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo",
+		Agents:      map[string]*config.InstalledAgent{"tech-lead": tl},
+	}
+	return &projectFixture{
+		root:    root,
+		cfg:     cfg,
+		lock:    config.NewLockFile(),
+		tlAgent: tl,
+	}
+}
+
+// writeFM is a helper that materialises a custom ability file with a
+// minimal valid frontmatter block. itemType selects between markdown
+// (.md) and bash-comment (.sh) frontmatter styles.
+func writeFM(t *testing.T, root, rel, itemType, description string, extraFields map[string]string) {
+	t.Helper()
+	abs := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
+	}
+	var body string
+	if itemType == "sensor" {
+		body = "#!/usr/bin/env bash\n# ---\n# description: " + description + "\n"
+		for k, v := range extraFields {
+			body += "# " + k + ": " + v + "\n"
+		}
+		body += "# ---\necho hi\n"
+	} else {
+		body = "---\ndescription: " + description + "\n"
+		for k, v := range extraFields {
+			body += k + ": " + v + "\n"
+		}
+		body += "---\nbody\n"
+	}
+	if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
+	}
+}
+
+// findIssue returns the first issue matching category + name, or nil if
+// none — failures are reported via the calling test to keep the helper
+// noise-free.
+func findIssue(issues []Issue, cat Category, name string) *Issue {
+	for i := range issues {
+		if issues[i].Category == cat && issues[i].Name == name {
+			return &issues[i]
+		}
+	}
+	return nil
+}
+
+// TestRun_CleanProject checks the empty-project happy path. A project
+// with one agent and zero abilities should produce zero issues.
+func TestRun_CleanProject(t *testing.T) {
+	f := newFixture(t)
+	report, err := Run(f.root, f.cfg, nil, f.lock, "")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if report.HasIssues() {
+		t.Fatalf("expected clean project, got issues: %+v", report.Issues)
+	}
+	if got := report.AgentsScanned; len(got) != 1 || got[0] != "tech-lead" {
+		t.Fatalf("AgentsScanned = %v, want [tech-lead]", got)
+	}
+}
+
+// TestRun_OrphanedRegistration verifies the Plan 34 repro pattern:
+// installed.Skills lists "foo", file exists with valid frontmatter, but
+// neither the lock nor custom_items[foo] is populated.
+func TestRun_OrphanedRegistration(t *testing.T) {
+	f := newFixture(t)
+	f.tlAgent.Skills = []string{"foo"}
+	writeFM(t, f.root, "station/agent/Skills/foo.md", "skill", "foo skill", nil)
+	// Note: NOT calling lock.Track and NOT setting custom_items[foo].
+
+	report, err := Run(f.root, f.cfg, nil, f.lock, "")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	iss := findIssue(report.Issues, CategoryOrphanedRegistration, "foo")
+	if iss == nil {
+		t.Fatalf("expected orphaned_registration for foo, got: %+v", report.Issues)
+	}
+	if iss.Severity != SeverityError {
+		t.Errorf("severity = %s, want error", iss.Severity)
+	}
+	if iss.AbilityType != "skill" {
+		t.Errorf("ability_type = %s, want skill", iss.AbilityType)
+	}
+	if iss.AgentName != "tech-lead" {
+		t.Errorf("agent = %s, want tech-lead", iss.AgentName)
+	}
+	if iss.Path != "station/agent/Skills/foo.md" {
+		t.Errorf("path = %s", iss.Path)
+	}
+}
+
+// TestRun_OrphanedRegistration_LockButNoCustomItems covers the variant
+// where the lock entry exists (so file is "tracked") but custom_items
+// metadata is missing or empty — also an orphan, just at a different
+// stage of breakage.
+func TestRun_OrphanedRegistration_LockButNoCustomItems(t *testing.T) {
+	f := newFixture(t)
+	f.tlAgent.Skills = []string{"bar"}
+	writeFM(t, f.root, "station/agent/Skills/bar.md", "skill", "bar skill", nil)
+	f.lock.Track("station/agent/Skills/bar.md", []byte("dummy"), "custom:skills/bar")
+	// custom_items left empty — should be flagged as orphan.
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	iss := findIssue(report.Issues, CategoryOrphanedRegistration, "bar")
+	if iss == nil {
+		t.Fatalf("expected orphaned_registration for bar, got: %+v", report.Issues)
+	}
+}
+
+// TestRun_MissingFile verifies the case where installed.<Cat> has a
+// name but the corresponding file is absent on disk.
+func TestRun_MissingFile(t *testing.T) {
+	f := newFixture(t)
+	f.tlAgent.Skills = []string{"ghost"}
+	// no file written
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	iss := findIssue(report.Issues, CategoryMissingFile, "ghost")
+	if iss == nil {
+		t.Fatalf("expected missing_file for ghost, got: %+v", report.Issues)
+	}
+	if iss.Severity != SeverityError {
+		t.Errorf("severity = %s, want error", iss.Severity)
+	}
+	if iss.AbilityType != "skill" {
+		t.Errorf("ability_type = %s, want skill", iss.AbilityType)
+	}
+}
+
+// TestRun_StaleLockEntry verifies a custom: lock entry whose file was
+// deleted produces a stale_lock_entry warning.
+func TestRun_StaleLockEntry(t *testing.T) {
+	f := newFixture(t)
+	// File never written, but lock thinks it tracked one.
+	f.lock.Track("station/agent/Skills/zombie.md", []byte("dummy"), "custom:skills/zombie")
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	iss := findIssue(report.Issues, CategoryStaleLockEntry, "zombie")
+	if iss == nil {
+		t.Fatalf("expected stale_lock_entry for zombie, got: %+v", report.Issues)
+	}
+	if iss.Severity != SeverityWarning {
+		t.Errorf("severity = %s, want warning", iss.Severity)
+	}
+	if iss.AbilityType != "skill" {
+		t.Errorf("ability_type = %s, want skill", iss.AbilityType)
+	}
+}
+
+// TestRun_UntrackedCustomFile verifies a valid-frontmatter file dropped
+// in agent/Skills/ but not yet registered emits a warning.
+func TestRun_UntrackedCustomFile(t *testing.T) {
+	f := newFixture(t)
+	writeFM(t, f.root, "station/agent/Skills/new.md", "skill", "new untracked skill", nil)
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	iss := findIssue(report.Issues, CategoryUntrackedCustomFile, "new")
+	if iss == nil {
+		t.Fatalf("expected untracked_custom_file for new, got: %+v", report.Issues)
+	}
+	if iss.Severity != SeverityWarning {
+		t.Errorf("severity = %s, want warning", iss.Severity)
+	}
+}
+
+// TestRun_InvalidFrontmatter verifies a file without frontmatter produces
+// an error, and a file with frontmatter but missing description also
+// produces an error.
+func TestRun_InvalidFrontmatter(t *testing.T) {
+	f := newFixture(t)
+	bad := filepath.Join(f.root, "station/agent/Skills/bad.md")
+	if err := os.WriteFile(bad, []byte("no frontmatter at all\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Empty-description case.
+	writeFM(t, f.root, "station/agent/Skills/empty.md", "skill", "", nil)
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	if iss := findIssue(report.Issues, CategoryInvalidFrontmatter, "bad"); iss == nil {
+		t.Fatalf("expected invalid_frontmatter for bad, got: %+v", report.Issues)
+	} else if iss.Severity != SeverityError {
+		t.Errorf("bad severity = %s, want error", iss.Severity)
+	}
+	if iss := findIssue(report.Issues, CategoryInvalidFrontmatter, "empty"); iss == nil {
+		t.Fatalf("expected invalid_frontmatter for empty, got: %+v", report.Issues)
+	}
+}
+
+// TestRun_InvalidFrontmatter_SensorMissingEvent verifies sensor-specific
+// validation: a sensor with valid frontmatter but missing `event` is
+// flagged.
+func TestRun_InvalidFrontmatter_SensorMissingEvent(t *testing.T) {
+	f := newFixture(t)
+	// Sensor frontmatter without an event field.
+	writeFM(t, f.root, "station/agent/Sensors/no-event.sh", "sensor", "missing event", nil)
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	iss := findIssue(report.Issues, CategoryInvalidFrontmatter, "no-event")
+	if iss == nil {
+		t.Fatalf("expected invalid_frontmatter for no-event, got: %+v", report.Issues)
+	}
+	if iss.AbilityType != "sensor" {
+		t.Errorf("ability_type = %s, want sensor", iss.AbilityType)
+	}
+}
+
+// TestRun_InvalidFrontmatter_RoutineMissingFrequency verifies the
+// routine-specific validation: missing frequency is flagged.
+func TestRun_InvalidFrontmatter_RoutineMissingFrequency(t *testing.T) {
+	f := newFixture(t)
+	writeFM(t, f.root, "station/agent/Routines/no-freq.md", "routine", "missing frequency", nil)
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	iss := findIssue(report.Issues, CategoryInvalidFrontmatter, "no-freq")
+	if iss == nil {
+		t.Fatalf("expected invalid_frontmatter for no-freq, got: %+v", report.Issues)
+	}
+	if iss.AbilityType != "routine" {
+		t.Errorf("ability_type = %s, want routine", iss.AbilityType)
+	}
+}
+
+// TestRun_WrongExtensionInCategory verifies an .md file in agent/Sensors/
+// or a .sh file in agent/Skills/ produces a wrong_extension warning.
+func TestRun_WrongExtensionInCategory(t *testing.T) {
+	f := newFixture(t)
+	// .md file in Sensors dir — wrong.
+	if err := os.WriteFile(filepath.Join(f.root, "station/agent/Sensors/notes.md"), []byte("md in sensors\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// .sh file in Skills dir — wrong.
+	if err := os.WriteFile(filepath.Join(f.root, "station/agent/Skills/script.sh"), []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+
+	// Both should appear.
+	if iss := findIssue(report.Issues, CategoryWrongExtension, "notes"); iss == nil {
+		t.Fatalf("expected wrong_extension for notes (md in Sensors), got: %+v", report.Issues)
+	} else if iss.AbilityType != "sensor" {
+		t.Errorf("notes ability_type = %s, want sensor", iss.AbilityType)
+	}
+	if iss := findIssue(report.Issues, CategoryWrongExtension, "script"); iss == nil {
+		t.Fatalf("expected wrong_extension for script (sh in Skills), got: %+v", report.Issues)
+	} else if iss.AbilityType != "skill" {
+		t.Errorf("script ability_type = %s, want skill", iss.AbilityType)
+	}
+}
+
+// TestRun_AgentFilter verifies --agent restricts the audit. A two-agent
+// project with issues in both agents, filtered to one, should only report
+// that agent's issues.
+func TestRun_AgentFilter(t *testing.T) {
+	f := newFixture(t)
+	// Add a second agent at workspace "code".
+	if err := os.MkdirAll(filepath.Join(f.root, "code/agent/Skills"), 0o755); err != nil {
+		t.Fatalf("mkdir code agent: %v", err)
+	}
+	codeAgent := &config.InstalledAgent{
+		AgentType:   "backend",
+		Workspace:   "code",
+		Skills:      []string{"orphan-code"},
+		CustomItems: map[string]*config.CustomItemMeta{},
+	}
+	f.cfg.Agents["backend"] = codeAgent
+	writeFM(t, f.root, "code/agent/Skills/orphan-code.md", "skill", "code skill", nil)
+
+	// And an orphan in the tech-lead agent too.
+	f.tlAgent.Skills = []string{"orphan-tl"}
+	writeFM(t, f.root, "station/agent/Skills/orphan-tl.md", "skill", "tl skill", nil)
+
+	// Filter to tech-lead only.
+	report, err := Run(f.root, f.cfg, nil, f.lock, "tech-lead")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := report.AgentsScanned; len(got) != 1 || got[0] != "tech-lead" {
+		t.Fatalf("AgentsScanned = %v, want [tech-lead]", got)
+	}
+	for _, iss := range report.Issues {
+		if iss.AgentName != "tech-lead" {
+			t.Fatalf("filter leak: issue from agent %q in tech-lead-only run: %+v", iss.AgentName, iss)
+		}
+	}
+	if findIssue(report.Issues, CategoryOrphanedRegistration, "orphan-tl") == nil {
+		t.Fatalf("expected orphan-tl issue, got: %+v", report.Issues)
+	}
+	if findIssue(report.Issues, CategoryOrphanedRegistration, "orphan-code") != nil {
+		t.Fatalf("orphan-code should be filtered out, got: %+v", report.Issues)
+	}
+}
+
+// TestRun_AgentFilter_UnknownAgent verifies a filter naming a
+// non-installed agent returns an error.
+func TestRun_AgentFilter_UnknownAgent(t *testing.T) {
+	f := newFixture(t)
+	if _, err := Run(f.root, f.cfg, nil, f.lock, "ghost-agent"); err == nil {
+		t.Fatalf("expected error for unknown agent filter")
+	}
+}
+
+// TestRun_MultipleCategoriesAtOnce stresses the report aggregation:
+// a single project with three different failure modes should report all
+// three. Also covers the Report.HasErrors / HasIssues distinction.
+func TestRun_MultipleCategoriesAtOnce(t *testing.T) {
+	f := newFixture(t)
+	// 1. Missing file.
+	f.tlAgent.Workflows = []string{"phantom"}
+	// 2. Untracked custom (warning).
+	writeFM(t, f.root, "station/agent/Skills/new.md", "skill", "new", nil)
+	// 3. Wrong-extension warning.
+	if err := os.WriteFile(filepath.Join(f.root, "station/agent/Sensors/oops.md"), []byte("md in sensors\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+
+	if !report.HasIssues() {
+		t.Fatalf("expected issues, got none")
+	}
+	if !report.HasErrors() {
+		t.Fatalf("expected at least one error (missing_file)")
+	}
+	// Each of the three categories should appear at least once.
+	cats := make(map[Category]bool)
+	for _, iss := range report.Issues {
+		cats[iss.Category] = true
+	}
+	for _, want := range []Category{CategoryMissingFile, CategoryUntrackedCustomFile, CategoryWrongExtension} {
+		if !cats[want] {
+			t.Fatalf("expected category %q in report, got: %+v", want, report.Issues)
+		}
+	}
+}
+
+// TestRun_CatalogTrackedItemNotFlaggedAsOrphan verifies the "tracked but
+// not custom" branch — a catalog-shipped item with a non-"custom:" lock
+// source must NOT be flagged as orphan even when custom_items lacks an
+// entry. Catalog items legitimately have empty custom_items.
+func TestRun_CatalogTrackedItemNotFlaggedAsOrphan(t *testing.T) {
+	f := newFixture(t)
+	f.tlAgent.Skills = []string{"planning-template"}
+	writeFM(t, f.root, "station/agent/Skills/planning-template.md", "skill", "catalog skill", nil)
+	// Source is the catalog format ("skills/foo"), not "custom:...".
+	f.lock.Track("station/agent/Skills/planning-template.md", []byte("dummy"), "skills/planning-template")
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	if iss := findIssue(report.Issues, CategoryOrphanedRegistration, "planning-template"); iss != nil {
+		t.Fatalf("catalog-tracked item must not be flagged as orphan: %+v", iss)
+	}
+}
+
+// TestRun_TopLevelOnly verifies subdirectories under agent/Skills/ are
+// ignored — same scoping rule as ScanCustomFiles.
+func TestRun_TopLevelOnly(t *testing.T) {
+	f := newFixture(t)
+	// File in a subdir — should be ignored entirely.
+	if err := os.MkdirAll(filepath.Join(f.root, "station/agent/Skills/nested"), 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeFM(t, f.root, "station/agent/Skills/nested/inner.md", "skill", "inner", nil)
+
+	report, _ := Run(f.root, f.cfg, nil, f.lock, "")
+	if report.HasIssues() {
+		t.Fatalf("nested file should be ignored, got: %+v", report.Issues)
+	}
+}
+
+// TestRun_NilConfig defensively checks the public API rejects nil cfg
+// rather than panicking.
+func TestRun_NilConfig(t *testing.T) {
+	if _, err := Run(t.TempDir(), nil, nil, nil, ""); err == nil {
+		t.Fatalf("expected error on nil cfg")
+	}
+}
+
+// TestRun_AgentsScannedSorted confirms AgentsScanned comes back sorted
+// — non-deterministic Go map iteration must not leak into the report.
+func TestRun_AgentsScannedSorted(t *testing.T) {
+	f := newFixture(t)
+	for _, n := range []string{"zebra", "alpha", "middle"} {
+		ws := n + "-ws"
+		if err := os.MkdirAll(filepath.Join(f.root, ws, "agent/Skills"), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", ws, err)
+		}
+		f.cfg.Agents[n] = &config.InstalledAgent{AgentType: "backend", Workspace: ws}
+	}
+	report, err := Run(f.root, f.cfg, nil, f.lock, "")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := append([]string(nil), report.AgentsScanned...)
+	want := append([]string(nil), got...)
+	sort.Strings(want)
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("AgentsScanned not sorted: got %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Add `bonsai validate` — read-only audit for ability-state inconsistencies. v0.4.0 headline feature. Proactive companion to Plan 34's reactive recovery in `bonsai update`.

## Changes
- `internal/validate/validate.go` — new package, six detection categories
- `internal/validate/validate_test.go` — table-driven tests (one per category) + agent-filter, multi-category, sorted-output, top-level-only
- `cmd/validate.go` — Cobra command, `--agent` + `--json` flags, exit codes 0/1/2
- `cmd/validate_test.go` — smoke tests (text + JSON renderer + e2e orphan)
- `catalog/skills/bonsai-model/bonsai-model.md` — command-table row, troubleshooting reference, quick-references row
- `catalog/skills/workspace-guide/workspace-guide.md.tmpl` — command-table row

## Detection categories
| Category | Severity |
|---|---|
| `orphaned_registration` | error |
| `missing_file` | error |
| `stale_lock_entry` | warning |
| `untracked_custom_file` | warning |
| `invalid_frontmatter` | error |
| `wrong_extension_in_category` | warning |

## Plan
station/Playbook/Plans/Active/35-bonsai-validate-command.md

## Verification
- [x] `make build` succeeds
- [x] `go test ./internal/validate/... ./cmd/...` passes
- [x] `go test ./...` passes (no regressions)
- [x] `go vet ./...` clean
- [x] `./bonsai --help` lists `validate`
- [x] `./bonsai validate --help` shows `--agent` and `--json`
- [x] Sandbox `clean` → exit 0, "No issues found"
- [x] Sandbox `orphan` → exit 1, `orphaned_registration` error (text + JSON)
- [x] Sandbox `missing_file` → exit 1, `missing_file` error
- [x] Sandbox `untracked` → exit 1, `untracked_custom_file` warning
- [x] Sandbox `invalid_frontmatter` → exit 1, `invalid_frontmatter` error
- [x] Sandbox `wrong_ext` → exit 1, `wrong_extension_in_category` warning
- [x] Sandbox `stale_lock_entry` → exit 1, `stale_lock_entry` warning
- [x] `--agent <name>` filter restricts output to one agent in 2-agent project

## Out of scope (deferred)
- `--fix` flag (use `bonsai update`)
- Walking subdirectories under `agent/<Category>/`
- Catalog hash drift validation
- Auto-running `validate` from `bonsai update`

🤖 Generated with [Claude Code](https://claude.com/claude-code)