### PR TITLE
Plan 40 Phase 3 — docs: memory-routing protocol + guide Formats page

### DIFF
--- a/catalog/protocols/memory/memory.md
+++ b/catalog/protocols/memory/memory.md
@@ -7,6 +7,40 @@ description: How to read, write, and clean working memory.
 
 ---
 
+## Three Surfaces — Where a Write Belongs
+
+Persistent project state lives on three distinct surfaces. Before writing
+anything, decide which one it belongs to — they are not interchangeable:
+
+| Surface | What it holds | Where it lives |
+|---------|---------------|----------------|
+| **Working memory** | Session/ephemeral agent state — flags, work-in-progress, cross-session notes | `agent/Core/memory.md` (this protocol) |
+| **Durable memory graph** | Long-lived, linkable record — **decisions**, facts, durable notes | `{memory_dir}/{decisions,notes}/<permalink>.md` |
+| **Logs** | Narrative/process history — what happened, in order | `Logs/` |
+
+Routing rules:
+
+- **A decision was made** → write a durable **decision note** to
+  `{memory_dir}/decisions/<permalink>.md`, following the frozen note schema in
+  `Playbook/Standards/NoteStandards.md` (frontmatter: `schema_version`,
+  `permalink`, `scope`, etc. + Observations / Relations). Link it from the
+  `MEMORY.md` index. This is the durable record other tooling and future
+  sessions read back — not a one-liner in working memory.
+- **A durable fact or reference** the project should keep → a **note** under
+  `{memory_dir}/notes/<permalink>.md`, same schema.
+- **A session needs to know X next time** (a flag, work-in-progress, a transient
+  gotcha) → working memory (`agent/Core/memory.md`), per the rest of this
+  protocol. Working memory is ephemeral — prune it; the durable graph is not.
+- **Process narrative** (how a saga unfolded, a rebase recovery, session
+  history) → `Logs/`, not memory.
+
+> `{memory_dir}` defaults to `station/Memory` (set in the project manifest,
+> `.bonsai/project.yaml`). The durable graph is untouched by working-memory
+> cleanup — a resolved flag is pruned from `memory.md`, but the decision note
+> it referenced stays.
+
+---
+
 ## Reading Memory
 
 At session start, read [agent/Core/memory.md](../Core/memory.md) and act on any flags:
@@ -19,12 +53,16 @@ At session start, read [agent/Core/memory.md](../Core/memory.md) and act on any 
 
 > **Brevity rule:** every memory write follows `Playbook/Standards/NoteStandards.md` — 3 lines max per entry, link out for detail. Work State = one-liner + plan/PR links. Notes = one line per durable gotcha. Phase walkthroughs go in the plan; commit walkthroughs in the PR; process narrative in `Logs/`.
 
-Update `agent/Core/memory.md` when:
+Update `agent/Core/memory.md` (working memory) when:
 
 - You encounter something the next session needs to know
 - A task is partially complete and will continue later
-- A decision was made that affects future work
 - You're blocked and need to flag it
+
+A **decision** that affects future work is not working memory — it goes to the
+durable memory graph (`{memory_dir}/decisions/<permalink>.md`) per the routing
+table above. Leave at most a one-line pointer in working memory if the next
+session needs to act on it.
 
 ## Cleaning Memory
 

--- a/cmd/bonsai/main.go
+++ b/cmd/bonsai/main.go
@@ -24,5 +24,6 @@ func main() {
 		"concepts":     bonsai.GuideConcepts,
 		"cli":          bonsai.GuideCli,
 		"custom-files": bonsai.GuideCustomFiles,
+		"formats":      bonsai.GuideFormats,
 	})
 }

