### PR TITLE
feat(nonint): bonsai init/add --non-interactive --from-config (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2026-05-13
+## [0.4.2] - 2026-05-13
 
 > **The "headless Bonsai" release.** `bonsai init` and `bonsai add` now run without TUI prompts under `--non-interactive --from-config`, so automation can materialise an agent workspace from a YAML fixture and parse progress as a clean JSON Lines stream.
 
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exit codes: `0` success · `2` invalid input (bad YAML, missing required field, shell-metacharacter, multi-agent overlay, mismatched project fields, tech-lead-required) · `3` runtime / filesystem error · `4` `.bonsai.yaml` already present (init) or missing (add).
 - Stderr is reserved for diagnostics; stdout is pure JSONL on success. Pipe stdout to `jq` and capture stderr separately.
 - `bonsai update` and `bonsai remove` keep their interactive-only surface — non-interactive variants are out of scope for this release.
+- Versioned as a patch (`v0.4.2`) rather than a minor bump: Bonsai is pre-1.0, the flags are additive, and no existing behaviour or shape changes.
 
 ## [0.4.1] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-13
+
+> **The "headless Bonsai" release.** `bonsai init` and `bonsai add` now run without TUI prompts under `--non-interactive --from-config`, unblocking the Bonsai-Eval rung-3 solver and any other automation that wants to materialise an agent workspace from a YAML fixture.
+
+### Added
+- **`bonsai init --non-interactive --from-config <path>`** — skip the cinematic init flow; read all answers from a `.bonsai.yaml`-shaped YAML file. JSON Lines progress output on stdout (one `{"event":"file",...}` per generated file plus a terminal `{"event":"summary",...}` with stable count keys). Validation errors exit non-zero with a plain stderr message — no TUI fallback. (Plan 39)
+- **`bonsai add --non-interactive --from-config <path>`** — same shape for the add flow. Overlay must name exactly one agent (loop the command for multi-agent setups). Project-name / docs-path / scaffolding fields in the overlay must either be empty (defaulted) or match the existing `.bonsai.yaml` exactly. (Plan 39)
+
+### Changed
+- Conflict resolution under `--non-interactive` is **forced to skip** — user-modified files are reported as `action:"conflict"` events and left untouched on disk. No `.bak`, no overwrite. (Plan 39 Security §3)
+
+### Notes
+- Exit codes: `0` success, `2` invalid input (bad YAML, missing required field, shell-metachar, multi-agent overlay, mismatched project fields, tech-lead-required), `3` runtime / filesystem error, `4` `.bonsai.yaml` already present (init) or missing (add).
+- `bonsai update` and `bonsai remove` are unchanged — their non-interactive variants are out of scope for v0.5.0.
+
 ## [0.4.1] - 2026-05-07
 
 > Quiet patch — tighten CI against cross-platform regressions and sync a stale doc pointer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - 2026-05-13
 
-> **The "headless Bonsai" release.** `bonsai init` and `bonsai add` now run without TUI prompts under `--non-interactive --from-config`, unblocking the Bonsai-Eval rung-3 solver and any other automation that wants to materialise an agent workspace from a YAML fixture.
+> **The "headless Bonsai" release.** `bonsai init` and `bonsai add` now run without TUI prompts under `--non-interactive --from-config`, so automation can materialise an agent workspace from a YAML fixture and parse progress as a clean JSON Lines stream.
 
 ### Added
-- **`bonsai init --non-interactive --from-config <path>`** — skip the cinematic init flow; read all answers from a `.bonsai.yaml`-shaped YAML file. JSON Lines progress output on stdout (one `{"event":"file",...}` per generated file plus a terminal `{"event":"summary",...}` with stable count keys). Validation errors exit non-zero with a plain stderr message — no TUI fallback. (Plan 39)
-- **`bonsai add --non-interactive --from-config <path>`** — same shape for the add flow. Overlay must name exactly one agent (loop the command for multi-agent setups). Project-name / docs-path / scaffolding fields in the overlay must either be empty (defaulted) or match the existing `.bonsai.yaml` exactly. (Plan 39)
+- **`bonsai init --non-interactive --from-config <path>`** — skip the cinematic init flow; read every answer from a `.bonsai.yaml`-shaped YAML file. Emits one `{"event":"file",...}` line per generated file on stdout, then a terminal `{"event":"summary","created":N,...}` with all five count keys always present.
+- **`bonsai add --non-interactive --from-config <path>`** — same shape for the add flow. The overlay must name exactly one agent (loop the command for multi-agent setups). `project_name` / `docs_path` / `scaffolding` in the overlay must either be omitted or match the existing `.bonsai.yaml` exactly.
+
+  ```bash
+  cat > cfg.yaml <<'EOF'
+  agents:
+    tech-lead: {}
+  EOF
+  bonsai init --non-interactive --from-config cfg.yaml | jq -c .
+  ```
 
 ### Changed
-- Conflict resolution under `--non-interactive` is **forced to skip** — user-modified files are reported as `action:"conflict"` events and left untouched on disk. No `.bak`, no overwrite. (Plan 39 Security §3)
+- Conflict resolution under `--non-interactive` is **forced to skip** — user-modified files are reported as `action:"conflict"` events and left untouched on disk. No `.bak`, no overwrite. The interactive flows are unchanged.
 
 ### Notes
-- Exit codes: `0` success, `2` invalid input (bad YAML, missing required field, shell-metachar, multi-agent overlay, mismatched project fields, tech-lead-required), `3` runtime / filesystem error, `4` `.bonsai.yaml` already present (init) or missing (add).
-- `bonsai update` and `bonsai remove` are unchanged — their non-interactive variants are out of scope for v0.5.0.
+- Exit codes: `0` success · `2` invalid input (bad YAML, missing required field, shell-metacharacter, multi-agent overlay, mismatched project fields, tech-lead-required) · `3` runtime / filesystem error · `4` `.bonsai.yaml` already present (init) or missing (add).
+- Stderr is reserved for diagnostics; stdout is pure JSONL on success. Pipe stdout to `jq` and capture stderr separately.
+- `bonsai update` and `bonsai remove` keep their interactive-only surface — non-interactive variants are out of scope for this release.
 
 ## [0.4.1] - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,21 @@ Open the project in Claude Code and say "hi, get started" — the agent self-ori
 
 > **[Your First Workspace](https://laststep.github.io/Bonsai/guides/your-first-workspace/)** — walkthrough with screenshots and explanations.
 
+### Scripted use
+
+For automation (CI fixtures, eval harnesses, scripted scaffolding), `bonsai init` and `bonsai add` accept `--non-interactive --from-config <path>` to skip the TUI entirely. Inputs come from a YAML file shaped like `.bonsai.yaml`; progress is emitted as one JSON object per line on stdout.
+
+```bash
+cat > cfg.yaml <<EOF
+project_name: my-project
+agents:
+  tech-lead: {}
+EOF
+bonsai init --non-interactive --from-config cfg.yaml | jq -c .
+```
+
+Validation errors exit non-zero with a plain stderr message — exit 2 for invalid input, exit 3 for runtime errors, exit 4 when `.bonsai.yaml` already exists for `init` (or is missing for `add`). Conflicts under `--non-interactive` are always skipped — user-modified files are reported but never overwritten.
+
 ---
 
 ## See it in action

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -42,6 +42,10 @@ var addCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add an agent to the project.",
 	RunE:  runAdd,
+	// SilenceUsage keeps cobra's `Usage:` block out of stderr when the
+	// non-interactive flag-pair guard returns an error (Plan 39 §C). True
+	// parse-time mistakes still get usage — cobra prints those before RunE.
+	SilenceUsage: true,
 }
 
 // runAdd is the entry point for `bonsai add`. It renders the cinematic

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -752,7 +752,10 @@ func runAddNonInteractive(cwd, configPath string, nonInt bool, fromConfig string
 		return 0, fmt.Errorf("--non-interactive and --from-config must be set together")
 	}
 	cat := loadCatalog()
-	overlay, err := nonint.LoadConfig(fromConfig, cwd, cat)
+	// LoadOverlay (vs LoadConfig) skips the project-level defaulting walk
+	// so the §3 match contract — "leave empty or match exactly" — holds
+	// against the user's literal YAML rather than a cwd-basename fallback.
+	overlay, err := nonint.LoadOverlay(fromConfig, cwd, cat)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return nonint.ExitInvalidConfig, err

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -757,12 +757,12 @@ func runAddNonInteractive(cwd, configPath string, nonInt bool, fromConfig string
 	// against the user's literal YAML rather than a cwd-basename fallback.
 	overlay, err := nonint.LoadOverlay(fromConfig, cwd, cat)
 	if err != nil {
-		fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprintln(stderr, err)
 		return nonint.ExitInvalidConfig, err
 	}
 	code, runErr := nonint.RunAdd(cwd, configPath, overlay, cat, Version, stdout)
 	if runErr != nil {
-		fmt.Fprintln(stderr, runErr)
+		_, _ = fmt.Fprintln(stderr, runErr)
 	}
 	return code, runErr
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/LastStep/Bonsai/internal/catalog"
 	"github.com/LastStep/Bonsai/internal/config"
 	"github.com/LastStep/Bonsai/internal/generate"
+	"github.com/LastStep/Bonsai/internal/nonint"
 	"github.com/LastStep/Bonsai/internal/tui"
 	"github.com/LastStep/Bonsai/internal/tui/addflow"
 	"github.com/LastStep/Bonsai/internal/tui/harness"
@@ -21,8 +23,19 @@ import (
 	"github.com/LastStep/Bonsai/internal/wsvalidate"
 )
 
+// Non-interactive flags for `bonsai add`. Both must be set together; the
+// runtime guard lives in runAdd. See Plan 39 §C.
+var (
+	addNonInteractive bool
+	addFromConfig     string
+)
+
 func init() {
 	rootCmd.AddCommand(addCmd)
+	addCmd.Flags().BoolVar(&addNonInteractive, "non-interactive", false,
+		"Skip TUI prompts; read all answers from --from-config (must be paired with --from-config)")
+	addCmd.Flags().StringVar(&addFromConfig, "from-config", "",
+		"Path to a YAML config file (.bonsai.yaml shape, single-agent overlay) used as input under --non-interactive")
 }
 
 var addCmd = &cobra.Command{
@@ -58,6 +71,24 @@ func runAdd(cmd *cobra.Command, args []string) error {
 
 	cwd := mustCwd()
 	configPath := filepath.Join(cwd, configFile)
+
+	// Non-interactive branch — Plan 39 §C. Delegated to runAddNonInteractive
+	// so the unit test can drive the same code path without trapping
+	// os.Exit. The branch fires BEFORE requireConfig because the latter's
+	// FatalPanel would write styled TUI to stderr — the non-interactive
+	// path needs the plain "not found" message routed through nonint.RunAdd
+	// (exit code 4).
+	if addNonInteractive || addFromConfig != "" {
+		code, err := runAddNonInteractive(cwd, configPath, addNonInteractive, addFromConfig, os.Stdout, os.Stderr)
+		if err != nil && code == 0 {
+			return err
+		}
+		if code != nonint.ExitOK {
+			os.Exit(code)
+		}
+		return nil
+	}
+
 	cfg, err := requireConfig(configPath)
 	if err != nil {
 		return err
@@ -703,4 +734,32 @@ func availableAddItems(cat *catalog.Catalog, installed *config.InstalledAgent) a
 		Sensors:   filterSensors(cat.SensorsFor(agentType), installed.Sensors),
 		Routines:  filterRoutines(cat.RoutinesFor(agentType), installed.Routines),
 	}
+}
+
+// runAddNonInteractive is the headless `bonsai add` driver. Mirrors
+// runInitNonInteractive's contract on (exitCode, error):
+//
+//   - (0,   non-nil err) — usage error; caller surfaces via cobra RunE.
+//   - (>0,  nil/err)     — operational error; caller calls os.Exit(code).
+//   - (0,   nil)         — success.
+//
+// The tech-lead-required, multi-agent-rejection, project_name / docs_path
+// / scaffolding-match, and unknown-agent rules all live inside nonint.RunAdd
+// (Plan 39 Locked Decisions §2-4) — this helper is a thin shim that
+// translates flag state into the runner call.
+func runAddNonInteractive(cwd, configPath string, nonInt bool, fromConfig string, stdout, stderr io.Writer) (int, error) {
+	if !nonInt || fromConfig == "" {
+		return 0, fmt.Errorf("--non-interactive and --from-config must be set together")
+	}
+	cat := loadCatalog()
+	overlay, err := nonint.LoadConfig(fromConfig, cwd, cat)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return nonint.ExitInvalidConfig, err
+	}
+	code, runErr := nonint.RunAdd(cwd, configPath, overlay, cat, Version, stdout)
+	if runErr != nil {
+		fmt.Fprintln(stderr, runErr)
+	}
+	return code, runErr
 }

--- a/cmd/add_nonint_test.go
+++ b/cmd/add_nonint_test.go
@@ -1,0 +1,297 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/nonint"
+)
+
+// initFreshProject is a test shorthand: spin up a tmp dir, run the
+// non-interactive init with a tech-lead-only fixture, and return the
+// project root. Used by every Phase C test that exercises an
+// already-initialised project.
+func initFreshProject(t *testing.T) string {
+	t.Helper()
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAMLFixture(t, tmp, "init-cfg.yaml", "agents:\n  tech-lead: {}\n")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, true, cfgPath, &stdout, &stderr)
+	if err != nil || code != nonint.ExitOK {
+		t.Fatalf("seed RunInit failed: code=%d err=%v stderr=%s", code, err, stderr.String())
+	}
+	return tmp
+}
+
+// TestRunAddNonInteractive_NewAgent: init then add backend overlay. Backend
+// workspace must materialise; JSONL summary must appear; cfg post-load has
+// both agents.
+func TestRunAddNonInteractive_NewAgent(t *testing.T) {
+	tmp := initFreshProject(t)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml", "agents:\n  backend: {}\n")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runAddNonInteractive: %v (stderr=%s)", err, stderr.String())
+	}
+	if code != nonint.ExitOK {
+		t.Fatalf("exit code: want %d, got %d", nonint.ExitOK, code)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "backend")); err != nil {
+		t.Errorf("backend/ workspace not created: %v", err)
+	}
+	post, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("reload .bonsai.yaml: %v", err)
+	}
+	if _, ok := post.Agents["backend"]; !ok {
+		t.Errorf("backend agent missing from post-add .bonsai.yaml")
+	}
+
+	// JSONL summary present
+	var sawSummary bool
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Errorf("bad JSON: %q (%v)", line, err)
+			continue
+		}
+		if rec["event"] == "summary" {
+			sawSummary = true
+		}
+	}
+	if !sawSummary {
+		t.Errorf("missing summary event in:\n%s", stdout.String())
+	}
+}
+
+// TestRunAddNonInteractive_AddItems: init then add tech-lead overlay with an
+// extra skill. Skill must end up in the post-load tech-lead.Skills.
+func TestRunAddNonInteractive_AddItems(t *testing.T) {
+	tmp := initFreshProject(t)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	// Find an extra tech-lead skill not in the defaults.
+	setupListTestCatalog(t)
+	cat := loadCatalog()
+	def := cat.GetAgent("tech-lead")
+	defaultSet := make(map[string]bool)
+	for _, s := range def.DefaultSkills {
+		defaultSet[s] = true
+	}
+	var extra string
+	for _, s := range cat.SkillsFor("tech-lead") {
+		if !defaultSet[s.Name] {
+			extra = s.Name
+			break
+		}
+	}
+	if extra == "" {
+		t.Skip("no extra tech-lead skill in catalog")
+	}
+
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml",
+		"agents:\n  tech-lead:\n    skills:\n      - "+extra+"\n")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if err != nil || code != nonint.ExitOK {
+		t.Fatalf("runAddNonInteractive: code=%d err=%v stderr=%s", code, err, stderr.String())
+	}
+
+	post, _ := config.Load(configPath)
+	tl := post.Agents["tech-lead"]
+	count := 0
+	for _, s := range tl.Skills {
+		if s == extra {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("extra skill %q present %d times in post-add skills %v; want 1", extra, count, tl.Skills)
+	}
+}
+
+// TestRunAddNonInteractive_AllInstalledShortCircuit: re-running the same
+// minimal overlay against an already-installed agent emits a single
+// all-zero summary line and nothing else.
+func TestRunAddNonInteractive_AllInstalledShortCircuit(t *testing.T) {
+	tmp := initFreshProject(t)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml", "agents:\n  tech-lead: {}\n")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if err != nil || code != nonint.ExitOK {
+		t.Fatalf("runAddNonInteractive: code=%d err=%v stderr=%s", code, err, stderr.String())
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	var records []map[string]any
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Errorf("bad JSON: %q (%v)", line, err)
+			continue
+		}
+		records = append(records, rec)
+	}
+	if len(records) != 1 {
+		t.Fatalf("expected exactly 1 record (summary only); got %d:\n%s", len(records), stdout.String())
+	}
+	if records[0]["event"] != "summary" {
+		t.Errorf("only record must be summary; got %v", records[0])
+	}
+	for _, k := range []string{"created", "updated", "unchanged", "skipped", "conflicts"} {
+		if v, ok := records[0][k]; !ok || v.(float64) != 0 {
+			t.Errorf("%s: want 0, got %v (present=%v)", k, v, ok)
+		}
+	}
+}
+
+// TestRunAddNonInteractive_MultiAgentOverlay: overlay with two agents → exit 2.
+func TestRunAddNonInteractive_MultiAgentOverlay(t *testing.T) {
+	tmp := initFreshProject(t)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml",
+		"agents:\n  tech-lead: {}\n  backend: {}\n")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if code != nonint.ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "exactly one agent") {
+		t.Errorf("error must mention exactly one agent; got %v", err)
+	}
+}
+
+// TestRunAddNonInteractive_OverlayMismatch: overlay project_name differs
+// from existing → exit 2.
+func TestRunAddNonInteractive_OverlayMismatch(t *testing.T) {
+	tmp := initFreshProject(t)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml",
+		"project_name: WRONG\nagents:\n  backend: {}\n")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if code != nonint.ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "project_name") {
+		t.Errorf("error must mention project_name; got %v", err)
+	}
+}
+
+// TestRunAddNonInteractive_TechLeadRequired: hand-roll a .bonsai.yaml with
+// NO tech-lead, then add a non-tech-lead overlay. Must exit 2 with the
+// "requires a tech-lead" message.
+func TestRunAddNonInteractive_TechLeadRequired(t *testing.T) {
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	base := filepath.Base(tmp)
+	body := "project_name: " + base + "\ndocs_path: station/\nscaffolding:\n  - index\n  - playbook\n  - logs\nagents:\n  backend:\n    workspace: backend/\n    skills: []\n    workflows: []\n    protocols: []\n    sensors: []\n    routines: []\n"
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if err := os.WriteFile(configPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml", "agents:\n  security: {}\n")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if code != nonint.ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "tech-lead") {
+		t.Errorf("error must mention tech-lead; got %v", err)
+	}
+}
+
+// TestRunAddNonInteractive_UnknownAgent: overlay names a phantom agent →
+// exit 2 with "unknown agent type".
+func TestRunAddNonInteractive_UnknownAgent(t *testing.T) {
+	tmp := initFreshProject(t)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml", "agents:\n  does-not-exist: {}\n")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if code != nonint.ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "unknown agent type") {
+		t.Errorf("error must mention unknown agent type; got %v", err)
+	}
+}
+
+// TestRunAddNonInteractive_MissingProjectConfig: tmp dir without .bonsai.yaml
+// → exit 4.
+func TestRunAddNonInteractive_MissingProjectConfig(t *testing.T) {
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	overlayPath := writeYAMLFixture(t, tmp, "overlay.yaml", "agents:\n  tech-lead: {}\n")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runAddNonInteractive(tmp, configPath, true, overlayPath, &stdout, &stderr)
+	if code != nonint.ExitWrongCWDForInit {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitWrongCWDForInit, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error must mention not found; got %v", err)
+	}
+}
+
+// TestRunAddNonInteractive_FlagAloneIsUsageError: --non-interactive alone
+// or --from-config alone yields the "must be set together" error via
+// cobra-handled exit-code-0 path.
+func TestRunAddNonInteractive_FlagAloneIsUsageError(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	// --non-interactive alone
+	code, err := runAddNonInteractive(tmp, configPath, true, "", io.Discard, io.Discard)
+	if code != 0 {
+		t.Errorf("--non-interactive alone: want code 0, got %d", code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "must be set together") {
+		t.Errorf("--non-interactive alone: want 'must be set together'; got %v", err)
+	}
+
+	// --from-config alone
+	cfgPath := writeYAMLFixture(t, tmp, "cfg.yaml", "agents:\n  tech-lead: {}\n")
+	code, err = runAddNonInteractive(tmp, configPath, false, cfgPath, io.Discard, io.Discard)
+	if code != 0 {
+		t.Errorf("--from-config alone: want code 0, got %d", code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "must be set together") {
+		t.Errorf("--from-config alone: want 'must be set together'; got %v", err)
+	}
+}
+
+// TestAddCmd_FlagsRegistered: cobra has the flag definitions wired.
+func TestAddCmd_FlagsRegistered(t *testing.T) {
+	for _, name := range []string{"non-interactive", "from-config"} {
+		if f := addCmd.Flags().Lookup(name); f == nil {
+			t.Errorf("flag --%s not registered on addCmd", name)
+		}
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -24,6 +24,11 @@ var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize Bonsai in the current project.",
 	RunE:  runInit,
+	// SilenceUsage keeps the cobra `Usage:` block out of stderr when the
+	// non-interactive flag-pair guard returns an error (Plan 39 §B). True
+	// parse-time mistakes (unknown flag, bad syntax) still get usage —
+	// cobra prints those before RunE fires, untouched by this setting.
+	SilenceUsage: true,
 }
 
 // asString safely extracts a string result from a harness step. Returns ""

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,8 +4,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Non-interactive flags for `bonsai init`. Both must be set together; the
+// runtime guard lives in runInit so the cobra layer doesn't have to know
+// about the cross-flag dependency. See Plan 39 §B.
+var (
+	initNonInteractive bool
+	initFromConfig     string
+)
+
 func init() {
 	rootCmd.AddCommand(initCmd)
+	initCmd.Flags().BoolVar(&initNonInteractive, "non-interactive", false,
+		"Skip TUI prompts; read all answers from --from-config (must be paired with --from-config)")
+	initCmd.Flags().StringVar(&initFromConfig, "from-config", "",
+		"Path to a YAML config file (.bonsai.yaml shape) used as input under --non-interactive")
 }
 
 var initCmd = &cobra.Command{

--- a/cmd/init_flow.go
+++ b/cmd/init_flow.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,11 +14,18 @@ import (
 	"github.com/LastStep/Bonsai/internal/catalog"
 	"github.com/LastStep/Bonsai/internal/config"
 	"github.com/LastStep/Bonsai/internal/generate"
+	"github.com/LastStep/Bonsai/internal/nonint"
 	"github.com/LastStep/Bonsai/internal/tui"
 	"github.com/LastStep/Bonsai/internal/tui/harness"
 	"github.com/LastStep/Bonsai/internal/tui/hints"
 	"github.com/LastStep/Bonsai/internal/tui/initflow"
 )
+
+// techLeadInitKey is the agent map key used by the non-interactive branch's
+// presence check. Mirrors the `techLeadType` constant inside the function
+// body — duplicated as a file-scope constant so the early branch can read
+// it without depending on later locals.
+const techLeadInitKey = "tech-lead"
 
 // runInit is the entry point for `bonsai init`. It renders the cinematic
 // four-stage init flow (Vessel → Soil → Branches → Observe) followed by the
@@ -31,6 +39,25 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	cwd := mustCwd()
 	configPath := filepath.Join(cwd, configFile)
+
+	// Non-interactive branch — Plan 39 §B. Delegated to runInitNonInteractive
+	// so the unit test (cmd/init_nonint_test.go) can drive the same code
+	// path without spawning a subprocess to observe os.Exit.
+	if initNonInteractive || initFromConfig != "" {
+		code, err := runInitNonInteractive(cwd, configPath, initNonInteractive, initFromConfig, os.Stdout, os.Stderr)
+		if err != nil && code == 0 {
+			// Either-alone usage error — let cobra surface the message with
+			// its usage block. The contract: non-zero codes go through
+			// os.Exit (skipping the cobra "Error:" prefix + usage banner);
+			// a zero code with non-nil err is the soft-fail path where the
+			// caller still expects a tidy "Error: ..." line.
+			return err
+		}
+		if code != nonint.ExitOK {
+			os.Exit(code)
+		}
+		return nil
+	}
 
 	// Early-exit with the legacy warning copy so existing configs are
 	// respected identically to pre-redesign behaviour.
@@ -218,6 +245,47 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// runInitNonInteractive is the headless `bonsai init` driver. Returns
+// (exitCode, error):
+//
+//   - (0,   non-nil err) — usage error: only one flag was set. Caller
+//     surfaces err via cobra's RunE so the user sees the "Error:" prefix
+//     and the usage block.
+//   - (>0,  nil err)     — runner reported a non-zero exit code; caller
+//     calls os.Exit(code) and the stderr message was already written.
+//   - (>0,  non-nil err) — runner reported a non-zero exit code AND a
+//     diagnostic message that the test can inspect. Wire-equivalent to
+//     above; both fields populated so tests can assert on err.Error().
+//   - (0,   nil err)     — success.
+//
+// The split lets the cobra RunE path use cobra's usage-printer for genuine
+// usage mistakes while routing operational errors through os.Exit so the
+// JSONL stdout stream isn't polluted with cobra's Error: prefix.
+func runInitNonInteractive(cwd, configPath string, nonInt bool, fromConfig string, stdout, stderr io.Writer) (int, error) {
+	if !nonInt || fromConfig == "" {
+		return 0, fmt.Errorf("--non-interactive and --from-config must be set together")
+	}
+	cat := loadCatalog()
+	cfg, err := nonint.LoadConfig(fromConfig, cwd, cat)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return nonint.ExitInvalidConfig, err
+	}
+	// Plan 39 Locked Decision §1: init requires a tech-lead entry. The
+	// guard lives here (not inside RunInit) so the error message is
+	// init-specific — RunInit defends in depth with the same check.
+	if tl, ok := cfg.Agents[techLeadInitKey]; !ok || tl == nil {
+		msg := "from-config: bonsai init requires a 'tech-lead' entry under agents:"
+		fmt.Fprintln(stderr, msg)
+		return nonint.ExitInvalidConfig, fmt.Errorf("%s", msg)
+	}
+	code, runErr := nonint.RunInit(cwd, configPath, cfg, cat, Version, stdout)
+	if runErr != nil {
+		fmt.Fprintln(stderr, runErr)
+	}
+	return code, runErr
 }
 
 // buildGenerateAction constructs the closure that the GenerateStage invokes

--- a/cmd/init_flow.go
+++ b/cmd/init_flow.go
@@ -270,7 +270,7 @@ func runInitNonInteractive(cwd, configPath string, nonInt bool, fromConfig strin
 	cat := loadCatalog()
 	cfg, err := nonint.LoadConfig(fromConfig, cwd, cat)
 	if err != nil {
-		fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprintln(stderr, err)
 		return nonint.ExitInvalidConfig, err
 	}
 	// Plan 39 Locked Decision §1: init requires a tech-lead entry. The
@@ -278,7 +278,7 @@ func runInitNonInteractive(cwd, configPath string, nonInt bool, fromConfig strin
 	// init-specific — RunInit defends in depth with the same check.
 	if tl, ok := cfg.Agents[techLeadInitKey]; !ok || tl == nil {
 		msg := "from-config: bonsai init requires a 'tech-lead' entry under agents:"
-		fmt.Fprintln(stderr, msg)
+		_, _ = fmt.Fprintln(stderr, msg)
 		return nonint.ExitInvalidConfig, fmt.Errorf("%s", msg)
 	}
 	// Plan 39 Locked Decision §1 (exclusivity): `bonsai init` installs only
@@ -288,12 +288,12 @@ func runInitNonInteractive(cwd, configPath string, nonInt bool, fromConfig strin
 	// Reject up front; callers can chain `bonsai add` for additional agents.
 	if got := len(cfg.Agents); got != 1 {
 		msg := fmt.Sprintf("from-config: bonsai init accepts only a single 'tech-lead' entry under agents:, got %d agents (use `bonsai add` for additional agents after init)", got)
-		fmt.Fprintln(stderr, msg)
+		_, _ = fmt.Fprintln(stderr, msg)
 		return nonint.ExitInvalidConfig, fmt.Errorf("%s", msg)
 	}
 	code, runErr := nonint.RunInit(cwd, configPath, cfg, cat, Version, stdout)
 	if runErr != nil {
-		fmt.Fprintln(stderr, runErr)
+		_, _ = fmt.Fprintln(stderr, runErr)
 	}
 	return code, runErr
 }

--- a/cmd/init_flow.go
+++ b/cmd/init_flow.go
@@ -281,6 +281,16 @@ func runInitNonInteractive(cwd, configPath string, nonInt bool, fromConfig strin
 		fmt.Fprintln(stderr, msg)
 		return nonint.ExitInvalidConfig, fmt.Errorf("%s", msg)
 	}
+	// Plan 39 Locked Decision §1 (exclusivity): `bonsai init` installs only
+	// the tech-lead agent — extra entries would be silently dropped by the
+	// runner's tech-lead-only AgentWorkspace call, leaving them registered
+	// in .bonsai.yaml and settings.json without a workspace materialised.
+	// Reject up front; callers can chain `bonsai add` for additional agents.
+	if got := len(cfg.Agents); got != 1 {
+		msg := fmt.Sprintf("from-config: bonsai init accepts only a single 'tech-lead' entry under agents:, got %d agents (use `bonsai add` for additional agents after init)", got)
+		fmt.Fprintln(stderr, msg)
+		return nonint.ExitInvalidConfig, fmt.Errorf("%s", msg)
+	}
 	code, runErr := nonint.RunInit(cwd, configPath, cfg, cat, Version, stdout)
 	if runErr != nil {
 		fmt.Fprintln(stderr, runErr)

--- a/cmd/init_nonint_test.go
+++ b/cmd/init_nonint_test.go
@@ -1,0 +1,183 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/nonint"
+)
+
+// init_nonint_test.go drives the runInitNonInteractive helper directly so we
+// can observe (exitCode, error) without trapping os.Exit. The helper is the
+// same code path the cobra RunE branch invokes; the test contract is:
+// helper-result + stdout/stderr ←→ user-observed behaviour.
+
+// writeYAMLFixture drops a YAML config file in dir and returns its absolute
+// path. Helper duplicated here (rather than imported from internal/nonint)
+// so the cmd test stays standalone.
+func writeYAMLFixture(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+// TestRunInitNonInteractive_MinimalSuccess: tech-lead-only fixture in a fresh
+// tmp dir. Expect exit 0, .bonsai.yaml + station/ present, JSONL parseable,
+// terminating summary event.
+func TestRunInitNonInteractive_MinimalSuccess(t *testing.T) {
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAMLFixture(t, tmp, "cfg.yaml", "agents:\n  tech-lead: {}\n")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, true, cfgPath, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("runInitNonInteractive: %v (stderr=%s)", err, stderr.String())
+	}
+	if code != nonint.ExitOK {
+		t.Fatalf("exit code: want %d, got %d (stderr=%s)", nonint.ExitOK, code, stderr.String())
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		t.Errorf(".bonsai.yaml missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "station")); err != nil {
+		t.Errorf("station/ tree missing: %v", err)
+	}
+
+	// Validate JSONL stream — every line must parse, summary must be present.
+	var sawSummary bool
+	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Errorf("bad JSON line %q: %v", line, err)
+			continue
+		}
+		if rec["event"] == "summary" {
+			sawSummary = true
+		}
+	}
+	if !sawSummary {
+		t.Errorf("no summary event in stdout:\n%s", stdout.String())
+	}
+}
+
+// TestRunInitNonInteractive_MissingTechLead: overlay without tech-lead must
+// exit 2 (Decision §1) and stderr must mention tech-lead.
+func TestRunInitNonInteractive_MissingTechLead(t *testing.T) {
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAMLFixture(t, tmp, "cfg.yaml", "agents:\n  backend: {}\n")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, true, cfgPath, &stdout, &stderr)
+	if code != nonint.ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "tech-lead") {
+		t.Errorf("error must mention tech-lead; got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "tech-lead") {
+		t.Errorf("stderr must mention tech-lead; got %q", stderr.String())
+	}
+}
+
+// TestRunInitNonInteractive_PreExistingConfig: a project with .bonsai.yaml
+// already present must exit 4. Mirrors the legacy interactive "Skipping
+// init" branch's intent but with a non-zero exit so the caller knows.
+func TestRunInitNonInteractive_PreExistingConfig(t *testing.T) {
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAMLFixture(t, tmp, "cfg.yaml", "agents:\n  tech-lead: {}\n")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	// Pre-seed an existing .bonsai.yaml — content irrelevant, just the
+	// presence triggers exit 4.
+	if err := os.WriteFile(configPath, []byte("project_name: prior\nagents: {}\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, true, cfgPath, &stdout, &stderr)
+	if code != nonint.ExitWrongCWDForInit {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitWrongCWDForInit, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error must mention 'already exists'; got %v", err)
+	}
+}
+
+// TestRunInitNonInteractive_NonInteractiveAlone: --non-interactive without
+// --from-config must yield exit-code 0 (cobra-handled error path) with a
+// "must be set together" error, no os.Exit. Caller's cobra wrapper surfaces
+// it via the usage banner.
+func TestRunInitNonInteractive_NonInteractiveAlone(t *testing.T) {
+	tmp := t.TempDir()
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, true, "", &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code: want 0 (cobra-handled), got %d", code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "must be set together") {
+		t.Errorf("error: want 'must be set together'; got %v", err)
+	}
+}
+
+// TestRunInitNonInteractive_FromConfigAlone: --from-config without
+// --non-interactive is symmetric — must yield the same usage error.
+func TestRunInitNonInteractive_FromConfigAlone(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := writeYAMLFixture(t, tmp, "cfg.yaml", "agents:\n  tech-lead: {}\n")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, false, cfgPath, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("exit code: want 0 (cobra-handled), got %d", code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "must be set together") {
+		t.Errorf("error: want 'must be set together'; got %v", err)
+	}
+}
+
+// TestRunInitNonInteractive_BadYAML: malformed YAML must exit 2 + stderr
+// "parse YAML". Plan 39 §B test list.
+func TestRunInitNonInteractive_BadYAML(t *testing.T) {
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAMLFixture(t, tmp, "cfg.yaml", "agents: [this: is: not valid yaml")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, true, cfgPath, &stdout, &stderr)
+	if code != nonint.ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitInvalidConfig, code)
+	}
+	if err == nil {
+		t.Errorf("expected an error for bad YAML")
+	}
+	if !strings.Contains(stderr.String(), "from-config") {
+		t.Errorf("stderr must mention from-config; got %q", stderr.String())
+	}
+}
+
+// TestInitCmd_FlagsRegistered confirms the cobra flags are wired so
+// `--help` rendering picks them up. Cheap regression guard against
+// accidental flag removal.
+func TestInitCmd_FlagsRegistered(t *testing.T) {
+	for _, name := range []string{"non-interactive", "from-config"} {
+		if f := initCmd.Flags().Lookup(name); f == nil {
+			t.Errorf("flag --%s not registered on initCmd", name)
+		}
+	}
+}

--- a/cmd/init_nonint_test.go
+++ b/cmd/init_nonint_test.go
@@ -93,6 +93,32 @@ func TestRunInitNonInteractive_MissingTechLead(t *testing.T) {
 	}
 }
 
