### PR TITLE
fix(generate): catalog_snapshot Windows cross-compile

### DIFF
--- a/internal/generate/catalog_snapshot.go
+++ b/internal/generate/catalog_snapshot.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
 
 	"github.com/LastStep/Bonsai/internal/catalog"
 )
@@ -200,8 +199,9 @@ func WriteCatalogSnapshot(projectRoot string, version string, cat *catalog.Catal
 	// O_NOFOLLOW: refuse to follow a symlink at the target path. Defends
 	// against an attacker pre-planting a symlink at .bonsai/catalog.json
 	// pointing at e.g. ~/.ssh/authorized_keys; without the flag, OpenFile
-	// would follow the link and we'd overwrite the target.
-	f, err := os.OpenFile(absPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0644)
+	// would follow the link and we'd overwrite the target. Platform-specific
+	// implementation lives in catalog_snapshot_unix.go / _windows.go.
+	f, err := openSnapshotFile(absPath)
 	if err != nil {
 		return fmt.Errorf("write catalog.json: %w", err)
 	}

--- a/internal/generate/catalog_snapshot_test.go
+++ b/internal/generate/catalog_snapshot_test.go
@@ -236,39 +236,6 @@ func TestWriteCatalogSnapshot_TrailingNewline(t *testing.T) {
 	}
 }
 
-// TestWriteCatalogSnapshot_RefusesSymlink — pre-create a symlink at the
-// target path; the writer must error out (O_NOFOLLOW) and leave the link
-// intact so an attacker-planted symlink cannot be used to overwrite an
-// arbitrary file.
-func TestWriteCatalogSnapshot_RefusesSymlink(t *testing.T) {
-	cat := buildMinimalCatalog(t)
-	tmpDir := t.TempDir()
-
-	bonsaiDir := filepath.Join(tmpDir, ".bonsai")
-	if err := os.MkdirAll(bonsaiDir, 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	target := filepath.Join(bonsaiDir, "catalog.json")
-	if err := os.Symlink("/dev/null", target); err != nil {
-		t.Fatalf("symlink: %v", err)
-	}
-
-	var wr WriteResult
-	err := WriteCatalogSnapshot(tmpDir, "v0.0.0", cat, &wr)
-	if err == nil {
-		t.Fatal("WriteCatalogSnapshot: want error for symlink target, got nil")
-	}
-
-	// Symlink must still be a symlink (Lstat, not Stat — Stat follows).
-	info, lerr := os.Lstat(target)
-	if lerr != nil {
-		t.Fatalf("lstat after refused write: %v", lerr)
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		t.Errorf("target is no longer a symlink (mode=%v)", info.Mode())
-	}
-}
-
 // TestSerializeCatalog_VersionPassThrough verifies the version string is
 // emitted verbatim — empty, dev label, and tagged release all round-trip.
 func TestSerializeCatalog_VersionPassThrough(t *testing.T) {

--- a/internal/generate/catalog_snapshot_unix.go
+++ b/internal/generate/catalog_snapshot_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package generate
+
+import (
+	"os"
+	"syscall"
+)
+
+// openSnapshotFile opens the catalog.json target for writing with
+// O_NOFOLLOW so the kernel refuses to follow a symlink at the path.
+// Defends against an attacker pre-planting a symlink at the target
+// to redirect the write at an arbitrary file (e.g. ~/.ssh/authorized_keys).
+func openSnapshotFile(absPath string) (*os.File, error) {
+	return os.OpenFile(absPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_NOFOLLOW, 0644)
+}

--- a/internal/generate/catalog_snapshot_unix_test.go
+++ b/internal/generate/catalog_snapshot_unix_test.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+package generate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWriteCatalogSnapshot_RefusesSymlink — pre-create a symlink at the
+// target path; the writer must error out (O_NOFOLLOW) and leave the link
+// intact so an attacker-planted symlink cannot be used to overwrite an
+// arbitrary file.
+func TestWriteCatalogSnapshot_RefusesSymlink(t *testing.T) {
+	cat := buildMinimalCatalog(t)
+	tmpDir := t.TempDir()
+
+	bonsaiDir := filepath.Join(tmpDir, ".bonsai")
+	if err := os.MkdirAll(bonsaiDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	target := filepath.Join(bonsaiDir, "catalog.json")
+	if err := os.Symlink("/dev/null", target); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	var wr WriteResult
+	err := WriteCatalogSnapshot(tmpDir, "v0.0.0", cat, &wr)
+	if err == nil {
+		t.Fatal("WriteCatalogSnapshot: want error for symlink target, got nil")
+	}
+
+	// Symlink must still be a symlink (Lstat, not Stat — Stat follows).
+	info, lerr := os.Lstat(target)
+	if lerr != nil {
+		t.Fatalf("lstat after refused write: %v", lerr)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("target is no longer a symlink (mode=%v)", info.Mode())
+	}
+}

--- a/internal/generate/catalog_snapshot_windows.go
+++ b/internal/generate/catalog_snapshot_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package generate
+
+import "os"
+
+// openSnapshotFile opens the catalog.json target for writing.
+//
+// Windows lacks `syscall.O_NOFOLLOW`; symlink-following defense degraded
+// on this platform. Acceptable: catalog.json is regenerable + non-secret.
+func openSnapshotFile(absPath string) (*os.File, error) {
+	return os.OpenFile(absPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+}


### PR DESCRIPTION
## Summary

v0.4.0 GoReleaser cross-compile failed: `internal/generate/catalog_snapshot.go:204` uses `syscall.O_NOFOLLOW` which doesn't exist on Windows. v0.3.0 predated this code (Plan 32, PR #80, merged 2026-04-25 vs v0.3.0 tag 2026-04-24); v0.4.0 first release affected.

Split `openSnapshotFile` into platform files via build tags. Unix variant keeps the symlink defense; Windows variant degrades gracefully (catalog.json is regenerable + non-secret).

## Changes

- `internal/generate/catalog_snapshot.go` — drop `syscall` import; call new helper
- `internal/generate/catalog_snapshot_unix.go` (new, `//go:build !windows`) — helper with `O_NOFOLLOW`
- `internal/generate/catalog_snapshot_windows.go` (new, `//go:build windows`) — helper without `O_NOFOLLOW`
- (if test file references symlink-only behavior) `internal/generate/catalog_snapshot_unix_test.go` — symlink test moved with `//go:build !windows`

## Verification

- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — clean (primary gate)
- [x] `GOOS=darwin GOARCH=arm64 go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `govulncheck ./...` — zero findings

## Followup

- Force-move `v0.4.0` tag to merge commit
- `gh workflow run release.yml --ref v0.4.0 -f tag=v0.4.0` (uses Plan 36's new dispatch hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)