--- a/cmd/guide.go
+++ b/cmd/guide.go
@@ -18,7 +18,7 @@ import (
 // invoked with neither an arg nor a TTY (e.g. piped through less
 // without specifying a topic). Decision D4 in Plan 28's 2026-04-23
 // deltas locks the wording; test asserts verbatim.
-const noTTYNoArgErr = "bonsai guide: specify a topic when piping output (quickstart, concepts, cli, custom-files)"
+const noTTYNoArgErr = "bonsai guide: specify a topic when piping output (quickstart, concepts, cli, custom-files, formats)"
 
 func init() {
 	rootCmd.AddCommand(guideCmd)
@@ -29,7 +29,7 @@ var guideCmd = &cobra.Command{
 	Short: "View bundled guides in the terminal.",
 	Long: "Render one of the bundled guides as styled terminal output. Run without a " +
 		"topic to open the cinematic viewer on the first topic; pass one of: " +
-		"quickstart, concepts, cli, custom-files.",
+		"quickstart, concepts, cli, custom-files, formats.",
 	Args: cobra.MaximumNArgs(1),
 	RunE: runGuide,
 }
@@ -46,7 +46,7 @@ func runGuide(cmd *cobra.Command, args []string) error {
 	if len(args) == 1 {
 		key = args[0]
 		if _, ok := guideContents[key]; !ok {
-			return fmt.Errorf("unknown topic %q. Available: quickstart, concepts, cli, custom-files", key)
+			return fmt.Errorf("unknown topic %q. Available: quickstart, concepts, cli, custom-files, formats", key)
 		}
 	}
 

--- a/cmd/guide_test.go
+++ b/cmd/guide_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	bonsai "github.com/LastStep/Bonsai"
 )
 
 // fakeGuides populates the package-level guideContents map with
@@ -14,6 +16,7 @@ func fakeGuides() map[string]string {
 		"concepts":     "# Concepts\n\nthe mental model.\n",
 		"cli":          "# CLI\n\ncommand reference.\n",
 		"custom-files": "# Custom Files\n\nadd your own.\n",
+		"formats":      "# Formats\n\nschema_version + permalink.\n",
 	}
 }
 
@@ -94,11 +97,34 @@ func TestRunGuide_NoArgNonTTYExactMessage(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error for no-arg non-TTY invocation; got nil")
 		}
-		want := "bonsai guide: specify a topic when piping output (quickstart, concepts, cli, custom-files)"
+		want := "bonsai guide: specify a topic when piping output (quickstart, concepts, cli, custom-files, formats)"
 		if err.Error() != want {
 			t.Fatalf("error mismatch:\n got=%q\nwant=%q", err.Error(), want)
 		}
 	})
+}
+
+// TestGuide_FormatsPageDocumentsFrozenSchemas is the Plan 40 Phase 3
+// gate: the shipped "Formats" guide must document both frozen v1
+// formats. It renders the real embedded docs/formats.md (not the
+// fake placeholder) through the static path and asserts the rendered
+// body carries the load-bearing keys from each schema — the
+// memory-note `permalink` and the shared `schema_version`. If either
+// is dropped from the doc, this fails.
+func TestGuide_FormatsPageDocumentsFrozenSchemas(t *testing.T) {
+	if strings.TrimSpace(bonsai.GuideFormats) == "" {
+		t.Fatal("embedded Formats guide (docs/formats.md) is empty")
+	}
+	out := captureStdout(t, func() {
+		if err := renderStatic(bonsai.GuideFormats); err != nil {
+			t.Fatalf("renderStatic(Formats): %v", err)
+		}
+	})
+	for _, want := range []string{"schema_version", "permalink"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("rendered Formats guide body missing %q:\n%s", want, out)
+		}
+	}
 }
 
 // TestRunGuide_ArgNonTTYRendersStatic verifies passing a valid

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -82,16 +82,16 @@ The `slug` is the project's machine identity: it anchors the memory-note `scope`
 
 ## Delivering the formats to an existing project
 
-Both formats ship as **opt-in** scaffolding (`project-manifest` and `memory`).
-To add them to a project that predates them, add the item name to the
-`scaffolding:` list in `.bonsai.yaml` and run `bonsai update`:
+Both formats ship as **opt-in scaffolding** (`project-manifest` and `memory`),
+selected during `bonsai init`. When you run `bonsai init` and tick them in the
+scaffolding picker, they're written: the manifest at the repo root
+(`.bonsai/project.yaml`) and the memory tree under `memory_dir`
+(`{memory_dir}/decisions/`, `{memory_dir}/notes/`, default `station/Memory`).
 
