### PR TITLE
docs(contract): Plan 41 Phase 5 — agent-interface contract + CHANGELOG + test sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Project manifest scaffolding (`project-manifest` opt-in item)** — writes a repo-root `.bonsai/project.yaml` describing the project against a frozen v1 schema. Root-relative, lock-tracked, and idempotent: re-runs preserve the original `created` timestamp.
 - **`bonsai validate` project-level pass** — lints the project manifest and the memory-note tree: `schema_version`, required fields, `status`/`type` enums, permalink charset, scope match, dangling `superseded_by`, and unresolved relations. Note-target resolution is adversarial-grade (`EvalSymlinks` plus a boundary check, with symlink-escape refused) over a bounded walk.
 - **`bonsai guide formats`** — a combined "Formats" reference page documenting both frozen v1 schemas (memory-note and project manifest) in one place.
+- **`bonsai update` non-interactive flags** — `--non-interactive` (force the headless JSONL core on a TTY) and `--skip-conflicts` (skip + count conflicting files instead of exiting `5`). A non-TTY stdin auto-enables headless mode.
+- **`bonsai remove` non-interactive flags** — `--non-interactive` / `-y`,`--yes` (bypass the cinematic confirm prompt) and `--from <agent>` (scope an item removal to one owning agent, required to disambiguate a multi-owner item). `--yes` bypasses confirmation only, never validation: empty/`*` targets are rejected, and `--yes --delete-files` refuses a symlinked delete target.
+- **`bonsai list --json`** — emit the installed-agent state as a single indent-2 JSON document (a pinned `ListSnapshot`), matching `catalog --json` / `validate --json`. Agent-consumable, exit `0`.
+- **Headless exit-code `5` (`ExitConflict`)** — `bonsai update` returns exit `5` when unresolved file conflicts are present and `--skip-conflicts` was not passed (the conflicting files are listed in the JSONL stream). The mutating exit-code contract is now `0`/`2`/`3`/`4`/`5`, defined canonically in `internal/nonint/runner.go`.
+- **`docs/agent-interface.md`** — canonical headless CLI contract: per-command flags, the two output serializations (JSONL for mutating commands, single-doc JSON for read commands), and the per-command exit-code table. The single reference for AI integrators and CI scripts.
 
 ### Changed
 - **Architectural decisions now route to the memory graph.** Generated workspaces record durable architectural decisions in `Memory/decisions/` (the in-repo memory graph) instead of appending to `Logs/KeyDecisionLog.md`.
+- **Piped `bonsai update` now emits JSON Lines** (was human-readable prose). Running `bonsai update` with a non-TTY stdin — or with the new `--non-interactive` flag — streams `file`/`summary` events to stdout instead of the previous styled success text. The interactive TTY flow is unchanged.
+- **`bonsai update` conflicts now exit `5`** (was a generic non-zero error). Headlessly, unresolved file conflicts return `ExitConflict` (5) with the conflicting files listed in the stream; pass `--skip-conflicts` to skip + count them and exit `0` instead.
 
 ## [0.4.3] - 2026-05-13
 

