### PR TITLE
feat(list): Plan 41 Phase 4 — list --json + read-command JSON parity

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -8,11 +8,15 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
 	"github.com/LastStep/Bonsai/internal/tui/listflow"
 )
 
 func init() {
 	rootCmd.AddCommand(listCmd)
+	listCmd.Flags().Bool("json", false, "Output installed agents as JSON (agent-consumable, non-interactive)")
 }
 
 var listCmd = &cobra.Command{
@@ -26,6 +30,12 @@ var listCmd = &cobra.Command{
 // pipeline is static (no BubbleTea) so piped invocations produce
 // clean non-ANSI output via the existing tui.DisableColor() pathway
 // in internal/tui/styles.go.
+//
+// Plan 41 Phase 4: the --json flag short-circuits the cinematic path and
+// emits a single-document ListSnapshot to stdout (mirroring catalog --json
+// at cmd/catalog.go:43 and validate --json), so an AI agent / CI script can
+// read the installed state non-interactively. The serializer lives in the
+// TUI-free internal/generate package (beside SerializeCatalog).
 func runList(cmd *cobra.Command, args []string) error {
 	cwd := mustCwd()
 	configPath := filepath.Join(cwd, configFile)
@@ -35,8 +45,29 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 	cat := loadCatalog()
 
+	// cmd may be nil when runList is invoked directly from a unit test;
+	// treat that as the default (cinematic) path.
+	if cmd != nil {
+		if jsonOut, _ := cmd.Flags().GetBool("json"); jsonOut {
+			return renderListJSON(cfg, cat, cwd)
+		}
+	}
+
 	termW, termH := terminalSize()
 	fmt.Print(listflow.RenderAll(cfg, cat, Version, cwd, termW, termH))
+	return nil
+}
+
+// renderListJSON serializes the installed-agent state to stdout as indent-2
+// JSON, reusing generate.SerializeJSON (single source of truth for the
+// ListSnapshot contract). Matches the catalog --json / validate --json output
+// style: marshaled JSON, stdout-only, exit 0.
+func renderListJSON(cfg *config.ProjectConfig, cat *catalog.Catalog, cwd string) error {
+	data, err := generate.SerializeJSON(cfg, cat, Version, cwd)
+	if err != nil {
+		return fmt.Errorf("serialize list: %w", err)
+	}
+	fmt.Println(string(data))
 	return nil
 }
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	bonsai "github.com/LastStep/Bonsai"
 	"github.com/LastStep/Bonsai/internal/config"
+	"github.com/LastStep/Bonsai/internal/generate"
 )
 
 // setupListTestCatalog wires the embedded catalog into the cmd package's
@@ -153,5 +155,147 @@ func TestRunList_NoAgents(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "0 agent") {
 		t.Fatalf("expected '0 agent' count, got:\n%s", stdout)
+	}
+}
+
+// TestRunList_JSONSchema is the Plan 41 Phase 4 B2 gate: a two-agent project
+// rendered through `bonsai list --json` must Unmarshal cleanly into the pinned
+// ListSnapshot struct with EVERY field populated and field names/types exactly
+// matching the contract. Drives runList with the --json flag set on listCmd so
+// the real flag-read short-circuit is exercised end to end.
+func TestRunList_JSONSchema(t *testing.T) {
+	setupListTestCatalog(t)
+
+	tmp := t.TempDir()
+	projectDir := filepath.Join(tmp, "demo-project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir projectDir: %v", err)
+	}
+
+	cfg := &config.ProjectConfig{
+		ProjectName: "demo-project",
+		DocsPath:    "docs",
+		Agents: map[string]*config.InstalledAgent{
+			"tech-lead": {
+				AgentType: "tech-lead",
+				Workspace: "station",
+				Skills:    []string{"planning-template", "review-checklist"},
+				Workflows: []string{"code-review"},
+				Protocols: []string{"memory", "security"},
+				Sensors:   []string{"scope-guard-files"},
+				Routines:  []string{"backlog-hygiene"},
+			},
+			"backend": {
+				AgentType: "backend",
+				Workspace: "backend-ws",
+				Skills:    []string{"coding-standards"},
+				Workflows: []string{"pr-review"},
+				Protocols: []string{"scope-boundaries"},
+				Sensors:   []string{"context-guard"},
+				Routines:  []string{"dependency-audit"},
+			},
+		},
+	}
+	if err := cfg.Save(filepath.Join(projectDir, configFile)); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	origCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origCwd) }()
+
+	// Set the --json flag on the real listCmd so runList's flag-read
+	// short-circuit fires; reset it afterwards so other tests see the
+	// default value.
+	if err := listCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set --json: %v", err)
+	}
+	defer func() { _ = listCmd.Flags().Set("json", "false") }()
+
+	out := captureStdout(t, func() {
+		if err := runList(listCmd, nil); err != nil {
+			t.Fatalf("runList --json: %v", err)
+		}
+	})
+
+	var snap generate.ListSnapshot
+	if err := json.Unmarshal([]byte(out), &snap); err != nil {
+		t.Fatalf("unmarshal ListSnapshot: %v\noutput:\n%s", err, out)
+	}
+
+	if snap.Version == "" {
+		t.Errorf("snap.Version empty — want the build version string")
+	}
+	if snap.DocsPath != "docs" {
+		t.Errorf("snap.DocsPath = %q, want %q", snap.DocsPath, "docs")
+	}
+	if len(snap.Agents) != 2 {
+		t.Fatalf("len(snap.Agents) = %d, want 2", len(snap.Agents))
+	}
+
+	// Agents are emitted alphabetically by type: backend then tech-lead.
+	if snap.Agents[0].Type != "backend" || snap.Agents[1].Type != "tech-lead" {
+		t.Fatalf("agent order = [%q %q], want [backend tech-lead]",
+			snap.Agents[0].Type, snap.Agents[1].Type)
+	}
+
+	// Every field of every ListAgent must be populated — proves no field
+	// dropped out of the contract.
+	for _, a := range snap.Agents {
+		if a.Type == "" {
+			t.Errorf("agent.Type empty")
+		}
+		if a.Workspace == "" {
+			t.Errorf("agent %q: Workspace empty", a.Type)
+		}
+		if len(a.Skills) == 0 {
+			t.Errorf("agent %q: Skills empty", a.Type)
+		}
+		if len(a.Workflows) == 0 {
+			t.Errorf("agent %q: Workflows empty", a.Type)
+		}
+		if len(a.Protocols) == 0 {
+			t.Errorf("agent %q: Protocols empty", a.Type)
+		}
+		if len(a.Sensors) == 0 {
+			t.Errorf("agent %q: Sensors empty", a.Type)
+		}
+		if len(a.Routines) == 0 {
+			t.Errorf("agent %q: Routines empty", a.Type)
+		}
+	}
+
+	// Spot-check the tech-lead record fully — every slice value preserved.
+	tl := snap.Agents[1]
+	if tl.Workspace != "station" {
+		t.Errorf("tech-lead Workspace = %q, want %q", tl.Workspace, "station")
+	}
+	if got, want := strings.Join(tl.Skills, ","), "planning-template,review-checklist"; got != want {
+		t.Errorf("tech-lead Skills = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(tl.Protocols, ","), "memory,security"; got != want {
+		t.Errorf("tech-lead Protocols = %q, want %q", got, want)
+	}
+
+	// Output must be indent-2 JSON (parity with catalog --json / validate
+	// --json) — assert the canonical 2-space indent appears.
+	if !strings.Contains(out, "\n  \"version\":") {
+		t.Errorf("expected indent-2 JSON (2-space), got:\n%s", out)
+	}
+}
+
+// TestListCmd_FlagsRegistered confirms the --json flag is wired onto listCmd
+// so `--help` picks it up and the JSON short-circuit is reachable. Mirrors
+// TestInitCmd_FlagsRegistered.
+func TestListCmd_FlagsRegistered(t *testing.T) {
+	for _, name := range []string{"json"} {
+		if f := listCmd.Flags().Lookup(name); f == nil {
+			t.Errorf("flag --%s not registered on listCmd", name)
+		}
 	}
 }