-```yaml
-# .bonsai.yaml
-scaffolding:
-  - project-manifest
-  - memory
-```
+To add them to a project that predates them, **re-run `bonsai init`** and select
+`project-manifest` / `memory` in the scaffolding picker. A re-run is safe and
+idempotent: the manifest is lock-tracked and the memory tree is write-once, so
+any files that already exist are left untouched.
 
 Run `bonsai validate` to lint both formats — it reports schema violations
 (missing required fields, bad `schema_version`, scope mismatch, out-of-charset

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,0 +1,100 @@
+---
+description: The frozen v1 repo formats — the memory-note schema and the project manifest.
+---
+
+# Formats
+
+Bonsai defines two repo-resident formats as a stable standard. They are
+**frozen at v1**: the keys are fixed, so downstream hub ingest / repo indexers
+can parse them directly. Fill in the values — don't rename the keys.
+
+## Memory note
+
+A durable memory note lives at `{memory_dir}/{decisions,notes}/<permalink>.md`
+(default `memory_dir` is `station/Memory`). Each note is one markdown file with
+frozen frontmatter plus an Observations / Relations body:
+
+```markdown
+---
+schema_version: 1
+title: <note title>
+type: decision | note | fact | log
+permalink: <stable-slug>
+tags: []
+scope: project/<slug>
+valid_from: 2026-06-13
+superseded_by: null
+---
+## Observations
+- [category] one fact per bullet #tag
+## Relations
+- relation_type [[Target Note]]
+```
+
+| field | type | required | rule |
+|-------|------|----------|------|
+| `schema_version` | int | yes | must be `1` |
+| `title` | string | yes | non-empty |
+| `type` | enum | yes | one of `decision`, `note`, `fact`, `log` |
+| `permalink` | string | yes | `[a-z0-9-]` only; out-of-charset is an error, never indexed; unique within the tree |
+| `tags` | list[str] | no | default `[]` |
+| `scope` | string | yes | `project/<slug>` — `<slug>` must match the manifest `slug` |
+| `valid_from` | date | no | `YYYY-MM-DD` if present; scaffolded notes emit it, hand-authored may omit |
+| `superseded_by` | string \| null | no | absent ≡ `null` ≡ not-superseded; if non-null must resolve to an existing permalink |
+
+The `permalink` is the note's stable identity — keep it fixed even when the
+title changes, since relations and `superseded_by` resolve by permalink.
+A relation (or `superseded_by`) pointing at a not-yet-existing note is a
+**warning**, not an error: forward references are legal while the graph is built
+out.
+
+## Project manifest
+
+The project manifest lives at `.bonsai/project.yaml` (repo root) and is the
+canonical repo-identity record:
+
+```yaml
+schema_version: 1
+name: My Project
+slug: my-project
+status: idea
+tags: []
+description: One-line summary.
+links: {}
+created: 2026-06-13
+memory_dir: station/Memory
+```
+
+| field | type | required | rule |
+|-------|------|----------|------|
+| `schema_version` | int | yes | must be `1` |
+| `name` | string | yes | non-empty |
+| `slug` | string | yes | `[a-z0-9-]` only |
+| `status` | enum | yes | one of `idea`, `active`, `paused`, `done`, `archived` |
+| `tags` | list[str] | no | |
+| `description` | string | no | |
+| `links` | map | no | each of `repo`, `docs`, `issues` optional; unknown keys ignored, not an error |
+| `created` | date | yes | `YYYY-MM-DD` |
+| `memory_dir` | string | no | repo-relative, non-traversing; default `station/Memory` |
+
+The `slug` is the project's machine identity: it anchors the memory-note `scope`
+(`project/<slug>`), so the two formats stay linked.
+
+## Delivering the formats to an existing project
+
+Both formats ship as **opt-in** scaffolding (`project-manifest` and `memory`).
+To add them to a project that predates them, add the item name to the
+`scaffolding:` list in `.bonsai.yaml` and run `bonsai update`:
+
+```yaml
+# .bonsai.yaml
+scaffolding:
+  - project-manifest
+  - memory
+```
+
+Run `bonsai validate` to lint both formats — it reports schema violations
+(missing required fields, bad `schema_version`, scope mismatch, out-of-charset
+permalinks) before downstream tooling ever sees them.
+
+> Full reference: <https://laststep.github.io/Bonsai/>

--- a/embed.go
+++ b/embed.go
@@ -19,3 +19,6 @@ var GuideConcepts string
 
 //go:embed docs/cli.md
 var GuideCli string
+
+//go:embed docs/formats.md
+var GuideFormats string

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -685,7 +685,7 @@ func howToWorkLines(agentName string, docsPrefix string, hasRoutines bool, hasWo
 		fmt.Sprintf("- **Before starting work:** Check `%sPlaybook/Status.md` for assigned tasks and `%sPlaybook/Plans/Active/` for your current plan.", docsPrefix, docsPrefix),
 		"- **When to load a Workflow:** You are starting a multi-step activity (planning, reviewing, auditing). Load the matching workflow from the table above and follow it end-to-end.",
 		"- **When to load a Skill:** You need reference standards for a specific domain (coding style, API design, test strategy). Load it, use it, move on.",
-		fmt.Sprintf("- **Decision logging:** When you make or observe a significant architectural decision, append it to `%sLogs/KeyDecisionLog.md`.", docsPrefix),
+		fmt.Sprintf("- **Decision logging:** When you make or observe a significant architectural decision, write a durable decision note under `%sMemory/decisions/` following `%sPlaybook/Standards/NoteStandards.md` (the durable memory graph) — not the session log.", docsPrefix, docsPrefix),
 		fmt.Sprintf("- **Out-of-scope findings:** Don't fix bugs, debt, or improvements outside your current task. Add them to `%sPlaybook/Backlog.md`.", docsPrefix),
 		"- **Workspace evolution:** `bonsai add` (new abilities), `bonsai remove` (uninstall), `bonsai update` (sync custom files), `bonsai list` (see installed), `bonsai catalog` (browse available).",
 	)

--- a/internal/tui/guideflow/guideflow.go
+++ b/internal/tui/guideflow/guideflow.go
@@ -29,7 +29,7 @@ type Topic struct {
 // surface. Matches the pre-Plan-28 static picker order so users
 // encountering the viewer for the first time still see the same
 // "quickstart first" entry point.
-var canonicalOrder = []string{"quickstart", "concepts", "cli", "custom-files"}
+var canonicalOrder = []string{"quickstart", "concepts", "cli", "custom-files", "formats"}
 
 // deriveLabel produces the default uppercased, hyphen-stripped form
 // used as the fallback for both labelFor and shortFor when a key
@@ -54,6 +54,8 @@ func labelFor(key string) string {
 		return "CLI"
 	case "custom-files":
 		return "CUSTOM"
+	case "formats":
+		return "FORMATS"
 	default:
 		return deriveLabel(key)
 	}
@@ -72,6 +74,8 @@ func shortFor(key string) string {
 		return "CLI"
 	case "custom-files":
 		return "CUSTM"
+	case "formats":
+		return "FORMT"
 	default:
 		up := deriveLabel(key)
 		if len(up) > 5 {


### PR DESCRIPTION
## Summary
Plan 40 Phase 3 — docs: three-surface memory-routing protocol, howToWorkLines fix (decisions → memory graph), combined bonsai guide "Formats" page (note schema + manifest).

## Changes
- `catalog/protocols/memory/memory.md` — three-surface routing
- `internal/generate/generate.go` — howToWorkLines: decisions → Memory/decisions/ (single line)
- guide content source + `cmd/guide.go` (or wherever pages live) — Formats page
- gate test — guide body contains schema_version + permalink

## Plan
Plans/Active/40-odysseus-platform-integration.md (Phase 3)

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — passes
- [x] guide Formats page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)