### PR TITLE
Plan 40 Phase 2 — project-level validate pass

### DIFF
--- a/internal/validate/project.go
+++ b/internal/validate/project.go
@@ -1,0 +1,626 @@
+package validate
+
+// Project-level validation pass (Plan 40 Phase 2).
+//
+// This pass lints two repo-resident formats that the downstream hub
+// consumes: the project manifest at the repo root (.bonsai/project.yaml)
+// and the in-repo memory note tree under {memory_dir} (default
+// station/Memory/). It is strictly read-only — never writes or mutates a
+// single byte — and runs regardless of any --agent filter because these
+// findings are project-scoped, not agent-scoped. Every Issue it appends
+// carries an empty AgentName and the pass never touches AgentsScanned.
+//
+// Security posture (frozen by the plan's Input-validation row):
+//   - manifest memory_dir traversal is accidental-grade — reuse
+//     wsvalidate.InvalidReason after trimming Normalise's trailing slash.
+//   - note-target resolution is adversarial-grade — every note file and
+//     every directory inside the tree is resolved via filepath.EvalSymlinks
+//     and checked to remain under the resolved memory_dir; symlinks that
+//     escape are rejected (never read, never indexed). Relations and
+//     superseded_by resolve by sanitized permalink against a trivial
+//     in-memory map — link text is NEVER treated as a filesystem path.
+//
+// Parsing uses typed structs + yaml.Unmarshal only (no eval) and the walk
+// is bounded on both file count and per-file size so a hostile or
+// accidentally-huge tree cannot OOM or hang the audit.
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/LastStep/Bonsai/internal/wsvalidate"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// manifestRelPath is the repo-relative location of the project manifest.
+	manifestRelPath = ".bonsai/project.yaml"
+	// defaultMemoryDir is the manifest's default memory_dir (frozen v1).
+	defaultMemoryDir = "station/Memory"
+	// memoryIndexName is the index file whose line budget we enforce. It
+	// lives one level above memory_dir (scaffolded under docs_path next to
+	// the Memory/ tree).
+	memoryIndexName = "MEMORY.md"
+	// memoryIndexMaxLines is the frozen MEMORY.md budget — over this is a
+	// warning, not an error.
+	memoryIndexMaxLines = 200
+
+	// maxNoteFiles bounds the recursive walk so a hostile tree with an
+	// enormous number of files cannot make the audit run unbounded. When the
+	// cap is hit the walk stops and a warning is emitted; the cap is far
+	// above any realistic hand-authored memory graph.
+	maxNoteFiles = 10000
+	// maxNoteSizeBytes bounds the bytes read from any single note. A note is
+	// a small markdown file; anything larger is either a mistake or hostile,
+	// so it is flagged (invalid_note) and its frontmatter is not parsed.
+	maxNoteSizeBytes = 1 << 20 // 1 MiB
+)
+
+// slugCharset is the frozen [a-z0-9-] rule shared by slug and permalink.
+var slugCharset = regexp.MustCompile(`^[a-z0-9-]+$`)
+
+// dateCharset matches a YYYY-MM-DD calendar date shape (content not range-checked).
+var dateCharset = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+// wikilinkPattern extracts [[target]] link bodies from a note's Relations
+// section. The captured text is treated as a permalink reference and is
+// sanitized + looked up in the in-memory index — it is NEVER used as a path.
+var wikilinkPattern = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+
+// noteTypes is the frozen set of legal note `type` values.
+var noteTypes = map[string]bool{"decision": true, "note": true, "fact": true, "log": true}
+
+// manifestStatuses is the frozen set of legal manifest `status` values.
+var manifestStatuses = map[string]bool{"idea": true, "active": true, "paused": true, "done": true, "archived": true}
+
+// projectManifest mirrors the frozen v1 manifest schema (.bonsai/project.yaml).
+// Typed struct only — we never extend config.CustomItemMeta. Unknown keys in
+// `links` (and elsewhere) are ignored by yaml.Unmarshal rather than erroring,
+// matching the frozen "unknown keys ignored" rule. SchemaVersion is a pointer
+// so a missing key is distinguishable from an explicit 0.
+type projectManifest struct {
+	SchemaVersion *int              `yaml:"schema_version"`
+	Name          string            `yaml:"name"`
+	Slug          string            `yaml:"slug"`
+	Status        string            `yaml:"status"`
+	Tags          []string          `yaml:"tags"`
+	Description   string            `yaml:"description"`
+	Links         map[string]string `yaml:"links"`
+	Created       string            `yaml:"created"`
+	MemoryDir     string            `yaml:"memory_dir"`
+}
+
+// noteFrontmatter mirrors the frozen v1 memory-note frontmatter. Pointer
+// fields capture present-vs-absent where the distinction matters:
+// SchemaVersion (absent is a missing-required-field error, not a 0-value
+// error) and SupersededBy (absent ≡ null ≡ not-superseded — no missing-key
+// error; only a non-null value is resolved). Typed struct only.
+type noteFrontmatter struct {
+	SchemaVersion *int     `yaml:"schema_version"`
+	Title         string   `yaml:"title"`
+	Type          string   `yaml:"type"`
+	Permalink     string   `yaml:"permalink"`
+	Tags          []string `yaml:"tags"`
+	Scope         string   `yaml:"scope"`
+	ValidFrom     string   `yaml:"valid_from"`
+	SupersededBy  *string  `yaml:"superseded_by"`
+}
+
+// noteRecord is a parsed, in-tree note retained for the relation-resolution
+// second pass. Only notes that survived frontmatter linting (and so have a
+// usable permalink) feed the index; relations are resolved against that index.
+type noteRecord struct {
+	relPath      string
+	permalink    string
+	supersededBy string   // sanitized; "" when absent/null
+	relations    []string // sanitized [[target]] bodies
+}
+
+// auditProject runs the manifest + memory-tree lint and appends any Issues
+// to report. projectRoot is the repo root (the same root auditAgent uses).
+func auditProject(projectRoot string, report *Report) {
+	manifest, manifestPresent := loadManifest(projectRoot, report)
+
+	// Resolve memory_dir. When the manifest is present we honour its
+	// (already-validated) memory_dir; otherwise fall back to the frozen
+	// default so an existing tree is still linted.
+	memDirRel := defaultMemoryDir
+	slug := ""
+	slugKnown := false
+	if manifestPresent && manifest != nil {
+		if manifest.MemoryDir != "" {
+			memDirRel = manifest.MemoryDir
+		}
+		if manifest.Slug != "" {
+			slug = manifest.Slug
+			slugKnown = true
+		}
+	}
+
+	memDirAbs := filepath.Join(projectRoot, filepath.FromSlash(memDirRel))
+	memInfo, statErr := os.Stat(memDirAbs)
+	memoryPresent := statErr == nil && memInfo.IsDir()
+
+	// Manifest absent but a memory tree present → scope is unverifiable.
+	// Warn, skip the scope-match check (slugKnown stays false), but still
+	// lint the rest of the frontmatter below.
+	if memoryPresent && !manifestPresent {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryMissingManifest,
+			Severity: SeverityWarning,
+			Path:     manifestRelPath,
+			Detail:   "memory tree present but " + manifestRelPath + " is missing — note scope cannot be verified; run `bonsai add` to install the project-manifest item",
+		})
+	}
+
+	if memoryPresent {
+		auditMemoryTree(projectRoot, memDirRel, memDirAbs, slug, slugKnown, report)
+	}
+
+	// MEMORY.md line budget. The index sits one level above the memory tree
+	// (scaffolded under docs_path beside Memory/). Checked independently of
+	// whether the tree itself has notes.
+	auditMemoryIndex(projectRoot, memDirRel, report)
+}
+
+// loadManifest reads + lints .bonsai/project.yaml. Returns (manifest, true)
+// when the file exists (manifest may still have carried errors — they are
+// appended to report). Returns (nil, false) when the file is simply absent
+// (not an error on its own — only a warning if a memory tree exists, handled
+// by the caller).
+func loadManifest(projectRoot string, report *Report) (*projectManifest, bool) {
+	abs := filepath.Join(projectRoot, filepath.FromSlash(manifestRelPath))
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false
+		}
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidManifest,
+			Severity: SeverityError,
+			Path:     manifestRelPath,
+			Detail:   "could not read manifest: " + err.Error(),
+		})
+		return nil, true
+	}
+
+	var m projectManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidManifest,
+			Severity: SeverityError,
+			Path:     manifestRelPath,
+			Detail:   "manifest is not valid YAML: " + err.Error(),
+		})
+		return nil, true
+	}
+
+	addManifest := func(detail string) {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidManifest,
+			Severity: SeverityError,
+			Path:     manifestRelPath,
+			Detail:   detail,
+		})
+	}
+
+	// Required fields + value rules (all errors on violation).
+	if m.SchemaVersion == nil {
+		addManifest("missing required field: schema_version")
+	} else if *m.SchemaVersion != 1 {
+		addManifest(fmt.Sprintf("schema_version must be 1, got %d", *m.SchemaVersion))
+	}
+	if m.Name == "" {
+		addManifest("missing required field: name")
+	}
+	if m.Slug == "" {
+		addManifest("missing required field: slug")
+	} else if !slugCharset.MatchString(m.Slug) {
+		addManifest(fmt.Sprintf("slug %q is out of charset — only [a-z0-9-] allowed", m.Slug))
+	}
+	if m.Status == "" {
+		addManifest("missing required field: status")
+	} else if !manifestStatuses[m.Status] {
+		addManifest(fmt.Sprintf("status %q is not one of idea|active|paused|done|archived", m.Status))
+	}
+	if m.Created == "" {
+		addManifest("missing required field: created")
+	} else if !dateCharset.MatchString(m.Created) {
+		addManifest(fmt.Sprintf("created %q must be YYYY-MM-DD", m.Created))
+	}
+
+	// memory_dir is optional + present-optional, but when present it must be
+	// repo-relative and non-traversing. Accidental-grade per the plan: reuse
+	// wsvalidate.InvalidReason on the Normalise'd value, trimming the
+	// trailing slash Normalise appends so the reason text reads cleanly.
+	if m.MemoryDir != "" {
+		norm := strings.TrimRight(wsvalidate.Normalise(m.MemoryDir), "/")
+		if reason := wsvalidate.InvalidReason(norm); reason != "" {
+			addManifest(fmt.Sprintf("memory_dir %q invalid: %s", m.MemoryDir, reason))
+		}
+	}
+
+	// links is present-optional; unknown keys are ignored (not an error) and
+	// URL content is intentionally not validated — nothing to do here.
+
+	return &m, true
+}
+
+// auditMemoryTree walks {memory_dir}/** in two passes: first it collects and
+// frontmatter-lints every note (building the permalink index), then it
+// resolves relations + superseded_by against that index. Symlinked files or
+// directories whose resolved target escapes memory_dir are rejected.
+func auditMemoryTree(projectRoot, memDirRel, memDirAbs, slug string, slugKnown bool, report *Report) {
+	// Resolve the memory_dir boundary once. EvalSymlinks canonicalises the
+	// real on-disk root so per-entry resolved paths can be prefix-checked
+	// against it. If the root itself can't be resolved, treat the tree as
+	// unwalkable rather than guessing.
+	rootResolved, err := filepath.EvalSymlinks(memDirAbs)
+	if err != nil {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Path:     filepath.ToSlash(memDirRel),
+			Detail:   "could not resolve memory_dir: " + err.Error(),
+		})
+		return
+	}
+	boundary := rootResolved + string(os.PathSeparator)
+
+	// underBoundary reports whether resolved is rootResolved itself or a
+	// descendant of it — the adversarial-grade prefix check.
+	underBoundary := func(resolved string) bool {
+		return resolved == rootResolved || strings.HasPrefix(resolved, boundary)
+	}
+
+	var records []noteRecord
+	index := map[string]bool{} // sanitized permalink → present
+	fileCount := 0
+	capHit := false
+
+	walkErr := filepath.WalkDir(memDirAbs, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// A per-entry stat/read error: record it and keep walking the
+			// rest of the tree rather than aborting the whole pass.
+			report.Issues = append(report.Issues, Issue{
+				Category: CategoryInvalidNote,
+				Severity: SeverityError,
+				Path:     relToProject(projectRoot, path),
+				Detail:   "could not walk entry: " + walkErr.Error(),
+			})
+			return nil
+		}
+
+		// Symlink rejection — adversarial-grade. Any symlink (file or dir)
+		// whose resolved target escapes memory_dir is refused: not read, not
+		// indexed, and (for dirs) not descended into. We conservatively skip
+		// in-bounds symlinks too — they are an unusual shape in a
+		// hand-authored note tree and WalkDir does not follow them anyway.
+		if d.Type()&fs.ModeSymlink != 0 {
+			resolved, rerr := filepath.EvalSymlinks(path)
+			if rerr != nil || !underBoundary(resolved) {
+				report.Issues = append(report.Issues, Issue{
+					Category: CategorySymlinkEscape,
+					Severity: SeverityError,
+					Path:     relToProject(projectRoot, path),
+					Detail:   "symlink target escapes memory_dir (or is unresolvable) — refused",
+				})
+			}
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+		// Only *.md files are notes. .gitkeep and anything else is ignored.
+		if !strings.EqualFold(filepath.Ext(path), ".md") {
+			return nil
+		}
+
+		fileCount++
+		if fileCount > maxNoteFiles {
+			capHit = true
+			return fs.SkipAll
+		}
+
+		rec, ok := lintNoteFile(projectRoot, path, slug, slugKnown, report)
+		if ok {
+			records = append(records, rec)
+			index[rec.permalink] = true
+		}
+		return nil
+	})
+
+	if walkErr != nil && walkErr != fs.SkipAll {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Path:     filepath.ToSlash(memDirRel),
+			Detail:   "memory tree walk failed: " + walkErr.Error(),
+		})
+	}
+
+	if capHit {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityWarning,
+			Path:     filepath.ToSlash(memDirRel),
+			Detail:   fmt.Sprintf("memory tree exceeds the %d-note cap — walk stopped early; some notes were not linted", maxNoteFiles),
+		})
+	}
+
+	// Second pass: resolve relations + non-null superseded_by against the
+	// index. Sort records for deterministic issue ordering.
+	sort.Slice(records, func(i, j int) bool { return records[i].relPath < records[j].relPath })
+	for _, rec := range records {
+		if rec.supersededBy != "" && !index[rec.supersededBy] {
+			report.Issues = append(report.Issues, Issue{
+				Category: CategoryInvalidNote,
+				Severity: SeverityError,
+				Name:     rec.permalink,
+				Path:     rec.relPath,
+				Detail:   fmt.Sprintf("superseded_by %q does not resolve to an existing note permalink", rec.supersededBy),
+			})
+		}
+		for _, target := range rec.relations {
+			if !index[target] {
+				report.Issues = append(report.Issues, Issue{
+					Category: CategoryUnresolvedRelation,
+					Severity: SeverityWarning,
+					Name:     rec.permalink,
+					Path:     rec.relPath,
+					Detail:   fmt.Sprintf("relation [[%s]] points at a not-yet-existing note (forward reference)", target),
+				})
+			}
+		}
+	}
+}
+
+// lintNoteFile reads + lints a single note. It returns (record, true) only
+// when the note has a usable permalink to seed the index; on a fatal
+// frontmatter problem it appends the error and returns ok=false so the broken
+// note is neither indexed nor considered a valid relation target. Note that a
+// note can still produce errors AND return ok=true (e.g. a bad scope) — the
+// permalink alone gates indexing.
+func lintNoteFile(projectRoot, path, slug string, slugKnown bool, report *Report) (noteRecord, bool) {
+	rel := relToProject(projectRoot, path)
+
+	fi, err := os.Lstat(path)
+	if err != nil {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Path:     rel,
+			Detail:   "could not stat note: " + err.Error(),
+		})
+		return noteRecord{}, false
+	}
+	if fi.Size() > maxNoteSizeBytes {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Path:     rel,
+			Detail:   fmt.Sprintf("note exceeds the %d-byte size cap — not parsed", int64(maxNoteSizeBytes)),
+		})
+		return noteRecord{}, false
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Path:     rel,
+			Detail:   "could not read note: " + err.Error(),
+		})
+		return noteRecord{}, false
+	}
+
+	fm, body, ok := splitFrontmatter(data)
+	if !ok {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Path:     rel,
+			Detail:   "missing or unterminated YAML frontmatter block",
+		})
+		return noteRecord{}, false
+	}
+
+	var note noteFrontmatter
+	if err := yaml.Unmarshal(fm, &note); err != nil {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Path:     rel,
+			Detail:   "frontmatter is not valid YAML: " + err.Error(),
+		})
+		return noteRecord{}, false
+	}
+
+	add := func(detail string) {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryInvalidNote,
+			Severity: SeverityError,
+			Name:     note.Permalink,
+			Path:     rel,
+			Detail:   detail,
+		})
+	}
+
+	// Required-field checks (all errors).
+	if note.SchemaVersion == nil {
+		add("missing required frontmatter field: schema_version")
+	} else if *note.SchemaVersion != 1 {
+		add(fmt.Sprintf("schema_version must be 1, got %d", *note.SchemaVersion))
+	}
+	if note.Title == "" {
+		add("missing required frontmatter field: title")
+	}
+	if note.Type == "" {
+		add("missing required frontmatter field: type")
+	} else if !noteTypes[note.Type] {
+		add(fmt.Sprintf("type %q is not one of decision|note|fact|log", note.Type))
+	}
+	if note.Scope == "" {
+		add("missing required frontmatter field: scope")
+	} else if slugKnown && note.Scope != "project/"+slug {
+		add(fmt.Sprintf("scope %q does not match manifest slug — expected %q", note.Scope, "project/"+slug))
+	}
+
+	// Permalink is required AND charset-checked. An out-of-charset permalink
+	// is an error and must never be indexed (so it cannot satisfy a
+	// relation), so we don't seed the index from it.
+	permalinkOK := false
+	if note.Permalink == "" {
+		add("missing required frontmatter field: permalink")
+	} else if !slugCharset.MatchString(note.Permalink) {
+		add(fmt.Sprintf("permalink %q is out of charset — only [a-z0-9-] allowed", note.Permalink))
+	} else {
+		permalinkOK = true
+	}
+
+	if !permalinkOK {
+		return noteRecord{}, false
+	}
+
+	rec := noteRecord{
+		relPath:   rel,
+		permalink: note.Permalink,
+	}
+	// superseded_by: absent ≡ null ≡ not-superseded (no error). Only a
+	// non-null value is recorded for second-pass resolution. Sanitize before
+	// indexing — link text is never a path.
+	if note.SupersededBy != nil {
+		if s := sanitizePermalink(*note.SupersededBy); s != "" {
+			rec.supersededBy = s
+		}
+	}
+	rec.relations = extractRelations(body)
+	return rec, true
+}
+
+// splitFrontmatter separates the leading `---`-delimited YAML frontmatter
+// from the markdown body. Returns (frontmatterBytes, bodyBytes, true) on a
+// well-formed block; (nil, nil, false) when the file does not open with a
+// frontmatter fence or the closing fence is missing.
+func splitFrontmatter(data []byte) ([]byte, []byte, bool) {
+	s := string(data)
+	s = strings.TrimPrefix(s, "\ufeff") // tolerate a leading UTF-8 BOM
+	if !strings.HasPrefix(s, "---\n") && !strings.HasPrefix(s, "---\r\n") {
+		return nil, nil, false
+	}
+	// Skip the opening fence line, then scan for the closing fence.
+	rest := s[strings.IndexByte(s, '\n')+1:]
+	lines := strings.SplitAfter(rest, "\n")
+	var fmLines []string
+	consumed := 0
+	closed := false
+	for _, ln := range lines {
+		trimmed := strings.TrimRight(ln, "\r\n")
+		consumed += len(ln)
+		if trimmed == "---" {
+			closed = true
+			break
+		}
+		fmLines = append(fmLines, ln)
+	}
+	if !closed {
+		return nil, nil, false
+	}
+	fm := strings.Join(fmLines, "")
+	body := rest[consumed:]
+	return []byte(fm), []byte(body), true
+}
+
+// extractRelations pulls every [[target]] wikilink body out of the note body,
+// sanitizes each to a permalink, and returns the deduplicated set. Link text
+// is ONLY ever turned into an index key — never a filesystem path.
+func extractRelations(body []byte) []string {
+	matches := wikilinkPattern.FindAllStringSubmatch(string(body), -1)
+	seen := map[string]bool{}
+	var out []string
+	for _, m := range matches {
+		s := sanitizePermalink(m[1])
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}
+
+// sanitizePermalink reduces arbitrary link text to the [a-z0-9-] permalink
+// charset for index lookups: lowercase, then drop every out-of-charset rune.
+// This is a pure string transform — the result is used solely as a map key,
+// never as a path component. An empty result means "no resolvable target".
+func sanitizePermalink(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// auditMemoryIndex flags MEMORY.md when it exceeds the line budget. The index
+// is expected one directory above memory_dir (it is scaffolded under
+// docs_path beside the Memory/ tree). Absent index → nothing to flag.
+func auditMemoryIndex(projectRoot, memDirRel string, report *Report) {
+	indexRel := filepath.ToSlash(filepath.Join(filepath.Dir(filepath.FromSlash(memDirRel)), memoryIndexName))
+	abs := filepath.Join(projectRoot, filepath.FromSlash(indexRel))
+
+	fi, err := os.Lstat(abs)
+	if err != nil || fi.IsDir() {
+		return
+	}
+	if fi.Size() > maxNoteSizeBytes {
+		// Pathologically large index — don't read it, just flag the budget
+		// breach (a >1MiB MEMORY.md is far past 200 lines by any measure).
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryMemoryIndexTooLarge,
+			Severity: SeverityWarning,
+			Path:     indexRel,
+			Detail:   fmt.Sprintf("%s exceeds the %d-line budget", memoryIndexName, memoryIndexMaxLines),
+		})
+		return
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return
+	}
+	lines := strings.Count(string(data), "\n")
+	if len(data) > 0 && !strings.HasSuffix(string(data), "\n") {
+		lines++ // count a final unterminated line
+	}
+	if lines > memoryIndexMaxLines {
+		report.Issues = append(report.Issues, Issue{
+			Category: CategoryMemoryIndexTooLarge,
+			Severity: SeverityWarning,
+			Path:     indexRel,
+			Detail:   fmt.Sprintf("%s is %d lines — exceeds the %d-line budget", memoryIndexName, lines, memoryIndexMaxLines),
+		})
+	}
+}
+
+// relToProject returns the slash-form project-relative path for abs, falling
+// back to the slash-form abs when Rel fails (it shouldn't here — abs is
+// always under projectRoot).
+func relToProject(projectRoot, abs string) string {
+	rel, err := filepath.Rel(projectRoot, abs)
+	if err != nil {
+		return filepath.ToSlash(abs)
+	}
+	return filepath.ToSlash(rel)
+}