--- a/internal/generate/list_snapshot.go
+++ b/internal/generate/list_snapshot.go
@@ -1,0 +1,95 @@
+package generate
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/LastStep/Bonsai/internal/catalog"
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// ListSnapshot is the stable JSON shape emitted by `bonsai list --json`.
+// Agent-consumable — a single-document snapshot of the project's installed
+// agents and the abilities each carries, read directly from .bonsai.yaml.
+//
+// The shape mirrors validate.Report's serialization conventions (explicit
+// struct, indent-2, no map-vs-list ambiguity) so an AI agent / CI script
+// driving Bonsai headlessly gets a pinned contract. Plan 41 Phase 4.
+//
+// This sits beside SerializeCatalog (catalog_snapshot.go) in internal/generate
+// precisely because that package is TUI-free: the list serializer must pull in
+// zero chrome (huh/bubbletea/lipgloss/glamour/charm) so a future bonsai mcp
+// server (Plan 42) can wrap it directly. A TUI-free import scan guards this.
+type ListSnapshot struct {
+	Version  string      `json:"version"`
+	DocsPath string      `json:"docs_path"`
+	Agents   []ListAgent `json:"agents"`
+}
+
+// ListAgent describes one installed agent and its registered abilities. Type
+// is the agent-type machine name (the .bonsai.yaml agents-map key); the
+// ability slices are always emitted (never nil) so the JSON shape is stable
+// — an agent with no skills serializes "skills": [] rather than null.
+type ListAgent struct {
+	Type      string   `json:"type"`
+	Workspace string   `json:"workspace"`
+	Skills    []string `json:"skills"`
+	Workflows []string `json:"workflows"`
+	Protocols []string `json:"protocols"`
+	Sensors   []string `json:"sensors"`
+	Routines  []string `json:"routines"`
+}
+
+// SerializeJSON builds a ListSnapshot from the project config and returns its
+// indent-2 JSON representation (matching SerializeCatalog / validate --json).
+// Agents are emitted alphabetically by type for deterministic output.
+//
+// The signature mirrors the cinematic list renderer (cfg, cat, version, cwd)
+// for call-site parity and Plan 42 readiness. cat and cwd are accepted but not
+// consulted today — all snapshot data lives in the config; display-name and
+// workspace-tree concerns belong to the TTY path, not the headless contract.
+func SerializeJSON(cfg *config.ProjectConfig, _ *catalog.Catalog, version, _ string) ([]byte, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("nil config")
+	}
+
+	snap := ListSnapshot{
+		Version:  version,
+		DocsPath: cfg.DocsPath,
+		Agents:   make([]ListAgent, 0, len(cfg.Agents)),
+	}
+
+	names := make([]string, 0, len(cfg.Agents))
+	for name := range cfg.Agents {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		agent := cfg.Agents[name]
+		if agent == nil {
+			continue
+		}
+		snap.Agents = append(snap.Agents, ListAgent{
+			Type:      name,
+			Workspace: agent.Workspace,
+			Skills:    nonNil(agent.Skills),
+			Workflows: nonNil(agent.Workflows),
+			Protocols: nonNil(agent.Protocols),
+			Sensors:   nonNil(agent.Sensors),
+			Routines:  nonNil(agent.Routines),
+		})
+	}
+
+	return json.MarshalIndent(snap, "", "  ")
+}
+
+// nonNil returns an empty (non-nil) slice for a nil input so the field
+// marshals to [] rather than null — keeps the JSON shape uniform.
+func nonNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}