--- a/docs/agent-interface.md
+++ b/docs/agent-interface.md
@@ -1,0 +1,245 @@
+---
+description: The headless CLI contract — flags, serializations, and exit codes for driving Bonsai non-interactively from an AI agent, CI script, or MCP wrapper.
+---
+
+# Agent Interface — the headless CLI contract
+
+This is the canonical, generic contract for driving `bonsai` without a TTY:
+which flags switch each command into a non-interactive mode, the two output
+serializations (streaming JSONL for mutating commands, single-document JSON for
+read commands), and the per-command exit-code table. It is the single source of
+truth for AI integrators, CI pipelines, and the planned `bonsai mcp` server
+(which wraps these same cores).
+
+The headless cores live in `internal/nonint` (mutating commands) and
+`internal/generate` (read serializers). Each mutating core is a pure function:
+typed options in, a structured `Result` out — no prompts, no `os.Exit`, no data
+on stdout from inside the core. The CLI adapter serializes the `Result` to
+JSONL on stdout and routes warnings to stderr; a future MCP adapter serializes
+the same `Result` to structured content.
+
+> **Exit-code source of truth.** The mutating exit-code constants
+> (`ExitOK=0`, `ExitInvalidConfig=2`, `ExitRuntime=3`, `ExitWrongCWDForInit=4`,
+> `ExitConflict=5`) are defined in `internal/nonint/runner.go`. That file is
+> canonical — if the table below ever disagrees with those constants, the
+> constants win.
+
+---
+
+## Stream discipline
+
+A single rule governs both serializations:
+
+- **Data goes to stdout.** Mutating commands write pure JSON Lines; read
+  commands write a single indent-2 JSON document. Nothing else is written to
+  stdout on the headless path.
+- **Diagnostics and warnings go to stderr.** Operational errors print to stderr
+  (the process then exits non-zero with no stdout). Non-fatal warnings (e.g. a
+  lock-save failure, an invalid custom-file discovery) print to stderr as plain
+  `warning: …` lines.
+- **`warning` events never appear on stdout.** Warnings ride in `Result.Warnings`
+  and are emitted by the CLI adapter to stderr only. The JSONL stream carries
+  exactly two event kinds: `file` and `summary`. This keeps stdout pure protocol
+  — safe to pipe straight into `jq` or an MCP stdio transport.
+
+Capture the two streams separately:
+
+```bash
+bonsai init --non-interactive --from-config cfg.yaml >events.jsonl 2>diag.log
+```
+
+---
+
+## Per-command flags
+
+| Command | Headless trigger | Other headless flags |
+|---------|------------------|----------------------|
+| `init` | `--non-interactive` + `--from-config <path>` (both required together) | — |
+| `add` | `--non-interactive` + `--from-config <path>` (both required together) | — |
+| `update` | `--non-interactive` (force headless on a TTY) **or** a non-TTY stdin | `--skip-conflicts` |
+| `remove` | `--non-interactive` / `-y`,`--yes` (bypass the confirm prompt) **or** a non-TTY stdin | `--from <agent>`, `-d`,`--delete-files` |
+| `list` | `--json` | — |
+| `catalog` | `--json` | `-a`,`--agent <type>` |
+| `validate` | `--json` | `-a`,`--agent <type>` |
+
+Notes:
+
+- `update` and `remove` auto-detect a non-TTY stdin and switch to headless
+  automatically; the explicit flag is only needed to force headless on a real
+  TTY. `init`/`add` require the explicit flag pair.
+- Mutating commands have **no `--json` flag** — headless mode always emits
+  JSONL, so a `--json` toggle would be redundant with `--non-interactive`.
+- `remove --yes` bypasses the human **confirmation** gate, never **validation**:
+  an empty target or a literal `*` is rejected (exit 2, zero mutation). Under
+  `--yes --delete-files`, each delete target is checked and the operation
+  refuses if any is a symlink (exit 2, zero deletion).
+- `remove --from <agent>` scopes an item removal to one owning agent; it is
+  required to disambiguate an item installed in more than one agent. `--from` is
+  not an escape hatch around required-item protection — removing a required item
+  via `--from` is still rejected (exit 2, zero mutation).
+
+---
+
+## Input shapes
+
+- **`init` / `add`** read a declarative overlay file via `--from-config <path>`:
+  a YAML document with the same shape as `.bonsai.yaml`. `init` accepts a single
+  `tech-lead` entry under `agents:`; `add` accepts exactly one agent in the
+  overlay (loop the command for multi-agent setups), and its non-`agents` fields
+  (`project_name`, `docs_path`, `scaffolding`) must either be omitted or match
+  the existing `.bonsai.yaml` exactly.
+- **`update` / `remove`** take **no config file**. `update` reconciles from the
+  existing `.bonsai.yaml` plus a workspace scan. `remove` is imperative and
+  takes positional arguments: `bonsai remove <agent>` or
+  `bonsai remove <type> <name>` (`type` ∈ skill | workflow | protocol | sensor |
+  routine).
+
+There is no new untrusted-input surface: `update`/`remove` ingest no
+caller-supplied file, and every JSON/JSONL byte is marshaled
+(`json.Marshal` / `json.MarshalIndent`), never string-concatenated.
+
+---
+
+## Serialization 1 — JSONL (mutating commands)
+
+`init`, `add`, `update`, and `remove` stream **JSON Lines** to stdout: one JSON
+object per line, no enclosing array. There are exactly two event kinds.
+
+### `file` event
+
+One per file outcome, emitted in write order. Empty optional fields are omitted.
+
+```json
+{"event":"file","path":"station/CLAUDE.md","action":"created","source":"tech-lead"}
+```
+
+| field | type | notes |
+|-------|------|-------|
+| `event` | string | always `"file"` |
+| `path` | string | repo-relative path of the affected file (omitted if empty) |
+| `action` | string | one of `created`, `updated`, `unchanged`, `skipped`, `conflict` (omitted if empty) |
+| `source` | string | origin label (e.g. the owning agent type); omitted if empty |
+
+### `summary` event
+
+Exactly one terminal line. **All five count keys are always present**, even when
+zero — downstream consumers can parse the shape unconditionally.
+
+```json
+{"event":"summary","created":12,"updated":0,"unchanged":3,"skipped":0,"conflicts":0}
+```
+
+| field | type | notes |
+|-------|------|-------|
+| `event` | string | always `"summary"` |
+| `created` | int | files newly written |
+| `updated` | int | files re-rendered over a Bonsai-managed prior version |
+| `unchanged` | int | files already up to date |
+| `skipped` | int | files left untouched (e.g. conflicts skipped under `--skip-conflicts`) |
+| `conflicts` | int | files that conflict with user edits and were not overwritten |
+
+The all-installed / no-op case (e.g. `add` against an already-fully-installed
+agent) emits a lone zero-count summary line and no `file` events.
+
+---
+
+## Serialization 2 — single-document JSON (read commands)
+
+`list`, `catalog`, and `validate` with `--json` emit a **single** indent-2 JSON
+document to stdout (not JSONL). All three share the same serialization
+conventions: `json.MarshalIndent(v, "", "  ")`, stdout-only.
+
+- **`list --json`** — a `ListSnapshot`: the installed agents and the abilities
+  each carries, read from `.bonsai.yaml`. Ability lists are always present
+  (an agent with no skills serializes `"skills": []`, never `null`).
+
+  ```json
+  {
+    "version": "v0.5.0",
+    "docs_path": "station/",
+    "agents": [
+      {
+        "type": "tech-lead",
+        "workspace": "station/",
+        "skills": ["planning-template"],
+        "workflows": ["planning"],
+        "protocols": ["memory"],
+        "sensors": ["status-bar"],
+        "routines": ["status-hygiene"]
+      }
+    ]
+  }
+  ```
+
+- **`catalog --json`** — the embedded catalog (available agents, skills,
+  workflows, protocols, sensors, routines). Honours `-a <agent>` filtering.
+  Scaffolding is intentionally excluded (it is project-config data, not catalog
+  data).
+
+- **`validate --json`** — a single audit `Report` object (orphaned
+  registrations, stale lock entries, untracked customs, frontmatter problems).
+
+---
+
+## Exit codes
+
+### Mutating commands
+
+Reachability is per command — a code not listed for a command is unreachable on
+its headless path. The constants below are defined in
+`internal/nonint/runner.go`.
+
+| Code | Constant | Meaning | Reachable by |
+|------|----------|---------|--------------|
+| `0` | `ExitOK` | success | init, add, update, remove |
+| `2` | `ExitInvalidConfig` | caller input rejected before any mutation — bad overlay shape, unknown agent type, missing tech-lead, multi-owner item with no `--from`, last-tech-lead removal, empty/`*` target, symlinked delete target | init, add, update, remove |
+| `3` | `ExitRuntime` | a generator or filesystem error occurred mid-run | init, add, update, remove |
+| `4` | `ExitWrongCWDForInit` | wrong working-directory state — `.bonsai.yaml` already present (init) or missing (add / update / remove) | init, add, update, remove |
+| `5` | `ExitConflict` | unresolved file conflicts; re-run with `--skip-conflicts` or interactively | **update only** |
+
+Per-command reachable set:
+
+| Command | 0 | 2 | 3 | 4 | 5 |
+|---------|---|---|---|---|---|
+| `init` | yes | yes | yes | yes (`.bonsai.yaml` exists) | — |
+| `add` | yes | yes | yes | yes (no `.bonsai.yaml`) | — |
+| `update` | yes | yes | yes | yes (no `.bonsai.yaml`) | yes (conflict, no `--skip-conflicts`) |
+| `remove` | yes | yes (not-found / multi-owner / last-tech-lead) | yes | yes (no `.bonsai.yaml`) | — |
+
+`init` and `add` never reach `5`: under `--non-interactive` they force conflicts
+to skip (reported as `action:"conflict"` file events with the files left
+untouched) and exit `0`.
+
+### Read commands
+
+Read commands do **not** use the mutating constants and do **not** all exit `0`:
+
+| Command | Exit codes |
+|---------|------------|
+| `catalog --json` | `0` |
+| `list --json` | `0` |
+| `validate --json` | `0` clean · `1` issues found · `2` config-load / internal error |
+
+---
+
+## Quick recipes
+
+```bash
+# init from a YAML overlay, parse the stream
+bonsai init --non-interactive --from-config cfg.yaml | jq -c 'select(.event=="file")'
+
+# update headlessly, treat conflicts as a hard stop (exit 5)
+bonsai update --non-interactive; echo "exit=$?"
+
+# update, skipping conflicts (exit 0, conflicts counted as skipped)
+bonsai update --non-interactive --skip-conflicts
+
+# remove an item owned by two agents — disambiguate with --from
+bonsai remove skill planning-template --from backend --yes
+
+# read the installed state as one JSON document
+bonsai list --json | jq '.agents[].type'
+
+# audit; exit 1 means issues were found
+bonsai validate --json; echo "exit=$?"
+```

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -97,4 +97,20 @@ Run `bonsai validate` to lint both formats — it reports schema violations
 (missing required fields, bad `schema_version`, scope mismatch, out-of-charset
 permalinks) before downstream tooling ever sees them.
 