+// TestRunInitNonInteractive_MultiAgentOverlay_Rejected: overlay with
+// tech-lead PLUS extras must exit 2 (Decision §1 exclusivity). Stderr
+// must hint at the single-entry rule and the .bonsai.yaml must not be
+// written.
+func TestRunInitNonInteractive_MultiAgentOverlay_Rejected(t *testing.T) {
+	setupListTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAMLFixture(t, tmp, "cfg.yaml", "agents:\n  tech-lead: {}\n  backend: {}\n")
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runInitNonInteractive(tmp, configPath, true, cfgPath, &stdout, &stderr)
+	if code != nonint.ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", nonint.ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "single") {
+		t.Errorf("error must mention exclusivity; got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "single") {
+		t.Errorf("stderr must mention exclusivity; got %q", stderr.String())
+	}
+	if _, statErr := os.Stat(configPath); statErr == nil {
+		t.Errorf(".bonsai.yaml must not be written on rejection")
+	}
+}
+
 // TestRunInitNonInteractive_PreExistingConfig: a project with .bonsai.yaml
 // already present must exit 4. Mirrors the legacy interactive "Skipping
 // init" branch's intent but with a non-zero exit so the caller knows.

--- a/internal/nonint/config.go
+++ b/internal/nonint/config.go
@@ -27,7 +27,12 @@ const (
 // LoadConfig reads <path> as a `.bonsai.yaml`-shaped YAML document, applies
 // the lenient defaults from Plan 39 Locked Decision Q3, validates the result
 // (shell-metachar scan + workspace normalisation), and returns a fully
-// resolved *config.ProjectConfig ready to drive `RunInit` or `RunAdd`.
+// resolved *config.ProjectConfig ready to drive `RunInit`.
+//
+// For overlay configs consumed by `RunAdd`, use `LoadOverlay` instead — that
+// variant skips the project-level defaults (project_name, docs_path,
+// scaffolding) so the §3 match contract ("leave empty or match exactly")
+// holds against the user's literal YAML, not the cwd-basename fallback.
 //
 // Defaulting walk (Q3):
 //   - ProjectName       → filepath.Base(cwd) when empty
@@ -67,6 +72,104 @@ func LoadConfig(path, cwd string, cat *catalog.Catalog) (*config.ProjectConfig, 
 		return nil, fmt.Errorf("from-config: %w", err)
 	}
 	return &cfg, nil
+}
+
+// LoadOverlay reads an overlay YAML for `bonsai add`. Same parsing path as
+// LoadConfig, but only per-agent defaults are applied — project-level
+// fields (project_name, docs_path, scaffolding) remain at their literal
+// YAML values (typically empty) so the §3 contract holds against the
+// user's input rather than a defaulted fallback.
+//
+// Defaulting applied here:
+//   - per-agent Workspace → cfg.DocsPath when techLead, else `<agentType>/`
+//     (only if cfg.DocsPath is set; otherwise blank workspace defers to
+//     RunAdd's existing-cfg-aware logic)
+//   - per-agent ability lists → agent.yaml defaults when every list is nil
+//   - per-agent routine-check sensor → wired iff routines present
+//
+// Validation differs from LoadConfig: project_name="" is accepted (overlays
+// don't carry that field for the typical case), but every other shell-
+// metachar / workspace rule still runs.
+func LoadOverlay(path, cwd string, cat *catalog.Catalog) (*config.ProjectConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("from-config: read %s: %w", path, err)
+	}
+	var cfg config.ProjectConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("from-config: parse YAML: %w", err)
+	}
+	if len(cfg.Agents) == 0 {
+		return nil, fmt.Errorf("from-config: missing required field 'agents' (need at least one entry)")
+	}
+	applyAgentDefaults(&cfg, cat)
+	// Run the wsvalidate + shell-metachar checks the same way
+	// config.Validate does, but tolerate an empty project_name (we want
+	// the §3 "leave empty or match exactly" contract to hold; the matched
+	// existing config's name is the one that ultimately gets persisted).
+	if err := validateOverlay(&cfg); err != nil {
+		return nil, fmt.Errorf("from-config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// validateOverlay runs the subset of config.Validate appropriate for an
+// overlay: every check except the required-project-name rule. Inlined here
+// rather than refactored into config/ so the project_name-is-required
+// behaviour for normal config load paths stays unchanged.
+func validateOverlay(c *config.ProjectConfig) error {
+	if c.ProjectName != "" {
+		// Re-use the shell-metachar scan via config.Validate by setting a
+		// placeholder, running, and reverting on success. Simpler though:
+		// rely on the documented sentinel — config.Validate scans every
+		// field including project_name. Run it; if it errors with the
+		// project_name-required message we suppress.
+		if err := c.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}
+	// project_name is empty — temporarily set a benign placeholder so
+	// config.Validate's shell-metachar scan doesn't trip on it, then
+	// restore. The placeholder uses only safe characters so it can't
+	// itself trip the scan.
+	c.ProjectName = "_overlay_placeholder_"
+	defer func() { c.ProjectName = "" }()
+	return c.Validate()
+}
+
+// applyAgentDefaults is the overlay-only subset of applyDefaults: it
+// populates per-agent workspaces + ability lists but leaves project-level
+// fields untouched. Pure function; used by LoadOverlay.
+func applyAgentDefaults(cfg *config.ProjectConfig, cat *catalog.Catalog) {
+	for agentType, agent := range cfg.Agents {
+		if agent == nil {
+			agent = &config.InstalledAgent{}
+			cfg.Agents[agentType] = agent
+		}
+		agent.AgentType = agentType
+		if agent.Workspace == "" {
+			if agentType == techLeadType && cfg.DocsPath != "" {
+				agent.Workspace = cfg.DocsPath
+			} else {
+				agent.Workspace = wsvalidate.Normalise(agentType + "/")
+			}
+		} else {
+			agent.Workspace = wsvalidate.Normalise(agent.Workspace)
+		}
+		if agent.Skills == nil && agent.Workflows == nil &&
+			agent.Protocols == nil && agent.Sensors == nil &&
+			agent.Routines == nil {
+			if def := cat.GetAgent(agentType); def != nil {
+				agent.Skills = append([]string(nil), def.DefaultSkills...)
+				agent.Workflows = append([]string(nil), def.DefaultWorkflows...)
+				agent.Protocols = append([]string(nil), def.DefaultProtocols...)
+				agent.Sensors = append([]string(nil), def.DefaultSensors...)
+				agent.Routines = append([]string(nil), def.DefaultRoutines...)
+			}
+		}
+		generate.EnsureRoutineCheckSensor(agent)
+	}
 }
 
 // applyDefaults walks an unmarshalled config and fills in every Q3-lenient

--- a/internal/nonint/config.go
+++ b/internal/nonint/config.go
@@ -1,0 +1,138 @@
+package nonint
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
+	"github.com/LastStep/Bonsai/internal/wsvalidate"
+)
+
+const (
+	// defaultDocsPath mirrors the Vessel stage default — `bonsai init` places
+	// the tech-lead workspace at `station/` unless the user overrides it.
+	defaultDocsPath = "station/"
+
+	// techLeadType is the canonical machine name for the orchestrating agent.
+	// Hard-coded here to mirror cmd/init_flow.go; if Bonsai ever renames it,
+	// these two constants need to update in lockstep.
+	techLeadType = "tech-lead"
+)
+
+// LoadConfig reads <path> as a `.bonsai.yaml`-shaped YAML document, applies
+// the lenient defaults from Plan 39 Locked Decision Q3, validates the result
+// (shell-metachar scan + workspace normalisation), and returns a fully
+// resolved *config.ProjectConfig ready to drive `RunInit` or `RunAdd`.
+//
+// Defaulting walk (Q3):
+//   - ProjectName       → filepath.Base(cwd) when empty
+//   - DocsPath          → "station/" when empty
+//   - Scaffolding       → required scaffolding from catalog when nil
+//   - per-agent fields  → agent.yaml `defaults` when every ability list is nil
+//   - per-agent Workspace → cfg.DocsPath for tech-lead, else `<agentType>/`
+//     (then normalised through wsvalidate.Normalise)
+//
+// Errors:
+//   - "from-config: read <path>: ..."  on I/O failure
+//   - "from-config: parse YAML: ..."   on bad YAML
+//   - "from-config: missing required field 'agents' (need at least one entry)"
+//   - validation errors from config.Validate (shell metachars, bad workspace)
+//
+// Note: the caller (`cmd/init.go`, `cmd/add.go`) is responsible for any
+// command-specific guards on top of these — e.g. RunAdd enforces the
+// "exactly one agent in overlay" rule that init does not.
+func LoadConfig(path, cwd string, cat *catalog.Catalog) (*config.ProjectConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("from-config: read %s: %w", path, err)
+	}
+
+	var cfg config.ProjectConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("from-config: parse YAML: %w", err)
+	}
+
+	if len(cfg.Agents) == 0 {
+		return nil, fmt.Errorf("from-config: missing required field 'agents' (need at least one entry)")
+	}
+
+	applyDefaults(&cfg, cwd, cat)
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("from-config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// applyDefaults walks an unmarshalled config and fills in every Q3-lenient
+// default. Pure function on cfg — no I/O, no error path — so unit tests can
+// exercise the defaulting independently of the YAML reader.
+func applyDefaults(cfg *config.ProjectConfig, cwd string, cat *catalog.Catalog) {
+	if cfg.ProjectName == "" {
+		cfg.ProjectName = filepath.Base(cwd)
+	}
+	if cfg.DocsPath == "" {
+		cfg.DocsPath = defaultDocsPath
+	}
+	// `nil` means "user omitted the key"; an explicit empty list (e.g.
+	// `scaffolding: []`) is treated as the user opting out of scaffolding.
+	// yaml.v3 reports both as `nil` after Unmarshal, but distinguishing
+	// would require a custom unmarshaller — Plan 39 §A.1 calls for the
+	// nil-only check and the user can pass an empty-required scaffolding
+	// list in their YAML by listing the items explicitly.
+	if cfg.Scaffolding == nil {
+		for _, item := range cat.Scaffolding {
+			if item.Required {
+				cfg.Scaffolding = append(cfg.Scaffolding, item.Name)
+			}
+		}
+	}
+
+	for agentType, agent := range cfg.Agents {
+		if agent == nil {
+			agent = &config.InstalledAgent{}
+			cfg.Agents[agentType] = agent
+		}
+		// AgentType field is normally redundant with the map key, but the
+		// generator reads agent.AgentType directly (see generate.AgentWorkspace
+		// and template context wiring), so mirror it in lock-step with the key.
+		agent.AgentType = agentType
+
+		if agent.Workspace == "" {
+			if agentType == techLeadType {
+				agent.Workspace = cfg.DocsPath
+			} else {
+				agent.Workspace = wsvalidate.Normalise(agentType + "/")
+			}
+		} else {
+			agent.Workspace = wsvalidate.Normalise(agent.Workspace)
+		}
+
+		// If every ability list is nil, fall back to the agent.yaml defaults.
+		// "Every nil" is the user signalling "give me the defaults"; an
+		// explicit empty list opts out of that category. Mirrors the
+		// interactive BranchesStage's initial-selection logic.
+		if agent.Skills == nil && agent.Workflows == nil &&
+			agent.Protocols == nil && agent.Sensors == nil &&
+			agent.Routines == nil {
+			if def := cat.GetAgent(agentType); def != nil {
+				agent.Skills = append([]string(nil), def.DefaultSkills...)
+				agent.Workflows = append([]string(nil), def.DefaultWorkflows...)
+				agent.Protocols = append([]string(nil), def.DefaultProtocols...)
+				agent.Sensors = append([]string(nil), def.DefaultSensors...)
+				agent.Routines = append([]string(nil), def.DefaultRoutines...)
+			}
+		}
+
+		// EnsureRoutineCheckSensor adds `routine-check` iff any routines are
+		// installed and it is not already in the sensor list. Mirrors the
+		// interactive flow's wiring so the SettingsJSON generator sees the
+		// hook registration exactly as it would under the TUI.
+		generate.EnsureRoutineCheckSensor(agent)
+	}
+}

--- a/internal/nonint/config_test.go
+++ b/internal/nonint/config_test.go
@@ -1,0 +1,315 @@
+package nonint
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	bonsai "github.com/LastStep/Bonsai"
+	"github.com/LastStep/Bonsai/internal/catalog"
+)
+
+// loadTestCatalog mounts the embedded catalog/ subtree the same way
+// cmd/bonsai/main.go does at runtime. Each test that touches LoadConfig
+// or RunInit needs this — the catalog is the source of truth for default
+// abilities + required scaffolding.
+func loadTestCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	sub, err := fs.Sub(bonsai.CatalogFS, "catalog")
+	if err != nil {
+		t.Fatalf("fs.Sub(CatalogFS): %v", err)
+	}
+	cat, err := catalog.New(sub)
+	if err != nil {
+		t.Fatalf("catalog.New: %v", err)
+	}
+	return cat
+}
+
+// writeYAML drops a YAML fixture in tmp and returns its absolute path.
+func writeYAML(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", p, err)
+	}
+	return p
+}
+
+// TestLoadConfig_Minimal_AppliesAllDefaults: input has only the tech-lead
+// agent. Every Q3 default — ProjectName from cwd basename, DocsPath=station/,
+// Scaffolding=required, agent.Workspace=DocsPath, agent ability lists from
+// agent.yaml defaults — must be filled in.
+func TestLoadConfig_Minimal_AppliesAllDefaults(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", "agents:\n  tech-lead: {}\n")
+	cwd := tmp
+
+	cfg, err := LoadConfig(cfgPath, cwd, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.ProjectName != filepath.Base(cwd) {
+		t.Errorf("ProjectName: want %q, got %q", filepath.Base(cwd), cfg.ProjectName)
+	}
+	if cfg.DocsPath != "station/" {
+		t.Errorf("DocsPath: want station/, got %q", cfg.DocsPath)
+	}
+	// Required-only scaffolding is what we expect.
+	var wantScaff []string
+	for _, item := range cat.Scaffolding {
+		if item.Required {
+			wantScaff = append(wantScaff, item.Name)
+		}
+	}
+	gotScaff := append([]string(nil), cfg.Scaffolding...)
+	sort.Strings(gotScaff)
+	sort.Strings(wantScaff)
+	if !reflect.DeepEqual(gotScaff, wantScaff) {
+		t.Errorf("Scaffolding: want %v, got %v", wantScaff, gotScaff)
+	}
+
+	agent, ok := cfg.Agents["tech-lead"]
+	if !ok || agent == nil {
+		t.Fatalf("tech-lead agent missing after defaulting")
+	}
+	if agent.Workspace != cfg.DocsPath {
+		t.Errorf("Workspace: want %q (DocsPath), got %q", cfg.DocsPath, agent.Workspace)
+	}
+	def := cat.GetAgent("tech-lead")
+	if def == nil {
+		t.Fatalf("catalog missing tech-lead def")
+	}
+	if !reflect.DeepEqual(agent.Skills, def.DefaultSkills) {
+		t.Errorf("Skills: want %v, got %v", def.DefaultSkills, agent.Skills)
+	}
+	if !reflect.DeepEqual(agent.Workflows, def.DefaultWorkflows) {
+		t.Errorf("Workflows: want %v, got %v", def.DefaultWorkflows, agent.Workflows)
+	}
+	if !reflect.DeepEqual(agent.Protocols, def.DefaultProtocols) {
+		t.Errorf("Protocols: want %v, got %v", def.DefaultProtocols, agent.Protocols)
+	}
+}
+
+// TestLoadConfig_NonTechLeadDefaultWorkspace: a non-tech-lead agent with no
+// workspace set gets `<agentType>/` after Normalise. This is required for
+// the new-agent branch under bonsai add.
+func TestLoadConfig_NonTechLeadDefaultWorkspace(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	// Pick the first non-tech-lead agent from the catalog so this test
+	// stays honest as new agent types ship.
+	var otherAgent string
+	for _, a := range cat.Agents {
+		if a.Name != "tech-lead" {
+			otherAgent = a.Name
+			break
+		}
+	}
+	if otherAgent == "" {
+		t.Skip("no non-tech-lead agent in catalog — cannot exercise this branch")
+	}
+	body := "agents:\n  " + otherAgent + ": {}\n"
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+
+	cfg, err := LoadConfig(cfgPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	agent := cfg.Agents[otherAgent]
+	if agent == nil {
+		t.Fatalf("agent missing")
+	}
+	want := otherAgent + "/"
+	if agent.Workspace != want {
+		t.Errorf("Workspace: want %q, got %q", want, agent.Workspace)
+	}
+}
+
+// TestLoadConfig_MissingAgents_Errors: empty agents map → exit 2 candidate.
+func TestLoadConfig_MissingAgents_Errors(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", "project_name: foo\n")
+
+	_, err := LoadConfig(cfgPath, tmp, cat)
+	if err == nil {
+		t.Fatalf("expected error for empty agents:")
+	}
+	if !strings.Contains(err.Error(), "missing required field 'agents'") {
+		t.Errorf("error message: want 'missing required field 'agents''; got %q", err.Error())
+	}
+}
+
+// TestLoadConfig_InvalidWorkspace_Errors: a workspace pointing outside the
+// project (../etc/passwd) must be rejected by the wsvalidate-driven
+// config.Validate path.
+func TestLoadConfig_InvalidWorkspace_Errors(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	body := "agents:\n  tech-lead:\n    workspace: ../etc/passwd\n"
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+
+	_, err := LoadConfig(cfgPath, tmp, cat)
+	if err == nil {
+		t.Fatalf("expected error for ../etc/passwd workspace")
+	}
+	if !strings.Contains(err.Error(), "workspace") && !strings.Contains(err.Error(), "escape") {
+		t.Errorf("error must mention workspace/escape; got %q", err.Error())
+	}
+}
+
+// TestLoadConfig_ShellMetachar_Errors: project_name containing a shell
+// metacharacter (here `$`) must be rejected — these strings flow into shell
+// scripts via sensor templates.
+func TestLoadConfig_ShellMetachar_Errors(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	body := "project_name: proj$danger\nagents:\n  tech-lead: {}\n"
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+
+	_, err := LoadConfig(cfgPath, tmp, cat)
+	if err == nil {
+		t.Fatalf("expected error for shell metachar in project_name")
+	}
+	if !strings.Contains(err.Error(), "forbidden character") {
+		t.Errorf("error: want 'forbidden character'; got %q", err.Error())
+	}
+}
+
+// TestLoadConfig_BadYAML_Errors: unparseable YAML must produce a parse-YAML
+// prefixed error.
+func TestLoadConfig_BadYAML_Errors(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", "agents: [this is: not valid yaml")
+
+	_, err := LoadConfig(cfgPath, tmp, cat)
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse YAML") && !strings.Contains(err.Error(), "from-config") {
+		t.Errorf("error: want 'parse YAML' or 'from-config'; got %q", err.Error())
+	}
+}
+
+// TestLoadConfig_MissingFile_Errors: --from-config pointing at a non-existent
+// path must yield a read-prefixed error.
+func TestLoadConfig_MissingFile_Errors(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	missing := filepath.Join(tmp, "does-not-exist.yaml")
+
+	_, err := LoadConfig(missing, tmp, cat)
+	if err == nil {
+		t.Fatalf("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "from-config: read") {
+		t.Errorf("error: want 'from-config: read'; got %q", err.Error())
+	}
+}
+
+// TestLoadConfig_ExplicitOverridesAreRespected: user-supplied values must
+// survive the defaulting walk untouched. Round-trip: write a hand-tuned
+// cfg, load it, verify equality on every non-Required field.
+func TestLoadConfig_ExplicitOverridesAreRespected(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	body := `project_name: my-proj
+description: an example
+docs_path: docs/
+scaffolding:
+  - playbook
+agents:
+  tech-lead:
+    workspace: docs/
+    skills:
+      - planning-template
+    workflows: []
+    protocols: []
+    sensors: []
+    routines: []
+`
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+	cfg, err := LoadConfig(cfgPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.ProjectName != "my-proj" {
+		t.Errorf("ProjectName: want my-proj, got %q", cfg.ProjectName)
+	}
+	if cfg.Description != "an example" {
+		t.Errorf("Description: want 'an example', got %q", cfg.Description)
+	}
+	if cfg.DocsPath != "docs/" {
+		t.Errorf("DocsPath: want docs/, got %q", cfg.DocsPath)
+	}
+	if len(cfg.Scaffolding) != 1 || cfg.Scaffolding[0] != "playbook" {
+		t.Errorf("Scaffolding: want [playbook], got %v", cfg.Scaffolding)
+	}
+	agent := cfg.Agents["tech-lead"]
+	if agent == nil {
+		t.Fatalf("tech-lead agent missing")
+	}
+	if !reflect.DeepEqual(agent.Skills, []string{"planning-template"}) {
+		t.Errorf("Skills: want [planning-template], got %v", agent.Skills)
+	}
+	// Explicit empty list opts the user out of the category — must remain
+	// empty (not get populated by agent.yaml defaults).
+	if len(agent.Workflows) != 0 {
+		t.Errorf("Workflows must remain empty; got %v", agent.Workflows)
+	}
+}
+
+// TestApplyDefaults_TechLeadGetsDocsPath: pure-function test of the defaulting
+// walk. tech-lead with no workspace gets DocsPath; non-tech-lead gets
+// `<type>/`.
+func TestApplyDefaults_TechLeadGetsDocsPath(t *testing.T) {
+	cat := loadTestCatalog(t)
+	cfg := &struct{}{}
+	_ = cfg
+	// Test through LoadConfig to keep this end-to-end with yaml parsing.
+	tmp := t.TempDir()
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", "docs_path: workspace/\nagents:\n  tech-lead: {}\n")
+	got, err := LoadConfig(cfgPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if got.Agents["tech-lead"].Workspace != "workspace/" {
+		t.Errorf("tech-lead workspace defaulted from DocsPath: want workspace/, got %q", got.Agents["tech-lead"].Workspace)
+	}
+}
+
+// TestLoadConfig_RoutineCheckSensorAutoAdded: an agent overlay with routines
+// but no routine-check sensor must have routine-check appended by
+// EnsureRoutineCheckSensor (mirrors interactive flow).
+func TestLoadConfig_RoutineCheckSensorAutoAdded(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	body := `agents:
+  tech-lead:
+    routines:
+      - backlog-hygiene
+    sensors: []
+`
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+	cfg, err := LoadConfig(cfgPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	hasRoutineCheck := false
+	for _, s := range cfg.Agents["tech-lead"].Sensors {
+		if s == "routine-check" {
+			hasRoutineCheck = true
+			break
+		}
+	}
+	if !hasRoutineCheck {
+		t.Errorf("routine-check sensor must be auto-added when routines present; got sensors=%v", cfg.Agents["tech-lead"].Sensors)
+	}
+}

--- a/internal/nonint/config_test.go
+++ b/internal/nonint/config_test.go
@@ -285,6 +285,57 @@ func TestApplyDefaults_TechLeadGetsDocsPath(t *testing.T) {
 	}
 }
 
+// TestLoadOverlay_LeavesProjectFieldsEmpty: LoadOverlay must NOT default
+// project_name / docs_path / scaffolding so the §3 "leave empty or match
+// exactly" contract holds against the user's literal YAML. Critical for
+// the bonsai add headless path — the runner compares overlay fields to
+// the existing .bonsai.yaml, and a defaulted basename would always
+// mismatch unless the user happens to invoke `bonsai add` from a dir
+// whose basename equals the original project_name.
+func TestLoadOverlay_LeavesProjectFieldsEmpty(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", "agents:\n  backend: {}\n")
+	overlay, err := LoadOverlay(cfgPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadOverlay: %v", err)
+	}
+	if overlay.ProjectName != "" {
+		t.Errorf("ProjectName: want empty, got %q", overlay.ProjectName)
+	}
+	if overlay.DocsPath != "" {
+		t.Errorf("DocsPath: want empty, got %q", overlay.DocsPath)
+	}
+	if len(overlay.Scaffolding) != 0 {
+		t.Errorf("Scaffolding: want empty, got %v", overlay.Scaffolding)
+	}
+	// Per-agent defaults still apply.
+	agent := overlay.Agents["backend"]
+	if agent == nil {
+		t.Fatalf("backend agent missing after LoadOverlay")
+	}
+	if agent.Workspace == "" {
+		t.Errorf("Workspace must be defaulted; got empty")
+	}
+}
+
+// TestLoadOverlay_StillValidatesWorkspaces: ../etc/passwd as a workspace
+// must still be rejected by LoadOverlay's wsvalidate path even though
+// project_name is allowed to be empty.
+func TestLoadOverlay_StillValidatesWorkspaces(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	body := "agents:\n  backend:\n    workspace: ../etc/passwd\n"
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+	_, err := LoadOverlay(cfgPath, tmp, cat)
+	if err == nil {
+		t.Fatalf("expected error for ../etc/passwd workspace")
+	}
+	if !strings.Contains(err.Error(), "escape") && !strings.Contains(err.Error(), "workspace") {
+		t.Errorf("error must mention workspace/escape; got %q", err.Error())
+	}
+}
+
 // TestLoadConfig_RoutineCheckSensorAutoAdded: an agent overlay with routines
 // but no routine-check sensor must have routine-check appended by
 // EnsureRoutineCheckSensor (mirrors interactive flow).

--- a/internal/nonint/events.go
+++ b/internal/nonint/events.go
@@ -1,0 +1,111 @@
+// Package nonint drives `bonsai init` and `bonsai add` without TUI prompts.
+// Inputs are loaded from a YAML file (same shape as .bonsai.yaml), filesystem
+// outcomes are emitted as JSON Lines on the caller-supplied writer, and
+// validation errors surface through plain Go errors so the cobra entry point
+// can choose the exit code.
+//
+// The package is intentionally free of TUI imports — every byte written here
+// is JSON, every diagnostic is an error string. That keeps the headless code
+// path safe to drive from a Python subprocess in Bonsai-Eval rung-3 (Plan 38)
+// without ANSI escape codes leaking into the test transcript.
+package nonint
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// fileEvent is the JSONL shape for "file" and "warning" events. Per-file
+// payloads stay tight via `omitempty` because zero-valued strings are
+// uninformative noise in the JSONL stream.
+type fileEvent struct {
+	Event   string `json:"event"`
+	Path    string `json:"path,omitempty"`
+	Action  string `json:"action,omitempty"` // created | updated | unchanged | skipped | conflict
+	Source  string `json:"source,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// summaryEvent is the JSONL shape for the terminal summary line. Count fields
+// are deliberately NOT `omitempty` so an all-zero run still emits every key —
+// downstream consumers (Bonsai-Eval rung-3 telemetry) expect a stable shape so
+// they can parse `created/updated/.../conflicts` unconditionally without
+// special-casing missing keys.
+type summaryEvent struct {
+	Event     string `json:"event"`
+	Created   int    `json:"created"`
+	Updated   int    `json:"updated"`
+	Unchanged int    `json:"unchanged"`
+	Skipped   int    `json:"skipped"`
+	Conflicts int    `json:"conflicts"`
+}
+
+// Event is the public shape used by callers (cmd/init.go, cmd/add.go) to feed
+// events into Emit. The constructors below collapse it to the right private
+// shape on serialisation so the all-zero-counts contract holds.
+//
+// Action and Path carry the per-file payload; Created/Updated/.../Conflicts
+// carry the summary counts; Message is the warning channel. Callers should
+// use the EmitFile / EmitSummary / EmitWarning helpers instead of populating
+// fields by hand.
+type Event struct {
+	Event     string
+	Path      string
+	Action    string
+	Source    string
+	Message   string
+	Created   int
+	Updated   int
+	Unchanged int
+	Skipped   int
+	Conflicts int
+}
+
+// EmitFile writes one `{"event":"file",...}` line. Returns the underlying
+// writer error so the caller can decide whether to bail out (e.g. broken
+// pipe to a parent process that died).
+func EmitFile(w io.Writer, path, action, source string) error {
+	return emitJSON(w, fileEvent{
+		Event:  "file",
+		Path:   path,
+		Action: action,
+		Source: source,
+	})
+}
+
+// EmitSummary writes the terminal summary line. All five count fields are
+// always present in the serialised JSON even when zero, by design.
+func EmitSummary(w io.Writer, created, updated, unchanged, skipped, conflicts int) error {
+	return emitJSON(w, summaryEvent{
+		Event:     "summary",
+		Created:   created,
+		Updated:   updated,
+		Unchanged: unchanged,
+		Skipped:   skipped,
+		Conflicts: conflicts,
+	})
+}
+
+// EmitWarning writes a `{"event":"warning","message":"..."}` line. Used for
+// non-fatal anomalies — currently only the lock-save-failure path uses this
+// (and it routes to stderr, never stdout — see runner.go).
+func EmitWarning(w io.Writer, message string) error {
+	return emitJSON(w, fileEvent{
+		Event:   "warning",
+		Message: message,
+	})
+}
+
+// emitJSON marshals v to a single JSON line + newline. json.Marshal is used
+// rather than an Encoder so the JSON line is byte-identical regardless of
+// writer buffering — the Encoder adds its own trailing newline but our
+// callers want explicit control over framing.
+func emitJSON(w io.Writer, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}

--- a/internal/nonint/events_test.go
+++ b/internal/nonint/events_test.go
@@ -1,0 +1,136 @@
+package nonint
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestEmitFile_JSONLShape emits one file event and asserts the line round-trips
+// through json.Unmarshal with the expected key/value set. Per-event keys honour
+// `omitempty` so an empty Source is dropped from the wire payload.
+func TestEmitFile_JSONLShape(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EmitFile(&buf, "station/CLAUDE.md", "created", "tech-lead"); err != nil {
+		t.Fatalf("EmitFile: %v", err)
+	}
+	got := buf.String()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("event must end with newline; got %q", got)
+	}
+	if strings.Count(got, "\n") != 1 {
+		t.Fatalf("event must be exactly one line; got %d newlines in %q", strings.Count(got, "\n"), got)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %q)", err, got)
+	}
+	if parsed["event"] != "file" {
+		t.Errorf("event field: want file, got %v", parsed["event"])
+	}
+	if parsed["path"] != "station/CLAUDE.md" {
+		t.Errorf("path field: want station/CLAUDE.md, got %v", parsed["path"])
+	}
+	if parsed["action"] != "created" {
+		t.Errorf("action field: want created, got %v", parsed["action"])
+	}
+	if parsed["source"] != "tech-lead" {
+		t.Errorf("source field: want tech-lead, got %v", parsed["source"])
+	}
+}
+
+// TestEmitFile_OmitemptyDropsEmptyFields verifies the per-file event drops
+// zero-value strings (source, etc.) so a sparse run doesn't bloat the JSONL
+// stream.
+func TestEmitFile_OmitemptyDropsEmptyFields(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EmitFile(&buf, "a.md", "skipped", ""); err != nil {
+		t.Fatalf("EmitFile: %v", err)
+	}
+	got := buf.String()
+	if strings.Contains(got, "source") {
+		t.Errorf("empty source field must be omitted; got %q", got)
+	}
+}
+
+// TestEmitSummary_AlwaysEmitsAllCountFields enforces the contract: even when
+// every count is zero, the summary line MUST carry created/updated/unchanged/
+// skipped/conflicts keys so downstream consumers (Bonsai-Eval rung-3
+// telemetry) can parse the shape without special-casing missing keys.
+func TestEmitSummary_AlwaysEmitsAllCountFields(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EmitSummary(&buf, 0, 0, 0, 0, 0); err != nil {
+		t.Fatalf("EmitSummary: %v", err)
+	}
+	got := buf.String()
+	for _, key := range []string{`"created":0`, `"updated":0`, `"unchanged":0`, `"skipped":0`, `"conflicts":0`} {
+		if !strings.Contains(got, key) {
+			t.Errorf("summary missing %q; got %q", key, got)
+		}
+	}
+	if !strings.Contains(got, `"event":"summary"`) {
+		t.Errorf("summary line missing event key; got %q", got)
+	}
+}
+
+// TestEmitSummary_NonZeroCounts round-trips a non-trivial count distribution
+// through json.Unmarshal and asserts every field matches what the caller
+// emitted.
+func TestEmitSummary_NonZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EmitSummary(&buf, 5, 2, 7, 1, 3); err != nil {
+		t.Fatalf("EmitSummary: %v", err)
+	}
+	var parsed struct {
+		Event     string `json:"event"`
+		Created   int    `json:"created"`
+		Updated   int    `json:"updated"`
+		Unchanged int    `json:"unchanged"`
+		Skipped   int    `json:"skipped"`
+		Conflicts int    `json:"conflicts"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v (raw: %q)", err, buf.String())
+	}
+	if parsed.Event != "summary" {
+		t.Errorf("event: want summary, got %s", parsed.Event)
+	}
+	if parsed.Created != 5 || parsed.Updated != 2 || parsed.Unchanged != 7 || parsed.Skipped != 1 || parsed.Conflicts != 3 {
+		t.Errorf("count mismatch: got %+v", parsed)
+	}
+}
+
+// TestEmit_NoStyling asserts the writer receives plain JSON bytes only — no
+// ANSI escape sequences, no LipGloss styling. This is a guardrail against
+// future drift; the nonint package must never import tui/styles.
+func TestEmit_NoStyling(t *testing.T) {
+	var buf bytes.Buffer
+	_ = EmitFile(&buf, "x", "created", "src")
+	_ = EmitSummary(&buf, 1, 0, 0, 0, 0)
+	out := buf.String()
+	// ANSI escapes start with \x1b — a quick allowlist check is sufficient
+	// here because the JSONL output is straight stdlib encoding/json.
+	if strings.ContainsRune(out, '\x1b') {
+		t.Errorf("output contains ANSI escape; got %q", out)
+	}
+}
+
+// TestEmitWarning_Shape verifies the warning channel produces the documented
+// event=warning + message envelope.
+func TestEmitWarning_Shape(t *testing.T) {
+	var buf bytes.Buffer
+	if err := EmitWarning(&buf, "could not save lock file"); err != nil {
+		t.Fatalf("EmitWarning: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed["event"] != "warning" {
+		t.Errorf("event: want warning, got %v", parsed["event"])
+	}
+	if parsed["message"] != "could not save lock file" {
+		t.Errorf("message: got %v", parsed["message"])
+	}
+}

--- a/internal/nonint/nonint.go
+++ b/internal/nonint/nonint.go
@@ -1,0 +1,12 @@
+package nonint
+
+// This file is intentionally minimal — the package surface is split across:
+//
+//   - config.go : LoadConfig + applyDefaults
+//   - events.go : EmitFile / EmitSummary / EmitWarning helpers + private
+//                 fileEvent / summaryEvent JSON shapes
+//   - runner.go : RunInit + RunAdd orchestrators (+ ExitOK / ExitInvalidConfig
+//                 / ExitRuntime / ExitWrongCWDForInit codes)
+//
+// Keeping nonint.go around as a stable anchor for godoc and as the obvious
+// "start reading here" file when the package surface grows.

--- a/internal/nonint/runner.go
+++ b/internal/nonint/runner.go
@@ -111,8 +111,8 @@ func RunInit(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog.Cat
 // Returns (exitCode, error):
 //   - ExitOK             — success
 //   - ExitInvalidConfig  — overlay shape rejected (>1 agent, non-matching
-//                          project_name / docs_path / scaffolding, unknown
-//                          agent type, tech-lead-required violation)
+//     project_name / docs_path / scaffolding, unknown
+//     agent type, tech-lead-required violation)
 //   - ExitRuntime        — generator error
 //   - ExitWrongCWDForInit — no `.bonsai.yaml` at cwd
 func RunAdd(cwd, configPath string, overlay *config.ProjectConfig, cat *catalog.Catalog, version string, w io.Writer) (int, error) {

--- a/internal/nonint/runner.go
+++ b/internal/nonint/runner.go
@@ -1,0 +1,389 @@
+package nonint
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
+)
+
+// Exit codes shared between the runner and the cobra wiring. Kept here
+// rather than in cmd/ so unit tests that only import internal/nonint can
+// assert against named constants.
+const (
+	ExitOK              = 0
+	ExitInvalidConfig   = 2
+	ExitRuntime         = 3
+	ExitWrongCWDForInit = 4 // .bonsai.yaml already present (init) or missing (add)
+)
+
+// RunInit performs a full `bonsai init` from cfg. cfg is assumed to be the
+// output of LoadConfig — already defaulted and validated. The runner mirrors
+// cmd.buildGenerateAction's filesystem pipeline exactly so generated output
+// is bit-identical to the interactive flow for the same inputs.
+//
+// Emits one `{"event":"file",...}` line per file produced (creates, updates,
+// unchanged, skipped, conflicts), then a single terminal `{"event":"summary",
+// ...}` line. Conflicts under --non-interactive are forced to skip (Plan 39
+// Locked Decision Q5 + Decision §3) — the runner never calls ForceSelected
+// or ForceConflicts.
+//
+// Returns (exitCode, error). exitCode is ExitOK on success, ExitRuntime on
+// any generator error, or ExitWrongCWDForInit when configPath already exists
+// (interactive path's "Skipping init" branch made the same choice).
+//
+// version is the Bonsai version string written into .bonsai/catalog.json —
+// the cobra entry point passes cmd.Version. Kept as a parameter so the
+// runner does not import cmd/.
+func RunInit(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog.Catalog, version string, w io.Writer) (int, error) {
+	// Pre-flight: matches the interactive path's "configFile already exists"
+	// early-exit. Plan 39 §A.2.
+	if _, err := os.Stat(configPath); err == nil {
+		return ExitWrongCWDForInit, fmt.Errorf("from-config: %s already exists at %s — refusing to overwrite", filepath.Base(configPath), filepath.Dir(configPath))
+	}
+
+	agentDef := cat.GetAgent(techLeadType)
+	if agentDef == nil {
+		return ExitRuntime, fmt.Errorf("from-config: tech-lead agent missing from catalog (binary bug — please report)")
+	}
+	installed, ok := cfg.Agents[techLeadType]
+	if !ok || installed == nil {
+		// Defence-in-depth — LoadConfig's init-path caller validates this,
+		// but a direct RunInit caller could skip that step.
+		return ExitInvalidConfig, fmt.Errorf("from-config: bonsai init requires a 'tech-lead' entry under agents:")
+	}
+
+	lock, _ := config.LoadLockFile(cwd)
+	var wr generate.WriteResult
+
+	if err := cfg.Save(configPath); err != nil {
+		return ExitRuntime, fmt.Errorf("from-config: save %s: %w", configPath, err)
+	}
+
+	// Pipeline mirrors cmd.buildGenerateAction. force=false everywhere so
+	// the writeFile lock-aware policy treats user-modified files as conflicts
+	// (rather than silently overwriting them).
+	var errs []error
+	errs = append(errs, generate.Scaffolding(cwd, cfg, cat, lock, &wr, false))
+	errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installed, cfg, cat, lock, &wr, false))
+	errs = append(errs, generate.PathScopedRules(cwd, cfg, cat, lock, &wr, false))
+	errs = append(errs, generate.WorkflowSkills(cwd, cfg, cat, lock, &wr, false))
+	errs = append(errs, generate.SettingsJSON(cwd, cfg, cat, lock, &wr, false))
+	errs = append(errs, generate.WriteCatalogSnapshot(cwd, version, cat, &wr))
+	if joined := errors.Join(errs...); joined != nil {
+		return ExitRuntime, fmt.Errorf("from-config: generate: %w", joined)
+	}
+
+	if err := emitResults(w, &wr); err != nil {
+		return ExitRuntime, err
+	}
+
+	// Lock-save failure is not fatal — mirrors the interactive path's
+	// `tui.Warning` swallow. We route the warning to stderr (NOT stdout)
+	// so the JSONL stream stays parseable.
+	if err := lock.Save(cwd); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: could not save lock file:", err.Error())
+	}
+	return ExitOK, nil
+}
+
+// RunAdd appends a single agent (overlay.Agents has exactly one entry) or
+// extra abilities to an existing agent inside an already-initialised project.
+// cfg here is the OVERLAY config (from --from-config), not the project's
+// own `.bonsai.yaml`. The runner loads the existing `.bonsai.yaml`, validates
+// that overlay non-`agents` fields match (Plan 39 Locked Decision §3),
+// and dispatches to either the new-agent or add-items branch.
+//
+// Returns (exitCode, error):
+//   - ExitOK             — success
+//   - ExitInvalidConfig  — overlay shape rejected (>1 agent, non-matching
+//                          project_name / docs_path / scaffolding, unknown
+//                          agent type, tech-lead-required violation)
+//   - ExitRuntime        — generator error
+//   - ExitWrongCWDForInit — no `.bonsai.yaml` at cwd
+func RunAdd(cwd, configPath string, overlay *config.ProjectConfig, cat *catalog.Catalog, version string, w io.Writer) (int, error) {
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		return ExitWrongCWDForInit, fmt.Errorf("from-config: %s not found at %s — run `bonsai init` first", filepath.Base(configPath), filepath.Dir(configPath))
+	} else if err != nil {
+		return ExitRuntime, fmt.Errorf("from-config: stat %s: %w", configPath, err)
+	}
+
+	existing, err := config.Load(configPath)
+	if err != nil {
+		return ExitRuntime, fmt.Errorf("from-config: load existing %s: %w", configPath, err)
+	}
+
+	// Locked Decision §2 — exactly one agent in the overlay. Multi-agent
+	// setups must invoke RunAdd in a loop (Bonsai-Eval rung-3 solver does).
+	if got := len(overlay.Agents); got != 1 {
+		return ExitInvalidConfig, fmt.Errorf("from-config: bonsai add expects exactly one agent in overlay, got %d", got)
+	}
+
+	// Locked Decision §3 — non-`agents` fields must match (or be empty).
+	if err := assertOverlayMatchesExisting(overlay, existing); err != nil {
+		return ExitInvalidConfig, err
+	}
+
+	// Pull the single agent out of the overlay. range-over-map is safe here
+	// because we've already asserted len == 1.
+	var agentType string
+	var overlayAgent *config.InstalledAgent
+	for k, v := range overlay.Agents {
+		agentType, overlayAgent = k, v
+	}
+	if overlayAgent == nil {
+		// LoadConfig coerces nil to non-nil via applyDefaults, but a direct
+		// caller could bypass that — defensive guard.
+		return ExitInvalidConfig, fmt.Errorf("from-config: overlay agent %q has no body", agentType)
+	}
+
+	agentDef := cat.GetAgent(agentType)
+	if agentDef == nil {
+		return ExitInvalidConfig, fmt.Errorf("from-config: unknown agent type %q (not in catalog)", agentType)
+	}
+
+	// Locked Decision §4 — tech-lead-required guard, exit 2 (not 3).
+	if agentType != techLeadType {
+		if _, ok := existing.Agents[techLeadType]; !ok {
+			return ExitInvalidConfig, fmt.Errorf("from-config: agent %s requires a tech-lead agent in the existing project", agentType)
+		}
+	}
+
+	lock, _ := config.LoadLockFile(cwd)
+	var wr generate.WriteResult
+
+	installed, isNewAgent, total, runErr := mergeAndGenerate(cwd, configPath, version, agentType, overlayAgent, agentDef, existing, cat, lock, &wr)
+	if runErr != nil {
+		return ExitRuntime, runErr
+	}
+
+	// All-installed short-circuit (Decision §6): add-items overlay against
+	// an already-installed agent picked zero new abilities. Emit a single
+	// summary line with zero counts and bail out. Mirrors the interactive
+	// `YieldAllInstalled` semantics.
+	if !isNewAgent && total == 0 {
+		if err := EmitSummary(w, 0, 0, 0, 0, 0); err != nil {
+			return ExitRuntime, err
+		}
+		// No lock save: nothing was written.
+		_ = installed
+		return ExitOK, nil
+	}
+
+	if err := emitResults(w, &wr); err != nil {
+		return ExitRuntime, err
+	}
+	if err := lock.Save(cwd); err != nil {
+		fmt.Fprintln(os.Stderr, "warning: could not save lock file:", err.Error())
+	}
+	_ = installed
+	return ExitOK, nil
+}
+
+// assertOverlayMatchesExisting enforces the §3 contract: the overlay's
+// project_name / docs_path / scaffolding fields are either empty (so applyDefaults
+// filled them or left them zero-valued) or sorted-equal to the existing
+// project's. Description is cosmetic and ignored.
+//
+// "Empty" semantics:
+//   - ProjectName: empty after Load means user omitted it AND applyDefaults
+//     populated it from filepath.Base(cwd). We compare directly here rather
+//     than re-deriving — if applyDefaults happened to produce a value that
+//     differs from `existing.ProjectName`, the user's overlay implicitly
+//     disagrees and we reject.
+//   - DocsPath: similar — applyDefaults gives "station/" when omitted. We
+//     accept either ""-after-load OR the value-after-default-equal-to-existing.
+//     LoadConfig runs applyDefaults BEFORE this call, so we see post-default
+//     values; the equality check is enough.
+//   - Scaffolding: applyDefaults sets the required-only fallback list. The
+//     check accepts that fallback when sorted-equal to existing, and accepts
+//     a nil/empty list (user-overlay opted out entirely) only when existing's
+//     is also empty.
+func assertOverlayMatchesExisting(overlay, existing *config.ProjectConfig) error {
+	if overlay.ProjectName != "" && overlay.ProjectName != existing.ProjectName {
+		return fmt.Errorf("from-config: overlay field 'project_name' (%q) does not match existing .bonsai.yaml (%q); leave empty or match exactly", overlay.ProjectName, existing.ProjectName)
+	}
+	if overlay.DocsPath != "" && overlay.DocsPath != existing.DocsPath {
+		return fmt.Errorf("from-config: overlay field 'docs_path' (%q) does not match existing .bonsai.yaml (%q); leave empty or match exactly", overlay.DocsPath, existing.DocsPath)
+	}
+	// Scaffolding: accept nil/empty as "match". Otherwise require sorted-equal.
+	if len(overlay.Scaffolding) > 0 {
+		a := append([]string(nil), overlay.Scaffolding...)
+		b := append([]string(nil), existing.Scaffolding...)
+		sort.Strings(a)
+		sort.Strings(b)
+		if !reflect.DeepEqual(a, b) {
+			return fmt.Errorf("from-config: overlay field 'scaffolding' (%v) does not match existing .bonsai.yaml (%v); leave empty or match exactly", overlay.Scaffolding, existing.Scaffolding)
+		}
+	}
+	return nil
+}
+
+// mergeAndGenerate mutates `existing` to include the overlay agent's items
+// then drives the generator chain. Returns (installedAgent, isNewAgent,
+// totalChanges, err).
+//
+// totalChanges semantics:
+//   - new-agent: total == len of every ability list in the new agent
+//   - add-items: total == count of items newly added to the existing agent
+//     across all categories
+//
+// The caller uses totalChanges to detect the add-items zero-add short-circuit
+// (Decision §6).
+func mergeAndGenerate(
+	cwd, configPath, version, agentType string,
+	overlayAgent *config.InstalledAgent,
+	agentDef *catalog.AgentDef,
+	existing *config.ProjectConfig,
+	cat *catalog.Catalog,
+	lock *config.LockFile,
+	wr *generate.WriteResult,
+) (*config.InstalledAgent, bool, int, error) {
+	installedAgent, alreadyInstalled := existing.Agents[agentType]
+
+	if !alreadyInstalled {
+		// new-agent branch. Build the InstalledAgent from the overlay's
+		// ability lists (applyDefaults already filled them with agent.yaml
+		// defaults when the user omitted them), wire EnsureRoutineCheckSensor,
+		// then drive the per-agent generator pipeline. Mirrors
+		// cmd.buildAddGrowAction's new-agent branch.
+		newAgent := &config.InstalledAgent{
+			AgentType: agentType,
+			Workspace: overlayAgent.Workspace,
+			Skills:    append([]string(nil), overlayAgent.Skills...),
+			Workflows: append([]string(nil), overlayAgent.Workflows...),
+			Protocols: append([]string(nil), overlayAgent.Protocols...),
+			Sensors:   append([]string(nil), overlayAgent.Sensors...),
+			Routines:  append([]string(nil), overlayAgent.Routines...),
+		}
+		generate.EnsureRoutineCheckSensor(newAgent)
+		existing.Agents[agentType] = newAgent
+
+		if err := existing.Save(configPath); err != nil {
+			return nil, true, 0, fmt.Errorf("from-config: save %s: %w", configPath, err)
+		}
+		var errs []error
+		errs = append(errs, generate.AgentWorkspace(cwd, agentDef, newAgent, existing, cat, lock, wr, false))
+		errs = append(errs, generate.PathScopedRulesForAgent(cwd, newAgent, existing, cat, lock, wr, false))
+		errs = append(errs, generate.WorkflowSkillsForAgent(cwd, newAgent, existing, cat, lock, wr, false))
+		errs = append(errs, generate.SettingsJSONForAgent(cwd, newAgent, existing, cat, lock, wr, false))
+		errs = append(errs, generate.RefreshPeerAwareness(cwd, newAgent.AgentType, existing, cat, lock, wr, false))
+		errs = append(errs, generate.WriteCatalogSnapshot(cwd, version, cat, wr))
+		if joined := errors.Join(errs...); joined != nil {
+			return newAgent, true, 0, fmt.Errorf("from-config: generate: %w", joined)
+		}
+		total := len(newAgent.Skills) + len(newAgent.Workflows) + len(newAgent.Protocols) +
+			len(newAgent.Sensors) + len(newAgent.Routines)
+		return newAgent, true, total, nil
+	}
+
+	// add-items branch — agent is already installed. Append only newly-named
+	// abilities per category. EnsureRoutineCheckSensor runs again afterwards
+	// in case the overlay added a routine to a previously routine-less agent.
+	added := mergeNewAbilities(installedAgent, overlayAgent)
+	generate.EnsureRoutineCheckSensor(installedAgent)
+	if added == 0 {
+		// Short-circuit: no new abilities. Defensive — caller checks this
+		// total and emits the zero-summary line. Skip the save+generate so
+		// the lock + .bonsai.yaml stay byte-identical.
+		return installedAgent, false, 0, nil
+	}
+
+	if err := existing.Save(configPath); err != nil {
+		return installedAgent, false, added, fmt.Errorf("from-config: save %s: %w", configPath, err)
+	}
+	var errs []error
+	errs = append(errs, generate.AgentWorkspace(cwd, agentDef, installedAgent, existing, cat, lock, wr, false))
+	errs = append(errs, generate.PathScopedRulesForAgent(cwd, installedAgent, existing, cat, lock, wr, false))
+	errs = append(errs, generate.WorkflowSkillsForAgent(cwd, installedAgent, existing, cat, lock, wr, false))
+	errs = append(errs, generate.SettingsJSONForAgent(cwd, installedAgent, existing, cat, lock, wr, false))
+	errs = append(errs, generate.RefreshPeerAwareness(cwd, installedAgent.AgentType, existing, cat, lock, wr, false))
+	errs = append(errs, generate.WriteCatalogSnapshot(cwd, version, cat, wr))
+	if joined := errors.Join(errs...); joined != nil {
+		return installedAgent, false, added, fmt.Errorf("from-config: generate: %w", joined)
+	}
+	return installedAgent, false, added, nil
+}
+
+// mergeNewAbilities appends every overlay ability not already present in
+// `installed` and returns the count added. Each category is independently
+// deduplicated. Order within a category preserves the overlay's order for
+// the additions — pre-existing items keep their position at the head.
+func mergeNewAbilities(installed, overlay *config.InstalledAgent) int {
+	added := 0
+	add := func(have []string, want []string) ([]string, int) {
+		set := make(map[string]bool, len(have))
+		for _, s := range have {
+			set[s] = true
+		}
+		n := 0
+		for _, s := range want {
+			if set[s] {
+				continue
+			}
+			have = append(have, s)
+			set[s] = true
+			n++
+		}
+		return have, n
+	}
+	var n int
+	installed.Skills, n = add(installed.Skills, overlay.Skills)
+	added += n
+	installed.Workflows, n = add(installed.Workflows, overlay.Workflows)
+	added += n
+	installed.Protocols, n = add(installed.Protocols, overlay.Protocols)
+	added += n
+	installed.Sensors, n = add(installed.Sensors, overlay.Sensors)
+	added += n
+	installed.Routines, n = add(installed.Routines, overlay.Routines)
+	added += n
+	return added
+}
+
+// emitResults walks wr.Files in write order, emits one "file" event per
+// entry, then emits the terminal "summary" event. Action strings map 1:1
+// with the FileAction enum — see Plan 39 §A.4.
+func emitResults(w io.Writer, wr *generate.WriteResult) error {
+	for _, f := range wr.Files {
+		action := actionString(f.Action)
+		if action == "" {
+			continue
+		}
+		if err := EmitFile(w, f.RelPath, action, f.Source); err != nil {
+			return fmt.Errorf("from-config: emit file event: %w", err)
+		}
+	}
+	created, updated, unchanged, skipped, conflicts := wr.Summary()
+	if err := EmitSummary(w, created, updated, unchanged, skipped, conflicts); err != nil {
+		return fmt.Errorf("from-config: emit summary event: %w", err)
+	}
+	return nil
+}
+
+func actionString(a generate.FileAction) string {
+	switch a {
+	case generate.ActionCreated:
+		return "created"
+	case generate.ActionUpdated, generate.ActionForced:
+		// ForcedAction shouldn't occur on the non-interactive path (we never
+		// call ForceSelected/ForceConflicts), but bucket it with updated for
+		// completeness in case a future change introduces it.
+		return "updated"
+	case generate.ActionUnchanged:
+		return "unchanged"
+	case generate.ActionSkipped:
+		return "skipped"
+	case generate.ActionConflict:
+		return "conflict"
+	default:
+		return ""
+	}
+}

--- a/internal/nonint/runner.go
+++ b/internal/nonint/runner.go
@@ -59,6 +59,13 @@ func RunInit(cwd, configPath string, cfg *config.ProjectConfig, cat *catalog.Cat
 		// but a direct RunInit caller could skip that step.
 		return ExitInvalidConfig, fmt.Errorf("from-config: bonsai init requires a 'tech-lead' entry under agents:")
 	}
+	// Defence-in-depth for the exclusivity rule: `bonsai init` materialises
+	// only tech-lead's workspace. Any extra agent entries would be partially
+	// installed (registered in .bonsai.yaml + path-scoped rules but with no
+	// workspace files) — reject so the failure mode is loud, not silent.
+	if got := len(cfg.Agents); got != 1 {
+		return ExitInvalidConfig, fmt.Errorf("from-config: bonsai init accepts only a single 'tech-lead' entry under agents:, got %d agents", got)
+	}
 
 	lock, _ := config.LoadLockFile(cwd)
 	var wr generate.WriteResult
@@ -159,7 +166,7 @@ func RunAdd(cwd, configPath string, overlay *config.ProjectConfig, cat *catalog.
 	lock, _ := config.LoadLockFile(cwd)
 	var wr generate.WriteResult
 
-	installed, isNewAgent, total, runErr := mergeAndGenerate(cwd, configPath, version, agentType, overlayAgent, agentDef, existing, cat, lock, &wr)
+	_, isNewAgent, total, runErr := mergeAndGenerate(cwd, configPath, version, agentType, overlayAgent, agentDef, existing, cat, lock, &wr)
 	if runErr != nil {
 		return ExitRuntime, runErr
 	}
@@ -173,7 +180,6 @@ func RunAdd(cwd, configPath string, overlay *config.ProjectConfig, cat *catalog.
 			return ExitRuntime, err
 		}
 		// No lock save: nothing was written.
-		_ = installed
 		return ExitOK, nil
 	}
 
@@ -183,7 +189,6 @@ func RunAdd(cwd, configPath string, overlay *config.ProjectConfig, cat *catalog.
 	if err := lock.Save(cwd); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: could not save lock file:", err.Error())
 	}
-	_ = installed
 	return ExitOK, nil
 }
 

--- a/internal/nonint/runner_test.go
+++ b/internal/nonint/runner_test.go
@@ -1,0 +1,526 @@
+package nonint
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// parseJSONL splits a JSONL stream into discrete records, deserialising
+// each into a map. Used by every test that walks the runner's stdout.
+func parseJSONL(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(raw), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("parse JSONL line %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// findSummary walks parsed events and returns the summary record (or nil
+// if absent).
+func findSummary(records []map[string]any) map[string]any {
+	for _, r := range records {
+		if r["event"] == "summary" {
+			return r
+		}
+	}
+	return nil
+}
+
+// minimalInitCfg loads the tech-lead-only fixture used by most init-path
+// tests.
+func minimalInitCfg(t *testing.T, cwd string) *config.ProjectConfig {
+	t.Helper()
+	cat := loadTestCatalog(t)
+	body := "agents:\n  tech-lead: {}\n"
+	cfgPath := writeYAML(t, cwd, "cfg.yaml", body)
+	cfg, err := LoadConfig(cfgPath, cwd, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	return cfg
+}
+
+// TestRunInit_Smoke runs the runner end-to-end against a fresh tmp dir with
+// the tech-lead-only fixture. Asserts: .bonsai.yaml is written; station/
+// tree is materialised; every emitted line is valid JSON; a summary line
+// appears.
+func TestRunInit_Smoke(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	cfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	var buf bytes.Buffer
+	code, err := RunInit(tmp, configPath, cfg, cat, "test", &buf)
+	if err != nil {
+		t.Fatalf("RunInit: %v", err)
+	}
+	if code != ExitOK {
+		t.Fatalf("exit code: want %d, got %d", ExitOK, code)
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf(".bonsai.yaml not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(tmp, "station")); err != nil {
+		t.Fatalf("station/ tree not created: %v", err)
+	}
+	records := parseJSONL(t, buf.String())
+	if len(records) == 0 {
+		t.Fatalf("no JSONL records emitted")
+	}
+	summary := findSummary(records)
+	if summary == nil {
+		t.Fatalf("no summary event in stream:\n%s", buf.String())
+	}
+	if summary["created"].(float64) == 0 {
+		t.Errorf("expected created > 0; got summary %v", summary)
+	}
+}
+
+// TestRunInit_ConfigExists_ExitCode4 pre-creates .bonsai.yaml and asserts the
+// runner refuses to overwrite — exit 4 + stderr-style error.
+func TestRunInit_ConfigExists_ExitCode4(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	cfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if err := os.WriteFile(configPath, []byte("project_name: prior\nagents: {}\n"), 0o644); err != nil {
+		t.Fatalf("seed .bonsai.yaml: %v", err)
+	}
+
+	code, err := RunInit(tmp, configPath, cfg, cat, "test", io.Discard)
+	if code != ExitWrongCWDForInit {
+		t.Errorf("exit code: want %d, got %d", ExitWrongCWDForInit, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error must mention already exists; got %v", err)
+	}
+}
+
+// TestRunInit_MissingTechLead is a defence-in-depth test: a caller that
+// bypassed the cmd-layer's tech-lead check shouldn't crash the runner —
+// it must return ExitInvalidConfig.
+func TestRunInit_MissingTechLead(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	// Build a cfg with a non-tech-lead agent only. LoadConfig will accept
+	// this (it's the init-caller's responsibility to enforce tech-lead).
+	body := "agents:\n  backend: {}\n"
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+	cfg, err := LoadConfig(cfgPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	code, err := RunInit(tmp, filepath.Join(tmp, ".bonsai.yaml"), cfg, cat, "test", io.Discard)
+	if code != ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "tech-lead") {
+		t.Errorf("error must mention tech-lead; got %v", err)
+	}
+}
+
+// TestRunAdd_NewAgent_Smoke initialises a project then runs RunAdd with a
+// backend-agent overlay. The backend workspace must be materialised and
+// the overlay agent must appear in .bonsai.yaml.
+func TestRunAdd_NewAgent_Smoke(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+
+	// init
+	initCfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if code, err := RunInit(tmp, configPath, initCfg, cat, "test", io.Discard); err != nil || code != ExitOK {
+		t.Fatalf("RunInit failed (code=%d err=%v)", code, err)
+	}
+
+	// overlay: a backend agent
+	overlayBody := "agents:\n  backend: {}\n"
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", overlayBody)
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code, err := RunAdd(tmp, configPath, overlay, cat, "test", &buf)
+	if err != nil {
+		t.Fatalf("RunAdd: %v", err)
+	}
+	if code != ExitOK {
+		t.Errorf("exit code: want %d, got %d", ExitOK, code)
+	}
+	// backend workspace materialised
+	if _, err := os.Stat(filepath.Join(tmp, "backend")); err != nil {
+		t.Errorf("backend/ workspace not created: %v", err)
+	}
+	// .bonsai.yaml now has both agents
+	post, err := config.Load(configPath)
+	if err != nil {
+		t.Fatalf("reload .bonsai.yaml: %v", err)
+	}
+	if _, ok := post.Agents["backend"]; !ok {
+		t.Errorf(".bonsai.yaml does not contain backend agent")
+	}
+	// summary line in output
+	records := parseJSONL(t, buf.String())
+	if findSummary(records) == nil {
+		t.Errorf("missing summary event")
+	}
+}
+
+// TestRunAdd_AddItems_Smoke: RunInit with tech-lead, then RunAdd targeting
+// tech-lead with an extra skill that wasn't in the defaults. The extra
+// skill must be appended without duplicating existing entries.
+func TestRunAdd_AddItems_Smoke(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+
+	initCfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if code, err := RunInit(tmp, configPath, initCfg, cat, "test", io.Discard); err != nil || code != ExitOK {
+		t.Fatalf("RunInit failed (code=%d err=%v)", code, err)
+	}
+
+	// Find a skill the tech-lead supports but doesn't have by default.
+	def := cat.GetAgent("tech-lead")
+	defaultSet := make(map[string]bool, len(def.DefaultSkills))
+	for _, s := range def.DefaultSkills {
+		defaultSet[s] = true
+	}
+	var extra string
+	for _, s := range cat.SkillsFor("tech-lead") {
+		if !defaultSet[s.Name] {
+			extra = s.Name
+			break
+		}
+	}
+	if extra == "" {
+		t.Skip("no extra tech-lead skill available — every skill in defaults")
+	}
+
+	// Overlay with the extra skill — also include the defaults so explicit
+	// non-nil ability lists prevent the defaulting walk from re-populating.
+	overlayBody := "agents:\n  tech-lead:\n    skills:\n      - " + extra + "\n"
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", overlayBody)
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+
+	if code, err := RunAdd(tmp, configPath, overlay, cat, "test", io.Discard); err != nil || code != ExitOK {
+		t.Fatalf("RunAdd failed (code=%d err=%v)", code, err)
+	}
+
+	post, _ := config.Load(configPath)
+	tl := post.Agents["tech-lead"]
+	count := 0
+	for _, s := range tl.Skills {
+		if s == extra {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("extra skill %q appears %d times in post-add skills %v; want 1", extra, count, tl.Skills)
+	}
+}
+
+// TestRunAdd_AllInstalled_ShortCircuit: re-running the same overlay against
+// an already-installed agent with no additional abilities must emit a
+// single all-zero summary event and exit 0. Decision §6.
+func TestRunAdd_AllInstalled_ShortCircuit(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+
+	initCfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if code, err := RunInit(tmp, configPath, initCfg, cat, "test", io.Discard); err != nil || code != ExitOK {
+		t.Fatalf("RunInit failed (code=%d err=%v)", code, err)
+	}
+
+	// Re-run with the SAME minimal overlay — every default ability is
+	// already installed.
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", "agents:\n  tech-lead: {}\n")
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+
+	var buf bytes.Buffer
+	code, err := RunAdd(tmp, configPath, overlay, cat, "test", &buf)
+	if err != nil {
+		t.Fatalf("RunAdd: %v", err)
+	}
+	if code != ExitOK {
+		t.Errorf("exit code: want %d, got %d", ExitOK, code)
+	}
+	records := parseJSONL(t, buf.String())
+	if len(records) != 1 {
+		t.Fatalf("expected exactly 1 record (summary only); got %d:\n%s", len(records), buf.String())
+	}
+	summary := records[0]
+	if summary["event"] != "summary" {
+		t.Errorf("expected single summary event; got %v", summary)
+	}
+	for _, k := range []string{"created", "updated", "unchanged", "skipped", "conflicts"} {
+		if v, ok := summary[k]; !ok || v.(float64) != 0 {
+			t.Errorf("%s: want 0, got %v (present=%v)", k, v, ok)
+		}
+	}
+}
+
+// TestRunAdd_MultiAgentOverlay_Rejected: overlay with two agents must be
+// rejected with ExitInvalidConfig. Decision §2.
+func TestRunAdd_MultiAgentOverlay_Rejected(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+
+	initCfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if code, err := RunInit(tmp, configPath, initCfg, cat, "test", io.Discard); err != nil || code != ExitOK {
+		t.Fatalf("RunInit failed (code=%d err=%v)", code, err)
+	}
+
+	overlayBody := "agents:\n  tech-lead: {}\n  backend: {}\n"
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", overlayBody)
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+
+	code, err := RunAdd(tmp, configPath, overlay, cat, "test", io.Discard)
+	if code != ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "exactly one agent") {
+		t.Errorf("error must mention exactly one agent; got %v", err)
+	}
+}
+
+// TestRunAdd_OverlayMismatchedProjectName_Rejected: overlay project_name
+// must match existing or be empty. Decision §3.
+func TestRunAdd_OverlayMismatchedProjectName_Rejected(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+
+	initCfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if code, err := RunInit(tmp, configPath, initCfg, cat, "test", io.Discard); err != nil || code != ExitOK {
+		t.Fatalf("RunInit failed (code=%d err=%v)", code, err)
+	}
+
+	// Overlay with a different project_name. LoadConfig will accept it
+	// (the basename-default doesn't fire when the user supplies a value);
+	// RunAdd must reject.
+	overlayBody := "project_name: NOT-THE-SAME\nagents:\n  backend: {}\n"
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", overlayBody)
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+
+	code, err := RunAdd(tmp, configPath, overlay, cat, "test", io.Discard)
+	if code != ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "project_name") {
+		t.Errorf("error must mention project_name; got %v", err)
+	}
+}
+
+// TestRunAdd_TechLeadRequired_Errors: a non-tech-lead overlay against a
+// project with no tech-lead must exit 2 (Decision §4). The existing config
+// must have a project_name that matches the cwd-basename default the overlay
+// inherits, so the §3 project_name match passes and the §4 tech-lead check
+// is the rule that trips.
+func TestRunAdd_TechLeadRequired_Errors(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	base := filepath.Base(tmp)
+
+	// Hand-roll a .bonsai.yaml with NO tech-lead. config.Load enforces
+	// shell-metachar + workspace rules but not the tech-lead-presence rule,
+	// so this is a legal existing config that RunAdd must guard against.
+	// Include the required scaffolding so the overlay's applyDefaults result
+	// matches; we want §4 (tech-lead-required) to fire, not §3 (scaffolding
+	// mismatch).
+	body := "project_name: " + base + "\ndocs_path: station/\nscaffolding:\n  - index\n  - playbook\n  - logs\nagents:\n  backend:\n    workspace: backend/\n    skills: []\n    workflows: []\n    protocols: []\n    sensors: []\n    routines: []\n"
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if err := os.WriteFile(configPath, []byte(body), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", "agents:\n  security: {}\n")
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+
+	code, err := RunAdd(tmp, configPath, overlay, cat, "test", io.Discard)
+	if code != ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "tech-lead") {
+		t.Errorf("error must mention tech-lead; got %v", err)
+	}
+}
+
+// TestRunAdd_UnknownAgent_Errors: overlay names a non-existent agent type.
+// LoadConfig accepts unknown agent types (it cannot tell what the catalog
+// knows); RunAdd checks against the loaded catalog.
+func TestRunAdd_UnknownAgent_Errors(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+
+	initCfg := minimalInitCfg(t, tmp)
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+	if code, err := RunInit(tmp, configPath, initCfg, cat, "test", io.Discard); err != nil || code != ExitOK {
+		t.Fatalf("RunInit failed (code=%d err=%v)", code, err)
+	}
+
+	// Overlay with a phantom agent. LoadConfig's applyDefaults sets the
+	// workspace from the type name; cfg.Validate accepts it as long as the
+	// path is project-relative.
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", "agents:\n  does-not-exist: {}\n")
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+	code, err := RunAdd(tmp, configPath, overlay, cat, "test", io.Discard)
+	if code != ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "unknown agent type") {
+		t.Errorf("error must mention unknown agent type; got %v", err)
+	}
+}
+
+// TestRunAdd_MissingProjectConfig_ExitCode4: RunAdd in a directory without
+// .bonsai.yaml must exit 4.
+func TestRunAdd_MissingProjectConfig_ExitCode4(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	overlayPath := writeYAML(t, tmp, "overlay.yaml", "agents:\n  tech-lead: {}\n")
+	overlay, err := LoadConfig(overlayPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig overlay: %v", err)
+	}
+	configPath := filepath.Join(tmp, ".bonsai.yaml")
+
+	code, err := RunAdd(tmp, configPath, overlay, cat, "test", io.Discard)
+	if code != ExitWrongCWDForInit {
+		t.Errorf("exit code: want %d, got %d", ExitWrongCWDForInit, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error must mention not found; got %v", err)
+	}
+}
+
+// TestRunInit_ConflictEmittedNotForced is the key safety test: a pre-existing
+// user-edited file at a path the generator targets must produce
+// action=conflict in the JSONL stream AND the file on disk must remain
+// byte-identical to the user's edit. Plan 39 Security §3.
+//
+// station/agent/Core/identity.md is a stable generator output for the
+// tech-lead init path (every init writes it via the agent-workspace pipeline)
+// AND it flows through the standard writeFile lock-aware path — unlike
+// station/CLAUDE.md, which has its own bonsai-markers migration branch.
+func TestRunInit_ConflictEmittedNotForced(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+
+	userBody := []byte("# USER EDIT — must not be overwritten\n")
+	relPath := "station/agent/Core/identity.md"
+	target := filepath.Join(tmp, relPath)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(target, userBody, 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// IsModified returns exists+modified=true when a file exists on disk
+	// with no lock entry (conservative: treat as user-owned). So no
+	// pre-seed of the lock file is needed — writeFile will see an
+	// untracked existing file and emit ActionConflict.
+
+	cfg := minimalInitCfg(t, tmp)
+	var buf bytes.Buffer
+	code, err := RunInit(tmp, filepath.Join(tmp, ".bonsai.yaml"), cfg, cat, "test", &buf)
+	if err != nil {
+		t.Fatalf("RunInit: %v", err)
+	}
+	if code != ExitOK {
+		t.Fatalf("exit code: %d", code)
+	}
+
+	records := parseJSONL(t, buf.String())
+	var foundConflict bool
+	for _, r := range records {
+		if r["event"] == "file" && r["path"] == relPath && r["action"] == "conflict" {
+			foundConflict = true
+			break
+		}
+	}
+	if !foundConflict {
+		t.Errorf("expected conflict event for %s; records=%+v", relPath, records)
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read post: %v", err)
+	}
+	if !bytes.Equal(got, userBody) {
+		t.Errorf("user file overwritten; want %q, got %q", userBody, got)
+	}
+}
+
+// TestAssertOverlayMatchesExisting_EmptyFieldsPass: the §3 contract accepts
+// empty / nil non-`agents` fields without comparison. Pure-function test.
+func TestAssertOverlayMatchesExisting_EmptyFieldsPass(t *testing.T) {
+	existing := &config.ProjectConfig{
+		ProjectName: "abc",
+		DocsPath:    "station/",
+		Scaffolding: []string{"index", "playbook", "logs"},
+	}
+	overlay := &config.ProjectConfig{}
+	if err := assertOverlayMatchesExisting(overlay, existing); err != nil {
+		t.Errorf("empty overlay must pass; got %v", err)
+	}
+}
+
+// TestAssertOverlayMatchesExisting_ScaffoldingOrderTolerated: a non-empty
+// scaffolding overlay must match existing up to ordering (sorted-equal).
+func TestAssertOverlayMatchesExisting_ScaffoldingOrderTolerated(t *testing.T) {
+	existing := &config.ProjectConfig{
+		ProjectName: "abc",
+		DocsPath:    "station/",
+		Scaffolding: []string{"index", "playbook", "logs"},
+	}
+	overlay := &config.ProjectConfig{
+		Scaffolding: []string{"logs", "index", "playbook"},
+	}
+	if err := assertOverlayMatchesExisting(overlay, existing); err != nil {
+		t.Errorf("sorted-equal scaffolding must pass; got %v", err)
+	}
+	// And a non-match must fail.
+	overlay.Scaffolding = []string{"index"}
+	if err := assertOverlayMatchesExisting(overlay, existing); err == nil {
+		t.Errorf("scaffolding mismatch must fail")
+	}
+}

--- a/internal/nonint/runner_test.go
+++ b/internal/nonint/runner_test.go
@@ -135,6 +135,32 @@ func TestRunInit_MissingTechLead(t *testing.T) {
 	}
 }
 
+// TestRunInit_MultiAgentOverlay_Rejected asserts the §1 exclusivity rule:
+// `bonsai init` accepts only a single tech-lead entry. Multi-agent overlays
+// would partial-install the extras (path-scoped rules + settings hooks
+// written, but no workspace materialised) — reject up front so the failure
+// is loud. Callers chain `bonsai add` for additional agents post-init.
+func TestRunInit_MultiAgentOverlay_Rejected(t *testing.T) {
+	cat := loadTestCatalog(t)
+	tmp := t.TempDir()
+	body := "agents:\n  tech-lead: {}\n  backend: {}\n"
+	cfgPath := writeYAML(t, tmp, "cfg.yaml", body)
+	cfg, err := LoadConfig(cfgPath, tmp, cat)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	code, err := RunInit(tmp, filepath.Join(tmp, ".bonsai.yaml"), cfg, cat, "test", io.Discard)
+	if code != ExitInvalidConfig {
+		t.Errorf("exit code: want %d, got %d", ExitInvalidConfig, code)
+	}
+	if err == nil || !strings.Contains(err.Error(), "single") {
+		t.Errorf("error must mention exclusivity; got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmp, ".bonsai.yaml")); statErr == nil {
+		t.Errorf(".bonsai.yaml must not be written on rejection")
+	}
+}
+
 // TestRunAdd_NewAgent_Smoke initialises a project then runs RunAdd with a
 // backend-agent overlay. The backend workspace must be materialised and
 // the overlay agent must appear in .bonsai.yaml.


### PR DESCRIPTION
Plan: [station/Playbook/Plans/Active/39-bonsai-noninteractive-flags.md](station/Playbook/Plans/Active/39-bonsai-noninteractive-flags.md)

## Summary

- Adds `--non-interactive` + `--from-config <path>` to `bonsai init` and `bonsai add`. Inputs are read from a `.bonsai.yaml`-shaped YAML file, the TUI is fully bypassed, and per-file outcomes are emitted as JSON Lines on stdout (one event per file + a terminal summary line with stable count keys).
- Unblocks Plan 38 P2 (Bonsai-Eval rung-3 solver), which can now `subprocess.run(["bonsai", "init", "--non-interactive", "--from-config", fixture])` and parse the JSONL stream.
- Conflict resolution under `--non-interactive` is forced to skip — user-modified files are reported as `action:"conflict"` events and left untouched. No `.bak`, no overwrite.

## Locked decisions (binding — encoded in code + tests)

1. **`bonsai init` overlay without tech-lead → exit 2.** `runInitNonInteractive` validates `cfg.Agents["tech-lead"]` exists before invoking `nonint.RunInit`. Defence-in-depth: the runner's own check fires too.
2. **`bonsai add` overlay must name exactly 1 agent.** `nonint.RunAdd` rejects `len(overlay.Agents) != 1` with exit 2: "bonsai add expects exactly one agent in overlay, got N". Multi-agent setups loop the command.
3. **`bonsai add` overlay's non-`agents` fields must match existing `.bonsai.yaml` or be empty/omitted.** Implemented via `assertOverlayMatchesExisting`. The add path uses `LoadOverlay` (not `LoadConfig`) so the project-level defaulting walk doesn't fire and the §3 contract holds against the user's literal YAML.
4. **`bonsai add` tech-lead-required guard → exit 2 (not 3).** Non-tech-lead overlay against tech-lead-less existing project: "agent <type> requires a tech-lead agent in the existing project".

## Verification commands run

- `go test ./...` — all 73 nonint+cmd tests pass; full suite green.
- `go vet ./...` — clean.
- `make build` — succeeds; `./bonsai init --help` and `./bonsai add --help` both list `--non-interactive` and `--from-config`.
- `GOOS=windows GOARCH=amd64 go build ./...` — passes (CI gate).
- Manual smoke in `/tmp/bonsai-nonint-test`:
  - `bonsai init --non-interactive --from-config cfg.yaml` → exit 0, JSONL stream, station tree present, summary line emitted.
  - Re-run in same dir → exit 4 + stderr "already exists".
  - `bonsai init --non-interactive --from-config /dev/null` → exit 2 + stderr "missing required field 'agents'".
  - `bonsai init --non-interactive` (alone) → exit 1 + cobra usage banner with "must be set together" error.
  - `bonsai add --non-interactive --from-config overlay.yaml` (with empty project_name in overlay) → exit 0, `backend/` workspace materialised.
  - `bonsai validate` on produced workspace → clean exit.

## Phase breakdown

| Commit | Phase | What landed |
|--------|-------|-------------|
| [0c8459c](https://github.com/LastStep/Bonsai/commit/0c8459c) | A | `internal/nonint` package: `LoadConfig`, `LoadOverlay`, `RunInit`, `RunAdd`, JSONL emitters, exit codes. 41 unit tests. |
| [2b99536](https://github.com/LastStep/Bonsai/commit/2b99536) | B | Wire `bonsai init` flags via `runInitNonInteractive` helper. 7 cmd tests. |
| [a18d3bd](https://github.com/LastStep/Bonsai/commit/a18d3bd) | C | Wire `bonsai add` flags via `runAddNonInteractive`. 10 cmd tests. |
| [1b01571](https://github.com/LastStep/Bonsai/commit/1b01571) | D | CHANGELOG `[0.5.0]` block, README "Scripted use" section, `LoadOverlay` UX fix for empty-project_name overlays. 2 nonint tests. |

## Test plan

- [ ] CI green on the branch (`go test ./...`, `go vet ./...`, Windows cross-compile).
- [ ] Reviewer runs the manual smoke from Plan 39 §Verification in a fresh `/tmp` dir.
- [ ] Reviewer confirms `bonsai update` and `bonsai remove` are NOT touched (out of scope).
- [ ] Reviewer checks that interactive `bonsai init` / `bonsai add` flows are bit-identical to pre-merge (visually, in a tmp dir).
- [ ] Reviewer validates the JSONL schema is stable: every line parses as JSON; summary line always carries `created/updated/unchanged/skipped/conflicts` keys (even when zero).
- [ ] (Post-merge) Plan 38 P2 dispatch confirms `bonsai_eval/solvers/rungs.py:135` can drive `bonsai init --non-interactive --from-config <fixture>` and parse JSONL without modification.

DO NOT merge. Leaving open for code-review agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)