--- a/internal/nonint/result_test.go
+++ b/internal/nonint/result_test.go
@@ -166,26 +166,41 @@ func TestResultCounts_DelegatesToSummary(t *testing.T) {
 	}
 }
 
-// TestMCPReadiness_NoTUIImports asserts the headless core stays TUI-free:
+// TestMCPReadiness_NoTUIImports asserts the headless cores stay TUI-free:
 // zero huh / bubbletea / lipgloss / glamour / charm imports anywhere in the
-// nonint package (production OR test files). The CLI adapter serialises the
-// Result; the package itself must never pull in chrome — a hard prerequisite
-// for the Plan 42 stdio MCP server (stdout must be pure protocol). Plan 41
-// Phase 5 widens this scan to internal/generate; Phase 1 guards nonint.
+// nonint package OR internal/generate (production AND test files). The CLI
+// adapter serialises the Result; these packages must never pull in chrome — a
+// hard prerequisite for the Plan 42 stdio MCP server (stdout must be pure
+// protocol).
+//
+// Plan 41 Phase 4 widens the scan to internal/generate because the
+// `list --json` serializer (list_snapshot.go / SerializeJSON) now lives there
+// beside SerializeCatalog — the scan proves the list serializer can't pull in
+// chrome undetected. Phase 1 originally guarded nonint only.
 func TestMCPReadiness_NoTUIImports(t *testing.T) {
 	banned := []string{"huh", "bubbletea", "lipgloss", "glamour", "charm"}
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", nil, parser.ImportsOnly)
-	if err != nil {
-		t.Fatalf("ParseDir: %v", err)
-	}
-	for _, pkg := range pkgs {
-		for fname, file := range pkg.Files {
-			for _, imp := range file.Imports {
-				path := strings.Trim(imp.Path.Value, `"`)
-				for _, b := range banned {
-					if strings.Contains(path, b) {
-						t.Errorf("%s imports banned TUI dependency %q (contains %q) — nonint must stay TUI-free", fname, path, b)
+
+	// "." is the nonint package dir (test cwd). "../generate" is the sibling
+	// internal/generate package — both must stay TUI-free.
+	dirs := []string{".", "../generate"}
+
+	for _, dir := range dirs {
+		fset := token.NewFileSet()
+		pkgs, err := parser.ParseDir(fset, dir, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("ParseDir(%s): %v", dir, err)
+		}
+		if len(pkgs) == 0 {
+			t.Fatalf("ParseDir(%s): no packages found — scan would silently pass", dir)
+		}
+		for _, pkg := range pkgs {
+			for fname, file := range pkg.Files {
+				for _, imp := range file.Imports {
+					path := strings.Trim(imp.Path.Value, `"`)
+					for _, b := range banned {
+						if strings.Contains(path, b) {
+							t.Errorf("%s imports banned TUI dependency %q (contains %q) — %s must stay TUI-free", fname, path, b, dir)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Plan 41 **Phase 4** — `list --json` headless output + read-command JSON-serialization parity audit. Builds on Phase 1 (already merged on `main`).

### `ListSnapshot` struct + serializer (`internal/generate/list_snapshot.go`)
New file beside `catalog_snapshot.go`/`SerializeCatalog` — chosen because `internal/generate` is already TUI-free (a future `bonsai mcp` server, Plan 42, can wrap the serializer directly; `internal/tui/listflow` was rejected since it imports glamour/initflow chrome).

```go
type ListSnapshot struct {
    Version  string      `json:"version"`
    DocsPath string      `json:"docs_path"`
    Agents   []ListAgent `json:"agents"`
}
type ListAgent struct {
    Type, Workspace string
    Skills, Workflows, Protocols, Sensors, Routines []string
}
```

`SerializeJSON(cfg, cat, version, cwd) ([]byte, error)` — `json.MarshalIndent("", "  ")`, agents sorted alphabetically by type, ability slices always non-nil (`[]` not `null`) for a stable shape. `cat`/`cwd` accepted for call-site parity + Plan 42 readiness; not consulted today (all snapshot data is in the config).

### `cmd/list.go`
- `--json` flag on `listCmd`; short-circuits the cinematic path to a single-doc JSON on stdout (mirrors `cmd/catalog.go:43` and `validate --json`).
- nil-`cmd` guard preserves the existing direct-call unit tests (`runList(nil, nil)`).

### Widened TUI-free import scan
`TestMCPReadiness_NoTUIImports` (`internal/nonint/result_test.go`) — Phase 1 scanned only `nonint` for `huh`/`bubbletea`/`lipgloss`/`glamour`/`charm`. Now also scans `../generate` so the list serializer can't pull in chrome undetected. Added a guard that fails if a scanned dir yields zero packages (so the scan can't silently pass). **Verified it catches violations:** injecting a `lipgloss` import into `internal/generate` made the test fail; clean again after removal.

### Audit findings (consistency)
`catalog --json`, `validate --json`, and the new `list --json` all share serialization conventions: `json.MarshalIndent(v, "", "  ")` (indent-2), printed to stdout via `fmt.Println(string(data))`, diagnostics/errors routed to stderr. **No serialization drift found — nothing fixed inline, nothing filed to Backlog.** Per-command exit codes differ by design and are left unchanged: `catalog --json` → 0; `validate --json` → 0 clean / 1 issues / 2 config error; `list --json` → 0.

## Gates passed
- `go build ./...`, `go vet ./...`, `go test ./...`, `GOOS=windows GOARCH=amd64 go build ./...` — all pass.
- `golangci-lint run ./...` (v2.11.4) — 0 issues.
- `list --json` schema gate: two-agent fixture `json.Unmarshal`s into `ListSnapshot`, every field populated, field names/types match the pinned struct, indent-2 asserted.
- Flag registration gate: `--json` registered on `listCmd`.
- TUI-free scan now covers both `internal/nonint` and `internal/generate`.
- `go.mod` / `go.sum` unchanged (no new module).

Reference: Plan 41 Phase 4 — read-command JSON parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)