--- a/internal/validate/project.go
+++ b/internal/validate/project.go
@@ -93,6 +93,13 @@ type projectManifest struct {
 	Links         map[string]string `yaml:"links"`
 	Created       string            `yaml:"created"`
 	MemoryDir     string            `yaml:"memory_dir"`
+
+	// memoryDirInvalid is set by loadManifest when an explicit memory_dir
+	// failed validation (traversal/absolute). It is unexported and untagged
+	// so yaml.Unmarshal never populates it. When true, auditProject skips the
+	// memory-tree walk entirely instead of defaulting to station/Memory — the
+	// manifest is broken and walking a sanitized/default tree would mislead.
+	memoryDirInvalid bool
 }
 
 // noteFrontmatter mirrors the frozen v1 memory-note frontmatter. Pointer
@@ -126,13 +133,20 @@ type noteRecord struct {
 func auditProject(projectRoot string, report *Report) {
 	manifest, manifestPresent := loadManifest(projectRoot, report)
 
-	// Resolve memory_dir. When the manifest is present we honour its
-	// (already-validated) memory_dir; otherwise fall back to the frozen
-	// default so an existing tree is still linted.
+	// Resolve memory_dir. When the manifest carries a non-empty, *validated*
+	// memory_dir we honour it; when the key is simply absent we fall back to
+	// the frozen default so an existing tree is still linted. But when the
+	// manifest carried an explicit memory_dir that FAILED validation
+	// (traversal/absolute), loadManifest has already recorded the error and
+	// blanked the field — we must NOT walk anything for this run (neither the
+	// out-of-tree target nor the default), so we bail before the stat/walk.
 	memDirRel := defaultMemoryDir
 	slug := ""
 	slugKnown := false
 	if manifestPresent && manifest != nil {
+		if manifest.memoryDirInvalid {
+			return
+		}
 		if manifest.MemoryDir != "" {
 			memDirRel = manifest.MemoryDir
 		}
@@ -238,10 +252,20 @@ func loadManifest(projectRoot string, report *Report) (*projectManifest, bool) {
 	// repo-relative and non-traversing. Accidental-grade per the plan: reuse
 	// wsvalidate.InvalidReason on the Normalise'd value, trimming the
 	// trailing slash Normalise appends so the reason text reads cleanly.
+	//
+	// On an invalid (traversing/absolute) value we blank m.MemoryDir AFTER
+	// recording the error so downstream code never joins it onto projectRoot
+	// and walks an out-of-tree directory. A blanked-because-invalid value is
+	// NOT the same as an absent key: auditProject must skip the walk entirely
+	// for this run rather than falling back to the default tree (the manifest
+	// is broken — the error already tells the user to fix it). See the
+	// memoryDirInvalid flag threaded through auditProject.
 	if m.MemoryDir != "" {
 		norm := strings.TrimRight(wsvalidate.Normalise(m.MemoryDir), "/")
 		if reason := wsvalidate.InvalidReason(norm); reason != "" {
 			addManifest(fmt.Sprintf("memory_dir %q invalid: %s", m.MemoryDir, reason))
+			m.MemoryDir = ""
+			m.memoryDirInvalid = true
 		}
 	}
 

--- a/internal/validate/project_test.go
+++ b/internal/validate/project_test.go
@@ -423,6 +423,52 @@ func TestProject_PermalinkOutOfCharsetNotIndexed(t *testing.T) {
 	}
 }
 
+// TestProject_TraversingMemoryDirNotWalked is the out-of-tree-read regression
+// guard. A manifest whose memory_dir traverses out of the repo (../outsidemem)
+// must (1) raise the invalid_manifest error AND (2) never read/lint the
+// out-of-tree note tree — so an attacker-planted ../outsidemem/evil.md whose
+// frontmatter would otherwise surface (HACKED scope) is never opened. Before
+// the fix, auditProject joined the unsanitized memory_dir onto projectRoot,
+// stat'd the resolved out-of-tree dir, and frontmatter-linted evil.md.
+func TestProject_TraversingMemoryDirNotWalked(t *testing.T) {
+	f := newFixture(t)
+
+	// Plant an out-of-tree memory tree as a sibling of the project root with a
+	// note whose frontmatter is structurally valid (so any walk WOULD parse it
+	// and emit note-derived issues against the HACKED scope).
+	outside := filepath.Join(f.root, "..", "outsidemem")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(outside) })
+	evil := validNote("evil", "project/HACKED", "", "")
+	if err := os.WriteFile(filepath.Join(outside, "evil.md"), []byte(evil), 0o644); err != nil {
+		t.Fatalf("write evil note: %v", err)
+	}
+
+	// Manifest points memory_dir at the traversing path.
+	writeProjectFile(t, f.root, ".bonsai/project.yaml",
+		strings.Replace(validManifest, "memory_dir: station/Memory", "memory_dir: ../outsidemem", 1))
+
+	report := runProject(t, f)
+
+	// (1) The traversing memory_dir IS flagged.
+	if iss := findProjectIssue(report.Issues, CategoryInvalidManifest, ""); iss == nil {
+		t.Fatalf("expected invalid_manifest for traversing memory_dir, got: %+v", report.Issues)
+	} else if iss.Severity != SeverityError {
+		t.Errorf("invalid_manifest severity = %s, want error", iss.Severity)
+	}
+
+	// (2) The out-of-tree evil.md was NEVER read/linted — no issue may
+	// reference the HACKED scope or the evil note in any way.
+	for _, iss := range report.Issues {
+		if strings.Contains(iss.Detail, "HACKED") || strings.Contains(iss.Path, "outsidemem") ||
+			strings.Contains(iss.Path, "evil.md") || iss.Name == "evil" {
+			t.Fatalf("out-of-tree note must not be read; leaked issue: %+v", iss)
+		}
+	}
+}
+
 // ensure config import is used even if a future refactor drops the direct
 // reference — keeps the test file self-documenting about its dependency.
 var _ = config.NewLockFile

--- a/internal/validate/project_test.go
+++ b/internal/validate/project_test.go
@@ -1,0 +1,428 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// --- Project-level pass fixtures (Plan 40 Phase 2) -------------------------
+
+// validManifest is the canonical good manifest body. Tests mutate one field
+// at a time to build a negative control per rule.
+const validManifest = `schema_version: 1
+name: Demo Project
+slug: demo
+status: active
+tags: []
+description: a demo
+links: {}
+created: 2026-06-13
+memory_dir: station/Memory
+`
+
+// validNote returns a well-formed note body for the given permalink, scope,
+// and an optional relations/superseded tail. The frontmatter matches the
+// frozen v1 schema.
+func validNote(permalink, scope, supersededBy, relations string) string {
+	sb := "null"
+	if supersededBy != "" {
+		sb = supersededBy
+	}
+	body := "---\n" +
+		"schema_version: 1\n" +
+		"title: A Note\n" +
+		"type: decision\n" +
+		"permalink: " + permalink + "\n" +
+		"tags: []\n" +
+		"scope: " + scope + "\n" +
+		"valid_from: 2026-06-13\n" +
+		"superseded_by: " + sb + "\n" +
+		"---\n" +
+		"## Observations\n- [decision] chose X #arch\n" +
+		"## Relations\n"
+	if relations != "" {
+		body += relations + "\n"
+	}
+	return body
+}
+
+// writeProjectFile materialises a file under root, creating parent dirs.
+func writeProjectFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(abs), err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
+	}
+}
+
+// seedMemoryDirs creates the empty Memory/{decisions,notes} tree so a
+// manifest-present fixture has a tree to walk even before notes are added.
+func seedMemoryDirs(t *testing.T, root string) {
+	t.Helper()
+	for _, sub := range []string{"station/Memory/decisions", "station/Memory/notes"} {
+		if err := os.MkdirAll(filepath.Join(root, filepath.FromSlash(sub)), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+}
+
+// runProject runs the full Run() against a fixture whose manifest + memory
+// tree the caller has already written, and returns the report.
+func runProject(t *testing.T, f *projectFixture) *Report {
+	t.Helper()
+	report, err := Run(f.root, f.cfg, nil, f.lock, "")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	return report
+}
+
+// findProjectIssue returns the first issue matching category (and optional
+// name) whose AgentName is empty — project-level issues are always unscoped.
+func findProjectIssue(issues []Issue, cat Category, name string) *Issue {
+	for i := range issues {
+		if issues[i].Category == cat && issues[i].AgentName == "" && (name == "" || issues[i].Name == name) {
+			return &issues[i]
+		}
+	}
+	return nil
+}
+
+// TestProject_ValidTree is the zero-issues control: a good manifest + a small
+// valid memory graph (including a resolved relation + a resolved
+// superseded_by) must produce ZERO issues.
+func TestProject_ValidTree(t *testing.T) {
+	f := newFixture(t)
+	writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+	seedMemoryDirs(t, f.root)
+	// note-a supersedes note-b and relates to note-b; both exist → resolved.
+	writeProjectFile(t, f.root, "station/Memory/decisions/note-a.md",
+		validNote("note-a", "project/demo", "note-b", "- relates_to [[note-b]]"))
+	writeProjectFile(t, f.root, "station/Memory/notes/note-b.md",
+		validNote("note-b", "project/demo", "", ""))
+
+	report := runProject(t, f)
+	if report.HasIssues() {
+		t.Fatalf("expected zero issues for valid tree, got: %+v", report.Issues)
+	}
+	// Project pass must NOT pollute AgentsScanned.
+	if len(report.AgentsScanned) != 1 || report.AgentsScanned[0] != "tech-lead" {
+		t.Fatalf("AgentsScanned = %v, want [tech-lead]", report.AgentsScanned)
+	}
+}
+
+// TestProject_RuleTable is the fixture↔rule↔(category,severity) table. Each
+// case mutates exactly one thing on top of the valid baseline and asserts the
+// expected category + severity fires. setup writes the manifest + tree.
+func TestProject_RuleTable(t *testing.T) {
+	cases := []struct {
+		name     string
+		setup    func(t *testing.T, f *projectFixture)
+		cat      Category
+		severity Severity
+		// issueName, when non-empty, is asserted on the matched issue.
+		issueName string
+	}{
+		{
+			name: "manifest schema_version 2",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml",
+					strings.Replace(validManifest, "schema_version: 1", "schema_version: 2", 1))
+			},
+			cat:      CategoryInvalidManifest,
+			severity: SeverityError,
+		},
+		{
+			name: "manifest status bogus",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml",
+					strings.Replace(validManifest, "status: active", "status: bogus", 1))
+			},
+			cat:      CategoryInvalidManifest,
+			severity: SeverityError,
+		},
+		{
+			name: "manifest memory_dir traversal",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml",
+					strings.Replace(validManifest, "memory_dir: station/Memory", "memory_dir: ../escape", 1))
+			},
+			cat:      CategoryInvalidManifest,
+			severity: SeverityError,
+		},
+		{
+			name: "manifest missing required slug",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml",
+					strings.Replace(validManifest, "slug: demo\n", "", 1))
+			},
+			cat:      CategoryInvalidManifest,
+			severity: SeverityError,
+		},
+		{
+			name: "note missing required frontmatter (no permalink/scope/...)",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				writeProjectFile(t, f.root, "station/Memory/notes/broken.md",
+					"---\nschema_version: 1\ntitle: x\n---\nbody\n")
+			},
+			cat:      CategoryInvalidNote,
+			severity: SeverityError,
+		},
+		{
+			name: "note bad schema_version",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				n := strings.Replace(validNote("nbad", "project/demo", "", ""), "schema_version: 1", "schema_version: 2", 1)
+				writeProjectFile(t, f.root, "station/Memory/notes/nbad.md", n)
+			},
+			cat:       CategoryInvalidNote,
+			severity:  SeverityError,
+			issueName: "nbad",
+		},
+		{
+			name: "note out-of-charset permalink",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				writeProjectFile(t, f.root, "station/Memory/notes/badlink.md",
+					validNote("Bad_Link!", "project/demo", "", ""))
+			},
+			cat:      CategoryInvalidNote,
+			severity: SeverityError,
+		},
+		{
+			name: "note bad type",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				n := strings.Replace(validNote("ntype", "project/demo", "", ""), "type: decision", "type: musing", 1)
+				writeProjectFile(t, f.root, "station/Memory/notes/ntype.md", n)
+			},
+			cat:       CategoryInvalidNote,
+			severity:  SeverityError,
+			issueName: "ntype",
+		},
+		{
+			name: "note bad scope (slug mismatch)",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				writeProjectFile(t, f.root, "station/Memory/notes/nscope.md",
+					validNote("nscope", "project/other", "", ""))
+			},
+			cat:       CategoryInvalidNote,
+			severity:  SeverityError,
+			issueName: "nscope",
+		},
+		{
+			name: "note dangling superseded_by",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				writeProjectFile(t, f.root, "station/Memory/decisions/ndang.md",
+					validNote("ndang", "project/demo", "does-not-exist", ""))
+			},
+			cat:       CategoryInvalidNote,
+			severity:  SeverityError,
+			issueName: "ndang",
+		},
+		{
+			name: "note unresolved relation (warning)",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				writeProjectFile(t, f.root, "station/Memory/notes/nrel.md",
+					validNote("nrel", "project/demo", "", "- relates_to [[ghost-note]]"))
+			},
+			cat:       CategoryUnresolvedRelation,
+			severity:  SeverityWarning,
+			issueName: "nrel",
+		},
+		{
+			name: "MEMORY.md over budget",
+			setup: func(t *testing.T, f *projectFixture) {
+				writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+				seedMemoryDirs(t, f.root)
+				writeProjectFile(t, f.root, "station/MEMORY.md", strings.Repeat("line\n", 250))
+			},
+			cat:      CategoryMemoryIndexTooLarge,
+			severity: SeverityWarning,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFixture(t)
+			tc.setup(t, f)
+			report := runProject(t, f)
+			iss := findProjectIssue(report.Issues, tc.cat, tc.issueName)
+			if iss == nil {
+				t.Fatalf("expected %s issue (name=%q), got: %+v", tc.cat, tc.issueName, report.Issues)
+			}
+			if iss.Severity != tc.severity {
+				t.Errorf("severity = %s, want %s", iss.Severity, tc.severity)
+			}
+			if iss.AgentName != "" {
+				t.Errorf("project issue carried AgentName %q, want empty", iss.AgentName)
+			}
+		})
+	}
+}
+
+// TestProject_ManifestAbsentButMemoryPresent asserts the warning fires AND
+// frontmatter errors still surface (scope-match is skipped, everything else
+// is still linted).
+func TestProject_ManifestAbsentButMemoryPresent(t *testing.T) {
+	f := newFixture(t)
+	seedMemoryDirs(t, f.root)
+	// A note with a bad schema_version — a non-scope error must still surface.
+	bad := strings.Replace(validNote("nabsent", "project/whatever", "", ""), "schema_version: 1", "schema_version: 2", 1)
+	writeProjectFile(t, f.root, "station/Memory/notes/nabsent.md", bad)
+
+	report := runProject(t, f)
+
+	if findProjectIssue(report.Issues, CategoryMissingManifest, "") == nil {
+		t.Fatalf("expected missing_manifest warning, got: %+v", report.Issues)
+	}
+	if iss := findProjectIssue(report.Issues, CategoryMissingManifest, ""); iss != nil && iss.Severity != SeverityWarning {
+		t.Errorf("missing_manifest severity = %s, want warning", iss.Severity)
+	}
+	// Frontmatter still linted: the bad schema_version must surface as an error.
+	if iss := findProjectIssue(report.Issues, CategoryInvalidNote, "nabsent"); iss == nil {
+		t.Fatalf("expected invalid_note for nabsent even with manifest absent, got: %+v", report.Issues)
+	} else if iss.Severity != SeverityError {
+		t.Errorf("invalid_note severity = %s, want error", iss.Severity)
+	}
+	// Scope-match check is skipped when slug is unknown — a project/whatever
+	// scope must NOT raise a scope-mismatch error.
+	for _, iss := range report.Issues {
+		if iss.Category == CategoryInvalidNote && strings.Contains(iss.Detail, "does not match manifest slug") {
+			t.Fatalf("scope-match check should be skipped when manifest absent, got: %+v", iss)
+		}
+	}
+}
+
+// TestProject_ManifestAbsentNoMemory verifies the common case: no manifest and
+// no memory tree → no project-level issues at all (the warning only fires when
+// a tree actually exists).
+func TestProject_ManifestAbsentNoMemory(t *testing.T) {
+	f := newFixture(t)
+	report := runProject(t, f)
+	if findProjectIssue(report.Issues, CategoryMissingManifest, "") != nil {
+		t.Fatalf("missing_manifest should not fire without a memory tree, got: %+v", report.Issues)
+	}
+}
+
+// TestProject_RunsRegardlessOfAgentFilter confirms the project-level pass
+// fires even when an --agent filter is applied (non-error path). The filtered
+// agent has no issues, but the manifest does.
+func TestProject_RunsRegardlessOfAgentFilter(t *testing.T) {
+	f := newFixture(t)
+	writeProjectFile(t, f.root, ".bonsai/project.yaml",
+		strings.Replace(validManifest, "schema_version: 1", "schema_version: 2", 1))
+
+	report, err := Run(f.root, f.cfg, nil, f.lock, "tech-lead")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if findProjectIssue(report.Issues, CategoryInvalidManifest, "") == nil {
+		t.Fatalf("project pass must run under --agent filter, got: %+v", report.Issues)
+	}
+}
+
+// TestProject_UnknownAgentFilterStillErrorsEarly confirms the project pass does
+// NOT run when the agent filter is unknown — Run errors out before reaching it.
+func TestProject_UnknownAgentFilterStillErrorsEarly(t *testing.T) {
+	f := newFixture(t)
+	writeProjectFile(t, f.root, ".bonsai/project.yaml",
+		strings.Replace(validManifest, "schema_version: 1", "schema_version: 2", 1))
+	if _, err := Run(f.root, f.cfg, nil, f.lock, "ghost"); err == nil {
+		t.Fatalf("expected early error for unknown agent filter")
+	}
+}
+
+// TestProject_SymlinkEscapeRejected verifies an adversarial symlinked note
+// whose target escapes memory_dir is refused (symlink_escape error) and never
+// read. POSIX-only — Windows symlink creation requires elevated privileges.
+func TestProject_SymlinkEscapeRejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	f := newFixture(t)
+	writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+	seedMemoryDirs(t, f.root)
+
+	// A secret file OUTSIDE the memory tree.
+	outside := filepath.Join(f.root, "secret.md")
+	if err := os.WriteFile(outside, []byte("top secret\n"), 0o644); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	// A symlink inside the tree pointing at it.
+	link := filepath.Join(f.root, "station/Memory/notes/leak.md")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	report := runProject(t, f)
+	iss := findProjectIssue(report.Issues, CategorySymlinkEscape, "")
+	if iss == nil {
+		t.Fatalf("expected symlink_escape, got: %+v", report.Issues)
+	}
+	if iss.Severity != SeverityError {
+		t.Errorf("severity = %s, want error", iss.Severity)
+	}
+}
+
+// TestProject_SupersededByAbsentIsNotSuperseded verifies the absent ≡ null ≡
+// not-superseded rule: a note with no superseded_by key produces no
+// missing-key error and no dangling-resolution error.
+func TestProject_SupersededByAbsentIsNotSuperseded(t *testing.T) {
+	f := newFixture(t)
+	writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+	seedMemoryDirs(t, f.root)
+	// Note body with NO superseded_by line at all.
+	body := "---\nschema_version: 1\ntitle: A\ntype: note\npermalink: nokey\ntags: []\nscope: project/demo\n---\n## Observations\n- [note] x\n"
+	writeProjectFile(t, f.root, "station/Memory/notes/nokey.md", body)
+
+	report := runProject(t, f)
+	if report.HasIssues() {
+		t.Fatalf("absent superseded_by must not raise issues, got: %+v", report.Issues)
+	}
+}
+
+// TestProject_PermalinkOutOfCharsetNotIndexed verifies an out-of-charset
+// permalink note is errored AND not indexed — so it cannot satisfy another
+// note's relation (which would then warn as unresolved).
+func TestProject_PermalinkOutOfCharsetNotIndexed(t *testing.T) {
+	f := newFixture(t)
+	writeProjectFile(t, f.root, ".bonsai/project.yaml", validManifest)
+	seedMemoryDirs(t, f.root)
+	// Bad-permalink note + a second note relating to its sanitized form.
+	writeProjectFile(t, f.root, "station/Memory/notes/bad.md", validNote("Bad!", "project/demo", "", ""))
+	writeProjectFile(t, f.root, "station/Memory/notes/ref.md", validNote("ref", "project/demo", "", "- relates_to [[bad]]"))
+
+	report := runProject(t, f)
+	// The bad permalink errors.
+	if findProjectIssue(report.Issues, CategoryInvalidNote, "") == nil {
+		t.Fatalf("expected invalid_note for out-of-charset permalink, got: %+v", report.Issues)
+	}
+	// And ref's relation to "bad" stays unresolved (not indexed).
+	if findProjectIssue(report.Issues, CategoryUnresolvedRelation, "ref") == nil {
+		t.Fatalf("out-of-charset permalink must not be indexed; ref's relation should be unresolved, got: %+v", report.Issues)
+	}
+}
+
+// ensure config import is used even if a future refactor drops the direct
+// reference — keeps the test file self-documenting about its dependency.
+var _ = config.NewLockFile

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -63,6 +63,35 @@ const (
 	// Routines). Top-level only — subdirs ignored to match
 	// generate.ScanCustomFiles.
 	CategoryWrongExtension Category = "wrong_extension_in_category"
+
+	// --- Project-level categories (Plan 40 Phase 2) ---
+	// These fire once per project (not per agent); their Issues carry an
+	// empty AgentName and are intentionally absent from AgentsScanned.
+
+	// CategoryInvalidManifest: .bonsai/project.yaml is unparseable, missing
+	// a required field, or carries an out-of-range value (bad
+	// schema_version, status not in the enum, traversing memory_dir, ...).
+	CategoryInvalidManifest Category = "invalid_manifest"
+	// CategoryMissingManifest: a memory tree exists on disk but no
+	// .bonsai/project.yaml was found, so scope cannot be verified. Warning —
+	// frontmatter is still linted, only the scope-match check is skipped.
+	CategoryMissingManifest Category = "missing_manifest"
+	// CategoryInvalidNote: a memory note has missing/bad frontmatter — a
+	// missing required field, schema_version != 1, out-of-charset permalink,
+	// a type outside the enum, a scope that doesn't match the manifest slug,
+	// or a dangling (non-null, unresolved) superseded_by.
+	CategoryInvalidNote Category = "invalid_note"
+	// CategoryUnresolvedRelation: a note's [[relation]] (or non-null
+	// superseded_by handled as a relation) points at a permalink that does
+	// not exist in the tree. Warning — forward references are legal while
+	// the graph is built out.
+	CategoryUnresolvedRelation Category = "unresolved_relation"
+	// CategorySymlinkEscape: a note file or a directory within the memory
+	// tree is a symlink whose resolved target escapes memory_dir. Rejected
+	// adversarially — never read, never indexed.
+	CategorySymlinkEscape Category = "symlink_escape"
+	// CategoryMemoryIndexTooLarge: MEMORY.md exceeds the 200-line budget.
+	CategoryMemoryIndexTooLarge Category = "memory_index_too_large"
 )
 
 // Issue is a single audit finding. JSON tag layout is the stable contract