+## Headless output formats
+
+Beyond the two repo-resident schemas above, Bonsai's CLI has a stable
+**headless contract** for driving it without a TTY. The mutating commands
+(`init` / `add` / `update` / `remove`) stream **JSON Lines** to stdout — one
+`{"event":"file",…}` line per file outcome, then a terminal
+`{"event":"summary",…}` with all five count keys always present. The read
+commands (`list` / `catalog` / `validate` with `--json`) emit a single
+indent-2 JSON document. Diagnostics and warnings go to stderr only, so stdout
+stays pure protocol. Exit codes are per command (mutating: `0`/`2`/`3`/`4`,
+plus `5` for an `update` conflict; `validate --json`: `0` clean / `1` issues /
+`2` error).
+
+Full per-command flags, event shapes, and the exit-code table:
+see [`docs/agent-interface.md`](agent-interface.md).
+
 > Full reference: <https://laststep.github.io/Bonsai/>

--- a/internal/nonint/contract_test.go
+++ b/internal/nonint/contract_test.go
@@ -1,0 +1,231 @@
+package nonint
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LastStep/Bonsai/internal/config"
+)
+
+// contract_test.go is the Plan 41 Phase 5 CROSS-command sweep. The per-command
+// test files (runner_test / update_test / remove_test and the cmd/*_nonint_test
+// adapters) each pin ONE command's behaviour. This file asserts the contract
+// holds UNIFORMLY across every mutating core in one place — so a future core
+// added to internal/nonint that forgets the JSONL/warnings discipline fails
+// here even if its own per-command test is missing.
+
+// runMutatingCore is one headless mutating core invoked through the same
+// signature shape every adapter uses: it returns the (*Result, exitCode, error)
+// triple. Each case materialises its own project so the cores run against a
+// real workspace + lock on disk.
+type mutatingCase struct {
+	name string
+	// run produces the core's Result. A non-nil error here is a SETUP failure
+	// (t.Fatal), distinct from the core's own returned error.
+	run func(t *testing.T) (*Result, int)
+}
+
+// allMutatingCores enumerates init / add / update / remove(agent) /
+// remove(item). Each closure builds a fresh tmp project and drives exactly one
+// core, returning its happy-path Result. Keeping all five in one slice is the
+// point: the sweep below iterates them so the invariant is asserted identically
+// for every command.
+func allMutatingCores() []mutatingCase {
+	return []mutatingCase{
+		{
+			name: "init",
+			run: func(t *testing.T) (*Result, int) {
+				cat := loadTestCatalog(t)
+				tmp := t.TempDir()
+				cfg := minimalInitCfg(t, tmp)
+				res, code, err := RunInit(tmp, filepath.Join(tmp, ".bonsai.yaml"), cfg, cat, "test")
+				if err != nil {
+					t.Fatalf("RunInit setup: %v", err)
+				}
+				return res, code
+			},
+		},
+		{
+			name: "add",
+			run: func(t *testing.T) (*Result, int) {
+				cat := loadTestCatalog(t)
+				tmp := t.TempDir()
+				configPath := filepath.Join(tmp, ".bonsai.yaml")
+				cfg := minimalInitCfg(t, tmp)
+				if _, code, err := RunInit(tmp, configPath, cfg, cat, "test"); err != nil || code != ExitOK {
+					t.Fatalf("RunInit (add setup): code=%d err=%v", code, err)
+				}
+				overlay, err := LoadConfig(writeYAML(t, tmp, "backend.yaml", "agents:\n  backend: {}\n"), tmp, cat)
+				if err != nil {
+					t.Fatalf("LoadConfig backend overlay: %v", err)
+				}
+				res, code, err := RunAdd(tmp, configPath, overlay, cat, "test")
+				if err != nil {
+					t.Fatalf("RunAdd setup: %v", err)
+				}
+				return res, code
+			},
+		},
+		{
+			name: "update",
+			run: func(t *testing.T) (*Result, int) {
+				cat := loadTestCatalog(t)
+				tmp := t.TempDir()
+				configPath := filepath.Join(tmp, ".bonsai.yaml")
+				cfg := minimalInitCfg(t, tmp)
+				if _, code, err := RunInit(tmp, configPath, cfg, cat, "test"); err != nil || code != ExitOK {
+					t.Fatalf("RunInit (update setup): code=%d err=%v", code, err)
+				}
+				reloaded, err := config.Load(configPath)
+				if err != nil {
+					t.Fatalf("reload config: %v", err)
+				}
+				lock, _ := config.LoadLockFile(tmp)
+				if lock == nil {
+					lock = config.NewLockFile()
+				}
+				res, code, err := RunUpdate(tmp, reloaded, cat, lock, "test", false)
+				if err != nil {
+					t.Fatalf("RunUpdate setup: %v", err)
+				}
+				return res, code
+			},
+		},
+		{
+			name: "remove-agent",
+			run: func(t *testing.T) (*Result, int) {
+				cat := loadTestCatalog(t)
+				tmp, configPath := initWithAgents(t, "backend")
+				cfg := reloadConfig(t, configPath)
+				lock, _ := config.LoadLockFile(tmp)
+				res, code, err := RunRemoveAgent(tmp, cfg, cat, lock, "test", "backend", false)
+				if err != nil {
+					t.Fatalf("RunRemoveAgent setup: %v", err)
+				}
+				return res, code
+			},
+		},
+		{
+			name: "remove-item",
+			run: func(t *testing.T) (*Result, int) {
+				cat := loadTestCatalog(t)
+				tmp, configPath := initWithAgents(t, "backend")
+				cfg := reloadConfig(t, configPath)
+				lock, _ := config.LoadLockFile(tmp)
+				// coding-standards is a non-required skill backend installs by
+				// default — a safe single-owner item to remove.
+				res, code, err := RunRemoveItem(tmp, cfg, cat, lock, "test", "skill", "coding-standards", "backend")
+				if err != nil {
+					t.Fatalf("RunRemoveItem setup: %v", err)
+				}
+				return res, code
+			},
+		},
+	}
+}
+
+// TestContract_AllMutatingCoresEmitPureJSONL is the cross-command stdout-purity
+// sweep. For every mutating core, EmitJSONL over its happy-path Result must
+// produce ONLY file/summary events (every line valid JSON, no other event
+// kind) and exactly one terminal summary line. This is the single guard that a
+// new core can't ship a non-conforming stdout shape.
+func TestContract_AllMutatingCoresEmitPureJSONL(t *testing.T) {
+	for _, tc := range allMutatingCores() {
+		t.Run(tc.name, func(t *testing.T) {
+			res, code := tc.run(t)
+			if code != ExitOK {
+				t.Fatalf("%s: want ExitOK, got %d", tc.name, code)
+			}
+
+			var buf bytes.Buffer
+			if err := EmitJSONL(&buf, res); err != nil {
+				t.Fatalf("%s: EmitJSONL: %v", tc.name, err)
+			}
+
+			records := parseJSONL(t, buf.String())
+			summaries := 0
+			for _, rec := range records {
+				ev, _ := rec["event"].(string)
+				if ev != "file" && ev != "summary" {
+					t.Errorf("%s: stdout carries event %q; only file/summary allowed", tc.name, ev)
+				}
+				if ev == "summary" {
+					summaries++
+				}
+			}
+			if summaries != 1 {
+				t.Errorf("%s: want exactly one terminal summary line, got %d", tc.name, summaries)
+			}
+			// The summary line must carry all five count keys (stable shape).
+			summary := findSummary(records)
+			if summary == nil {
+				t.Fatalf("%s: no summary event emitted", tc.name)
+			}
+			for _, key := range []string{"created", "updated", "unchanged", "skipped", "conflicts"} {
+				if _, ok := summary[key]; !ok {
+					t.Errorf("%s: summary missing count key %q", tc.name, key)
+				}
+			}
+		})
+	}
+}
+
+// TestContract_AllMutatingCoresKeepWarningsOffStdout asserts the warnings
+// discipline uniformly: for EVERY core, any Result.Warnings text must NOT leak
+// into the EmitJSONL stdout stream. The cores route warnings to Result.Warnings
+// (which the CLI adapter prints to stderr); the JSONL writer must never see them.
+// We inject a synthetic warning into each core's real Result and confirm the
+// serialized stream stays clean — proving the boundary holds regardless of how
+// the core was reached.
+func TestContract_AllMutatingCoresKeepWarningsOffStdout(t *testing.T) {
+	const sentinel = "CONTRACT-SWEEP-SENTINEL-WARNING"
+	for _, tc := range allMutatingCores() {
+		t.Run(tc.name, func(t *testing.T) {
+			res, code := tc.run(t)
+			if code != ExitOK {
+				t.Fatalf("%s: want ExitOK, got %d", tc.name, code)
+			}
+			res.Warnings = append(res.Warnings, sentinel)
+
+			var buf bytes.Buffer
+			if err := EmitJSONL(&buf, res); err != nil {
+				t.Fatalf("%s: EmitJSONL: %v", tc.name, err)
+			}
+			if strings.Contains(buf.String(), sentinel) {
+				t.Errorf("%s: warning text leaked onto the JSONL stdout stream:\n%s", tc.name, buf.String())
+			}
+			// And no line is a `warning` event.
+			for _, rec := range parseJSONL(t, buf.String()) {
+				if ev, _ := rec["event"].(string); ev == "warning" {
+					t.Errorf("%s: warning event must never appear on stdout", tc.name)
+				}
+			}
+		})
+	}
+}
+
+// TestContract_ExitConstantsAreStable pins the mutating exit-code constants to
+// their documented values. docs/agent-interface.md names internal/nonint/runner.go
+// as the canonical source; this test is the machine-checked half of that
+// contract — if a constant's value drifts the doc table is wrong and CI fails
+// here (no markdown-parsing doc-drift test, by Plan 41 design).
+func TestContract_ExitConstantsAreStable(t *testing.T) {
+	cases := []struct {
+		name string
+		got  int
+		want int
+	}{
+		{"ExitOK", ExitOK, 0},
+		{"ExitInvalidConfig", ExitInvalidConfig, 2},
+		{"ExitRuntime", ExitRuntime, 3},
+		{"ExitWrongCWDForInit", ExitWrongCWDForInit, 4},
+		{"ExitConflict", ExitConflict, 5},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %d, want %d — docs/agent-interface.md exit-code table is now stale", c.name, c.got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Final phase of **Plan 41 — Headless CLI Contract + MCP-Ready Cores**. Documents the headless surface that Phases 1-4 shipped, records the user-visible changes, and adds a cross-command contract test sweep. Completes Plan 41.

## Contract doc — `docs/agent-interface.md` (new)
Canonical, generic contract for AI integrators / CI / the planned `bonsai mcp` server:

- **Per-command flags** — `init`/`add`: `--non-interactive` + `--from-config`; `update`: `--non-interactive` + `--skip-conflicts`; `remove`: `--non-interactive`/`-y`,`--yes` + `--from <agent>` + `-d`,`--delete-files`; `list`/`catalog`/`validate`: `--json`.
- **Two serializations** — (1) JSONL on stdout for the mutating commands: `file` events (`event`/`path`/`action`/`source`) and a terminal `summary` event with all five count keys always present (`created`/`updated`/`unchanged`/`skipped`/`conflicts`) — field names taken verbatim from `internal/nonint/events.go`; (2) single-document indent-2 JSON for the read commands (`list` → `ListSnapshot`, `catalog`, `validate`).
- **Per-command exit-code table** — mutating: init/add/remove `0/2/3/4`, update `0/2/3/4/5` (5 = conflict, update only); read commands documented separately (`catalog`/`list` → 0; `validate` → 0 clean / 1 issues / 2 error). Explicitly does **not** claim all read commands exit 0.
- **Input shapes** — `init`/`add` take a `--from-config` overlay; `update`/`remove` take no config file (`update` reconciles from `.bonsai.yaml` + scan; `remove` is imperative/positional).
- **Stream discipline** — data → stdout, diagnostics/warnings → stderr, `warning` events never on stdout.
- Names `internal/nonint/runner.go` as the canonical source of the mutating exit-code constants. No consumer product names.

## `docs/formats.md` (extended)
Condensed "Headless output formats" pointer to `agent-interface.md`.

## CHANGELOG `[0.5.0]`
- **Added** — `update`/`remove` non-interactive flags, `remove --from`, `list --json`, `ExitConflict=5`.
- **Changed** — piped `bonsai update` now emits JSONL (was human prose); update conflicts now exit `5` (was a generic error).

## Cross-command tests — `internal/nonint/contract_test.go` (new)
Per-command tests (Phases 1-4) each pin one command; this sweep asserts the contract holds **uniformly** across all five mutating cores in one place:
- `TestContract_AllMutatingCoresEmitPureJSONL` — every core's happy-path `Result` serializes to file/summary events only, exactly one terminal summary, all five count keys.
- `TestContract_AllMutatingCoresKeepWarningsOffStdout` — an injected sentinel warning never leaks onto the JSONL stdout stream for any core.
- `TestContract_ExitConstantsAreStable` — machine-pins the exit constants to their documented values (the non-ceremony half of doc-drift protection; no markdown-parsing test, per plan).

Per-command flag-registration and stream-separation tests already exist from Phases 1-4 — not duplicated.

## Gates
- `go build ./...`, `go vet ./...`, `go test ./...`, `GOOS=windows GOARCH=amd64 go build ./...` — all pass.
- `go.mod` / `go.sum` unchanged.
- `golangci-lint run ./...` (v2.11.4) — 0 issues.
- Exit-code table in `docs/agent-interface.md` verified against `internal/nonint/runner.go` constants.

References Plan 41 Phase 5. **Completes Plan 41.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)