### PR TITLE
fix(generate): bake absolute paths into sensor hook commands (v0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-05-13
+
+> **Hotfix.** Sensor hook commands in generated `.claude/settings.json` no longer use a `$PWD`-walk-up to locate their parent project — they bake the install-time absolute paths instead. Surfaced during the Bonsai-Eval bootstrap dogfood when a Bash invocation drifted between two sibling projects and a Stop hook executed against the wrong workspace.
+
+### Fixed
+- **Sensor hook commands now use absolute paths.** `internal/generate/generate.go` previously emitted `bash -c 'r="$PWD"; while [ ! -f "$r/.bonsai.yaml" ]; do r=$(dirname "$r"); done; bash "$r/<sensor>" "$r"'` for every sensor entry. In any multi-`.bonsai.yaml` setup, the walker landed in whichever project the runtime `$PWD` was under — which could be a *different* Bonsai project than the session was scoped to. Generator now writes `bash "<absolute-script>" "<absolute-project-root>"` instead. Survives bash-cwd drift across sibling projects. Trade-off: settings.json embeds the install-time absolute path, so moving a project requires re-running `bonsai update` to regenerate.
+
+### Notes
+- Run `bonsai update` in any existing Bonsai project to refresh `.claude/settings.json` with the new template. The hook content is the only meaningful change; sensor scripts themselves are unchanged.
+
 ## [0.4.2] - 2026-05-13
 
 > **The "headless Bonsai" release.** `bonsai init` and `bonsai add` now run without TUI prompts under `--non-interactive --from-config`, so automation can materialise an agent workspace from a YAML fixture and parse progress as a clean JSON Lines stream.

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -508,6 +508,19 @@ func writeSettingsJSONForAgent(projectRoot string, installed *config.InstalledAg
 
 	settingsPath := filepath.Join(projectRoot, installed.Workspace, ".claude", "settings.json")
 
+	// Resolve project root to an absolute path so generated hook commands
+	// don't depend on the runtime $PWD when the hook fires. The legacy
+	// template walked $PWD up to the nearest .bonsai.yaml, which fails in
+	// multi-project setups (e.g. a Bash tool invocation in repo A's
+	// session that cd's into sibling repo B silently re-targets B's
+	// sensors). Trade-off: settings.json now embeds the install-time
+	// absolute path, so moving the project requires re-running
+	// `bonsai update` to regenerate.
+	absRoot, absErr := filepath.Abs(projectRoot)
+	if absErr != nil {
+		return fmt.Errorf("resolve project root: %w", absErr)
+	}
+
 	existing := make(map[string]interface{})
 	if data, err := os.ReadFile(settingsPath); err == nil {
 		_ = json.Unmarshal(data, &existing)
@@ -530,11 +543,8 @@ func writeSettingsJSONForAgent(projectRoot string, installed *config.InstalledAg
 			continue
 		}
 		k := groupKey{event, matcher}
-		scriptPath := installed.Workspace + "agent/Sensors/" + sensorName + ".sh"
-		cmd := fmt.Sprintf(
-			`bash -c 'r="$PWD"; while [ "$r" != "/" ] && [ ! -f "$r/.bonsai.yaml" ]; do r=$(dirname "$r"); done; bash "$r/%s" "$r"'`,
-			scriptPath,
-		)
+		scriptPath := filepath.Join(absRoot, installed.Workspace, "agent/Sensors", sensorName+".sh")
+		cmd := fmt.Sprintf("bash %q %q", scriptPath, absRoot)
 		groups[k] = append(groups[k], cmd)
 	}
 

--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -1668,3 +1668,61 @@ func TestSettingsJSONForAgentScope(t *testing.T) {
 		t.Fatalf("expected legacy SettingsJSON to surface a conflict under tech-lead/; got none (wr conflicts=%d total)", len(wrAll.Conflicts()))
 	}
 }
+
+// TestSettingsJSON_HookCommandsAreAbsolutePaths asserts that generated
+// .claude/settings.json sensor hook commands embed the install-time
+// absolute path to the sensor script + project root, rather than the
+// legacy `$PWD`-walk-up template. The walker broke in multi-project
+// setups: a Bash tool invocation in repo A's session that cd's into
+// sibling repo B silently re-targets B's sensors (see Backlog P0 bug
+// surfaced during Plan 39's Bonsai-Eval bootstrap).
+func TestSettingsJSON_HookCommandsAreAbsolutePaths(t *testing.T) {
+	cat, err := buildTestCatalogWithItems(map[string]string{
+		"sensors/scope-guard/meta.yaml":           "name: scope-guard\ndescription: SG\nagents: all\nevent: PreToolUse\nmatcher: \"Edit|Write\"\n",
+		"sensors/scope-guard/scope-guard.sh.tmpl": "#!/usr/bin/env bash\necho sg\n",
+	})
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	cfg := &config.ProjectConfig{
+		ProjectName: "TestProject",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": {
+				AgentType: "tech-lead",
+				Workspace: "station/",
+				Sensors:   []string{"scope-guard"},
+			},
+		},
+	}
+	lock := config.NewLockFile()
+	var wr WriteResult
+	if err := SettingsJSON(tmpDir, cfg, cat, lock, &wr, false); err != nil {
+		t.Fatalf("SettingsJSON: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "station", ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	body := string(data)
+
+	// Legacy walker must not appear anywhere in the generated content.
+	if strings.Contains(body, "$PWD") || strings.Contains(body, "dirname") || strings.Contains(body, ".bonsai.yaml") {
+		t.Fatalf("legacy $PWD-walk template leaked into settings.json:\n%s", body)
+	}
+
+	absRoot, _ := filepath.Abs(tmpDir)
+	expectedScript := filepath.Join(absRoot, "station", "agent/Sensors", "scope-guard.sh")
+	if !strings.Contains(body, expectedScript) {
+		t.Fatalf("expected absolute script path %q in settings.json; got:\n%s", expectedScript, body)
+	}
+	// absRoot must appear at least twice in the body — once as the
+	// script's parent directory, and once as the second positional
+	// argument the hook passes to the sensor. (Quote escaping in the
+	// JSON makes a literal-string suffix match too brittle.)
+	if strings.Count(body, absRoot) < 2 {
+		t.Fatalf("expected absolute project root %q to appear at least twice (script path + hook arg); got:\n%s", absRoot, body)
+	}
+}


### PR DESCRIPTION
Hotfix for the $PWD-walk-up bug surfaced during Bonsai-Eval bootstrap dogfood. See CHANGELOG v0.4.3 + Backlog P0 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)