@@ -185,6 +214,13 @@ func Run(projectRoot string, cfg *config.ProjectConfig, cat *catalog.Catalog, lo
 		report.AgentsScanned = append(report.AgentsScanned, agentName)
 		auditAgent(projectRoot, agentName, installed, lock, report)
 	}
+
+	// Project-level pass (Plan 40 Phase 2): lints the repo-root manifest and
+	// the in-repo memory note tree. Runs regardless of agentFilter — these
+	// findings are project-scoped, not agent-scoped, so an --agent filter
+	// must not suppress them. Their Issues carry an empty AgentName and the
+	// pass deliberately does NOT touch report.AgentsScanned.
+	auditProject(projectRoot, report)
 
 	return report, nil
 }


### PR DESCRIPTION
## Summary
Plan 40 Phase 2 — project-level validate pass: lints the project manifest + in-repo memory note tree (frozen v1 schemas). Read-only; adversarial-grade note-target resolution.

## Changes
- `internal/validate/validate.go` — project-level pass (runs regardless of agentFilter), new Category constants, manifest + note frontmatter structs, bounded walk, EvalSymlinks prefix check
- `internal/validate/validate_test.go` — fixture↔rule↔(category,severity) table + valid-tree zero-issues fixture

> Note: the new code lives in `internal/validate/project.go` (pass + structs) and `internal/validate/project_test.go` (the table). `validate.go` gains the additive `Category` constants and the `auditProject` call site; the original `validate_test.go` is unchanged.

## Plan
Plans/Active/40-odysseus-platform-integration.md (Phase 2)

## Verification
- [x] `make build` — passes
- [x] `go test ./...` — passes
- [x] `GOOS=windows GOARCH=amd64 go build ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)